### PR TITLE
Improvements

### DIFF
--- a/api/api.go
+++ b/api/api.go
@@ -19,7 +19,6 @@ import (
 	"doppler-cli/models"
 	utils "doppler-cli/utils"
 	"encoding/json"
-	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -33,14 +32,13 @@ func GetAPISecrets(cmd *cobra.Command, apiKey string, project string, config str
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/variables", params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch secrets")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch secrets")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	computed := make(map[string]models.ComputedSecret)
@@ -60,8 +58,7 @@ func SetAPISecrets(cmd *cobra.Command, apiKey string, project string, config str
 	reqBody["variables"] = secrets
 	body, err := json.Marshal(reqBody)
 	if err != nil {
-		fmt.Println("Invalid secrets")
-		utils.Err(err)
+		utils.Err(err, "Invalid secrets")
 	}
 
 	var params []utils.QueryParam
@@ -71,14 +68,13 @@ func SetAPISecrets(cmd *cobra.Command, apiKey string, project string, config str
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.PostRequest(host, "v2/variables", params, apiKey, body)
 	if err != nil {
-		fmt.Println("Unable to fetch secrets")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch secrets")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	computed := make(map[string]models.ComputedSecret)
@@ -95,14 +91,13 @@ func GetAPIWorkplaceSettings(cmd *cobra.Command, apiKey string) ([]byte, models.
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/workplace", []utils.QueryParam{}, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch workplace settings")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch workplace settings")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	settings := models.ParseWorkplaceSettings(result["workplace"].(map[string]interface{}))
@@ -113,21 +108,19 @@ func GetAPIWorkplaceSettings(cmd *cobra.Command, apiKey string) ([]byte, models.
 func SetAPIWorkplaceSettings(cmd *cobra.Command, apiKey string, values models.WorkplaceSettings) ([]byte, models.WorkplaceSettings) {
 	body, err := json.Marshal(values)
 	if err != nil {
-		fmt.Println("Invalid workplace settings")
-		utils.Err(err)
+		utils.Err(err, "Invalid workplace settings")
 	}
 
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.PostRequest(host, "v2/workplace", []utils.QueryParam{}, apiKey, body)
 	if err != nil {
-		fmt.Println("Unable to update workplace settings")
-		utils.Err(err)
+		utils.Err(err, "Unable to update workplace settings")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	settings := models.ParseWorkplaceSettings(result["workplace"].(map[string]interface{}))
@@ -139,14 +132,13 @@ func GetAPIProjects(cmd *cobra.Command, apiKey string) ([]byte, []models.Project
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/pipelines", []utils.QueryParam{}, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch projects")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch projects")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	var info []models.ProjectInfo
@@ -162,14 +154,13 @@ func GetAPIProject(cmd *cobra.Command, apiKey string, project string) ([]byte, m
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/pipelines/"+project, []utils.QueryParam{}, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch project")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch project")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	projectInfo := models.ParseProjectInfo(result["pipeline"].(map[string]interface{}))
@@ -181,21 +172,19 @@ func CreateAPIProject(cmd *cobra.Command, apiKey string, name string, descriptio
 	postBody := map[string]string{"name": name, "description": description}
 	body, err := json.Marshal(postBody)
 	if err != nil {
-		fmt.Println("Invalid project info")
-		utils.Err(err)
+		utils.Err(err, "Invalid project info")
 	}
 
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.PostRequest(host, "v2/pipelines/", []utils.QueryParam{}, apiKey, body)
 	if err != nil {
-		fmt.Println("Unable to create project")
-		utils.Err(err)
+		utils.Err(err, "Unable to create project")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	projectInfo := models.ParseProjectInfo(result["pipeline"].(map[string]interface{}))
@@ -207,21 +196,19 @@ func UpdateAPIProject(cmd *cobra.Command, apiKey string, project string, name st
 	postBody := map[string]string{"name": name, "description": description}
 	body, err := json.Marshal(postBody)
 	if err != nil {
-		fmt.Println("Invalid project info")
-		utils.Err(err)
+		utils.Err(err, "Invalid project info")
 	}
 
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.PostRequest(host, "v2/pipelines/"+project, []utils.QueryParam{}, apiKey, body)
 	if err != nil {
-		fmt.Println("Unable to update project")
-		utils.Err(err)
+		utils.Err(err, "Unable to update project")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	projectInfo := models.ParseProjectInfo(result["pipeline"].(map[string]interface{}))
@@ -233,14 +220,13 @@ func DeleteAPIProject(cmd *cobra.Command, apiKey string, project string) {
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.DeleteRequest(host, "v2/pipelines/"+project, []utils.QueryParam{}, apiKey)
 	if err != nil {
-		fmt.Println("Unable to delete project")
-		utils.Err(err)
+		utils.Err(err, "Unable to delete project")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 }
 
@@ -252,14 +238,13 @@ func GetAPIEnvironments(cmd *cobra.Command, apiKey string, project string) ([]by
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/stages", params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch environments")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch environments")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	var info []models.EnvironmentInfo
@@ -278,14 +263,13 @@ func GetAPIEnvironment(cmd *cobra.Command, apiKey string, project string, enviro
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/stages/"+environment, params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch environment")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch environment")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	info := models.ParseEnvironmentInfo(result["stage"].(map[string]interface{}))
@@ -300,14 +284,13 @@ func GetAPIConfigs(cmd *cobra.Command, apiKey string, project string) ([]byte, [
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/environments", params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch configs")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch configs")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	var info []models.ConfigInfo
@@ -326,14 +309,13 @@ func GetAPIConfig(cmd *cobra.Command, apiKey string, project string, config stri
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/environments/"+config, params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch configs")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch configs")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	info := models.ParseConfigInfo(result["environment"].(map[string]interface{}))
@@ -345,8 +327,7 @@ func CreateAPIConfig(cmd *cobra.Command, apiKey string, project string, name str
 	postBody := map[string]interface{}{"name": name, "stage": environment, "defaults": defaults}
 	body, err := json.Marshal(postBody)
 	if err != nil {
-		fmt.Println("Invalid config info")
-		utils.Err(err)
+		utils.Err(err, "Invalid config info")
 	}
 
 	var params []utils.QueryParam
@@ -355,14 +336,13 @@ func CreateAPIConfig(cmd *cobra.Command, apiKey string, project string, name str
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.PostRequest(host, "v2/environments", params, apiKey, body)
 	if err != nil {
-		fmt.Println("Unable to create config")
-		utils.Err(err)
+		utils.Err(err, "Unable to create config")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	info := models.ParseConfigInfo(result["environment"].(map[string]interface{}))
@@ -377,14 +357,13 @@ func DeleteAPIConfig(cmd *cobra.Command, apiKey string, project string, config s
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.DeleteRequest(host, "v2/environments/"+config, params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to delete config")
-		utils.Err(err)
+		utils.Err(err, "Unable to delete config")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 }
 
@@ -393,8 +372,7 @@ func UpdateAPIConfig(cmd *cobra.Command, apiKey string, project string, config s
 	postBody := map[string]interface{}{"name": name}
 	body, err := json.Marshal(postBody)
 	if err != nil {
-		fmt.Println("Invalid config info")
-		utils.Err(err)
+		utils.Err(err, "Invalid config info")
 	}
 
 	var params []utils.QueryParam
@@ -403,14 +381,13 @@ func UpdateAPIConfig(cmd *cobra.Command, apiKey string, project string, config s
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.PostRequest(host, "v2/environments/"+config, params, apiKey, body)
 	if err != nil {
-		fmt.Println("Unable to update config")
-		utils.Err(err)
+		utils.Err(err, "Unable to update config")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	info := models.ParseConfigInfo(result["environment"].(map[string]interface{}))
@@ -422,14 +399,13 @@ func GetAPIActivityLogs(cmd *cobra.Command, apiKey string) ([]byte, []models.Log
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/logs", []utils.QueryParam{}, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch activity logs")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch activity logs")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	var logs []models.Log
@@ -445,14 +421,13 @@ func GetAPIActivityLog(cmd *cobra.Command, apiKey string, log string) ([]byte, m
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/logs/"+log, []utils.QueryParam{}, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch activity log")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch activity log")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	parsedLog := models.ParseLog(result["log"].(map[string]interface{}))
@@ -467,14 +442,13 @@ func GetAPIConfigLogs(cmd *cobra.Command, apiKey string, project string, config 
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/environments/"+config+"/logs", params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch config logs")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch config logs")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	var logs []models.Log
@@ -493,14 +467,13 @@ func GetAPIConfigLog(cmd *cobra.Command, apiKey string, project string, config s
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.GetRequest(host, "v2/environments/"+config+"/logs/"+log, params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch config log")
-		utils.Err(err)
+		utils.Err(err, "Unable to fetch config log")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	parsedLog := models.ParseLog(result["log"].(map[string]interface{}))
@@ -515,14 +488,13 @@ func RollbackAPIConfigLog(cmd *cobra.Command, apiKey string, project string, con
 	host := cmd.Flag("api-host").Value.String()
 	response, err := utils.PostRequest(host, "v2/environments/"+config+"/logs/"+log+"/rollback", params, apiKey, []byte{})
 	if err != nil {
-		fmt.Println("Unable to rollback config log")
-		utils.Err(err)
+		utils.Err(err, "Unable to rollback config log")
 	}
 
 	var result map[string]interface{}
 	err = json.Unmarshal(response, &result)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	parsedLog := models.ParseLog(result["log"].(map[string]interface{}))

--- a/api/api.go
+++ b/api/api.go
@@ -30,7 +30,7 @@ func GetAPISecrets(cmd *cobra.Command, apiKey string, project string, config str
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/variables", params, apiKey)
+	response, err := utils.GetRequest(host, "/v2/variables", params, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch secrets")
 	}
@@ -66,7 +66,7 @@ func SetAPISecrets(cmd *cobra.Command, apiKey string, project string, config str
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.PostRequest(host, "v2/variables", params, apiKey, body)
+	response, err := utils.PostRequest(host, "/v2/variables", params, apiKey, body)
 	if err != nil {
 		utils.Err(err, "Unable to fetch secrets")
 	}
@@ -89,7 +89,7 @@ func SetAPISecrets(cmd *cobra.Command, apiKey string, project string, config str
 // GetAPIWorkplaceSettings get specified workplace settings
 func GetAPIWorkplaceSettings(cmd *cobra.Command, apiKey string) ([]byte, models.WorkplaceSettings) {
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/workplace", []utils.QueryParam{}, apiKey)
+	response, err := utils.GetRequest(host, "/v2/workplace", []utils.QueryParam{}, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch workplace settings")
 	}
@@ -112,7 +112,7 @@ func SetAPIWorkplaceSettings(cmd *cobra.Command, apiKey string, values models.Wo
 	}
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.PostRequest(host, "v2/workplace", []utils.QueryParam{}, apiKey, body)
+	response, err := utils.PostRequest(host, "/v2/workplace", []utils.QueryParam{}, apiKey, body)
 	if err != nil {
 		utils.Err(err, "Unable to update workplace settings")
 	}
@@ -130,7 +130,7 @@ func SetAPIWorkplaceSettings(cmd *cobra.Command, apiKey string, values models.Wo
 // GetAPIProjects get projects
 func GetAPIProjects(cmd *cobra.Command, apiKey string) ([]byte, []models.ProjectInfo) {
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/pipelines", []utils.QueryParam{}, apiKey)
+	response, err := utils.GetRequest(host, "/v2/pipelines", []utils.QueryParam{}, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch projects")
 	}
@@ -152,7 +152,7 @@ func GetAPIProjects(cmd *cobra.Command, apiKey string) ([]byte, []models.Project
 // GetAPIProject get specified project
 func GetAPIProject(cmd *cobra.Command, apiKey string, project string) ([]byte, models.ProjectInfo) {
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/pipelines/"+project, []utils.QueryParam{}, apiKey)
+	response, err := utils.GetRequest(host, "/v2/pipelines/"+project, []utils.QueryParam{}, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch project")
 	}
@@ -176,7 +176,7 @@ func CreateAPIProject(cmd *cobra.Command, apiKey string, name string, descriptio
 	}
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.PostRequest(host, "v2/pipelines/", []utils.QueryParam{}, apiKey, body)
+	response, err := utils.PostRequest(host, "/v2/pipelines/", []utils.QueryParam{}, apiKey, body)
 	if err != nil {
 		utils.Err(err, "Unable to create project")
 	}
@@ -200,7 +200,7 @@ func UpdateAPIProject(cmd *cobra.Command, apiKey string, project string, name st
 	}
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.PostRequest(host, "v2/pipelines/"+project, []utils.QueryParam{}, apiKey, body)
+	response, err := utils.PostRequest(host, "/v2/pipelines/"+project, []utils.QueryParam{}, apiKey, body)
 	if err != nil {
 		utils.Err(err, "Unable to update project")
 	}
@@ -218,7 +218,7 @@ func UpdateAPIProject(cmd *cobra.Command, apiKey string, project string, name st
 // DeleteAPIProject create a project
 func DeleteAPIProject(cmd *cobra.Command, apiKey string, project string) {
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.DeleteRequest(host, "v2/pipelines/"+project, []utils.QueryParam{}, apiKey)
+	response, err := utils.DeleteRequest(host, "/v2/pipelines/"+project, []utils.QueryParam{}, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to delete project")
 	}
@@ -236,7 +236,7 @@ func GetAPIEnvironments(cmd *cobra.Command, apiKey string, project string) ([]by
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/stages", params, apiKey)
+	response, err := utils.GetRequest(host, "/v2/stages", params, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch environments")
 	}
@@ -261,7 +261,7 @@ func GetAPIEnvironment(cmd *cobra.Command, apiKey string, project string, enviro
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/stages/"+environment, params, apiKey)
+	response, err := utils.GetRequest(host, "/v2/stages/"+environment, params, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch environment")
 	}
@@ -282,7 +282,7 @@ func GetAPIConfigs(cmd *cobra.Command, apiKey string, project string) ([]byte, [
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/environments", params, apiKey)
+	response, err := utils.GetRequest(host, "/v2/environments", params, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch configs")
 	}
@@ -307,7 +307,7 @@ func GetAPIConfig(cmd *cobra.Command, apiKey string, project string, config stri
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/environments/"+config, params, apiKey)
+	response, err := utils.GetRequest(host, "/v2/environments/"+config, params, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch configs")
 	}
@@ -334,7 +334,7 @@ func CreateAPIConfig(cmd *cobra.Command, apiKey string, project string, name str
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.PostRequest(host, "v2/environments", params, apiKey, body)
+	response, err := utils.PostRequest(host, "/v2/environments", params, apiKey, body)
 	if err != nil {
 		utils.Err(err, "Unable to create config")
 	}
@@ -355,7 +355,7 @@ func DeleteAPIConfig(cmd *cobra.Command, apiKey string, project string, config s
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.DeleteRequest(host, "v2/environments/"+config, params, apiKey)
+	response, err := utils.DeleteRequest(host, "/v2/environments/"+config, params, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to delete config")
 	}
@@ -379,7 +379,7 @@ func UpdateAPIConfig(cmd *cobra.Command, apiKey string, project string, config s
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.PostRequest(host, "v2/environments/"+config, params, apiKey, body)
+	response, err := utils.PostRequest(host, "/v2/environments/"+config, params, apiKey, body)
 	if err != nil {
 		utils.Err(err, "Unable to update config")
 	}
@@ -397,7 +397,7 @@ func UpdateAPIConfig(cmd *cobra.Command, apiKey string, project string, config s
 // GetAPIActivityLogs get activity logs
 func GetAPIActivityLogs(cmd *cobra.Command, apiKey string) ([]byte, []models.Log) {
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/logs", []utils.QueryParam{}, apiKey)
+	response, err := utils.GetRequest(host, "/v2/logs", []utils.QueryParam{}, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch activity logs")
 	}
@@ -419,7 +419,7 @@ func GetAPIActivityLogs(cmd *cobra.Command, apiKey string) ([]byte, []models.Log
 // GetAPIActivityLog get specified activity log
 func GetAPIActivityLog(cmd *cobra.Command, apiKey string, log string) ([]byte, models.Log) {
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/logs/"+log, []utils.QueryParam{}, apiKey)
+	response, err := utils.GetRequest(host, "/v2/logs/"+log, []utils.QueryParam{}, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch activity log")
 	}
@@ -440,7 +440,7 @@ func GetAPIConfigLogs(cmd *cobra.Command, apiKey string, project string, config 
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/environments/"+config+"/logs", params, apiKey)
+	response, err := utils.GetRequest(host, "/v2/environments/"+config+"/logs", params, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch config logs")
 	}
@@ -465,7 +465,7 @@ func GetAPIConfigLog(cmd *cobra.Command, apiKey string, project string, config s
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.GetRequest(host, "v2/environments/"+config+"/logs/"+log, params, apiKey)
+	response, err := utils.GetRequest(host, "/v2/environments/"+config+"/logs/"+log, params, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to fetch config log")
 	}
@@ -486,7 +486,7 @@ func RollbackAPIConfigLog(cmd *cobra.Command, apiKey string, project string, con
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("api-host").Value.String()
-	response, err := utils.PostRequest(host, "v2/environments/"+config+"/logs/"+log+"/rollback", params, apiKey, []byte{})
+	response, err := utils.PostRequest(host, "/v2/environments/"+config+"/logs/"+log+"/rollback", params, apiKey, []byte{})
 	if err != nil {
 		utils.Err(err, "Unable to rollback config log")
 	}

--- a/api/deploy.go
+++ b/api/deploy.go
@@ -58,7 +58,7 @@ func GetDeploySecrets(cmd *cobra.Command, apiKey string, project string, config 
 	params = append(params, utils.QueryParam{Key: "pipeline", Value: project})
 
 	host := cmd.Flag("deploy-host").Value.String()
-	response, err := utils.GetRequest(host, "v1/variables", params, apiKey)
+	response, err := utils.GetRequest(host, "/v1/variables", params, apiKey)
 	if err != nil {
 		utils.Log("Unable to fetch secrets")
 		return nil, err
@@ -76,7 +76,7 @@ func DownloadSecrets(cmd *cobra.Command, apiKey string, project string, config s
 	params = append(params, utils.QueryParam{Key: "metadata", Value: strconv.FormatBool(metadata)})
 
 	host := cmd.Flag("deploy-host").Value.String()
-	response, err := utils.GetRequest(host, "v1/variables", params, apiKey)
+	response, err := utils.GetRequest(host, "/v1/variables", params, apiKey)
 	if err != nil {
 		utils.Err(err, "Unable to download secrets")
 	}

--- a/api/deploy.go
+++ b/api/deploy.go
@@ -18,7 +18,6 @@ package api
 import (
 	utils "doppler-cli/utils"
 	"encoding/json"
-	"fmt"
 	"strconv"
 
 	"github.com/spf13/cobra"
@@ -61,7 +60,7 @@ func GetDeploySecrets(cmd *cobra.Command, apiKey string, project string, config 
 	host := cmd.Flag("deploy-host").Value.String()
 	response, err := utils.GetRequest(host, "v1/variables", params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to fetch secrets")
+		utils.Log("Unable to fetch secrets")
 		return nil, err
 	}
 
@@ -79,8 +78,7 @@ func DownloadSecrets(cmd *cobra.Command, apiKey string, project string, config s
 	host := cmd.Flag("deploy-host").Value.String()
 	response, err := utils.GetRequest(host, "v1/variables", params, apiKey)
 	if err != nil {
-		fmt.Println("Unable to download secrets")
-		utils.Err(err)
+		utils.Err(err, "Unable to download secrets")
 	}
 
 	return response

--- a/cmd/activity.go
+++ b/cmd/activity.go
@@ -56,11 +56,9 @@ var activityGetCmd = &cobra.Command{
 }
 
 func init() {
-	activityGetCmd.Flags().Bool("json", false, "output json")
 	activityGetCmd.Flags().String("log", "", "activity log id")
 	activityCmd.AddCommand(activityGetCmd)
 
-	activityCmd.Flags().Bool("json", false, "output json")
 	activityCmd.Flags().IntP("number", "n", 5, "max number of logs to display")
 	rootCmd.AddCommand(activityCmd)
 }

--- a/cmd/configs.go
+++ b/cmd/configs.go
@@ -18,9 +18,7 @@ package cmd
 import (
 	"doppler-cli/api"
 	configuration "doppler-cli/config"
-	"doppler-cli/models"
 	"doppler-cli/utils"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -39,7 +37,7 @@ var configsCmd = &cobra.Command{
 
 		_, configs := api.GetAPIConfigs(cmd, localConfig.Key.Value, localConfig.Project.Value)
 
-		printConfigsInfo(configs, jsonFlag)
+		utils.PrintConfigsInfo(configs, jsonFlag)
 	},
 }
 
@@ -57,7 +55,7 @@ var configsGetCmd = &cobra.Command{
 
 		_, configInfo := api.GetAPIConfig(cmd, localConfig.Key.Value, localConfig.Project.Value, config)
 
-		printConfigInfo(configInfo, jsonFlag)
+		utils.PrintConfigInfo(configInfo, jsonFlag)
 	},
 }
 
@@ -79,7 +77,7 @@ var configsCreateCmd = &cobra.Command{
 		_, info := api.CreateAPIConfig(cmd, localConfig.Key.Value, localConfig.Project.Value, name, environment, defaults)
 
 		if !silent {
-			printConfigInfo(info, jsonFlag)
+			utils.PrintConfigInfo(info, jsonFlag)
 		}
 	},
 }
@@ -103,7 +101,7 @@ var configsDeleteCmd = &cobra.Command{
 
 			if !silent {
 				_, configs := api.GetAPIConfigs(cmd, localConfig.Key.Value, localConfig.Project.Value)
-				printConfigsInfo(configs, jsonFlag)
+				utils.PrintConfigsInfo(configs, jsonFlag)
 			}
 		}
 	},
@@ -126,7 +124,7 @@ var configsUpdateCmd = &cobra.Command{
 		_, info := api.UpdateAPIConfig(cmd, localConfig.Key.Value, localConfig.Project.Value, config, name)
 
 		if !silent {
-			printConfigInfo(info, jsonFlag)
+			utils.PrintConfigInfo(info, jsonFlag)
 		}
 	},
 }
@@ -231,27 +229,4 @@ func init() {
 	configsLogsCmd.AddCommand(configsLogsRollbackCmd)
 
 	rootCmd.AddCommand(configsCmd)
-}
-
-func printConfigsInfo(info []models.ConfigInfo, jsonFlag bool) {
-	if jsonFlag {
-		utils.PrintJSON(info)
-		return
-	}
-
-	var rows [][]string
-	for _, configInfo := range info {
-		rows = append(rows, []string{configInfo.Name, strings.Join(configInfo.MissingVariables, ", "), configInfo.DeployedAt, configInfo.CreatedAt, configInfo.Environment, configInfo.Project})
-	}
-	utils.PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows)
-}
-
-func printConfigInfo(info models.ConfigInfo, jsonFlag bool) {
-	if jsonFlag {
-		utils.PrintJSON(info)
-		return
-	}
-
-	rows := [][]string{{info.Name, strings.Join(info.MissingVariables, ", "), info.DeployedAt, info.CreatedAt, info.Environment, info.Project}}
-	utils.PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows)
 }

--- a/cmd/configs.go
+++ b/cmd/configs.go
@@ -245,12 +245,7 @@ func init() {
 
 func printConfigsInfo(info []models.ConfigInfo, jsonFlag bool) {
 	if jsonFlag {
-		resp, err := json.Marshal(info)
-		if err != nil {
-			utils.Err(err)
-		}
-
-		fmt.Println(string(resp))
+		utils.PrintJSON(info)
 		return
 	}
 
@@ -263,12 +258,7 @@ func printConfigsInfo(info []models.ConfigInfo, jsonFlag bool) {
 
 func printConfigInfo(info models.ConfigInfo, jsonFlag bool) {
 	if jsonFlag {
-		resp, err := json.Marshal(info)
-		if err != nil {
-			utils.Err(err)
-		}
-
-		fmt.Println(string(resp))
+		utils.PrintJSON(info)
 		return
 	}
 

--- a/cmd/configs.go
+++ b/cmd/configs.go
@@ -20,8 +20,6 @@ import (
 	configuration "doppler-cli/config"
 	"doppler-cli/models"
 	"doppler-cli/utils"
-	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -190,18 +188,15 @@ var configsLogsRollbackCmd = &cobra.Command{
 
 func init() {
 	configsCmd.Flags().String("project", "", "doppler project (e.g. backend)")
-	configsCmd.Flags().Bool("json", false, "output json")
 
 	configsGetCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	configsGetCmd.Flags().String("config", "", "doppler config (e.g. dev)")
-	configsGetCmd.Flags().Bool("json", false, "output json")
 	configsCmd.AddCommand(configsGetCmd)
 
 	configsCreateCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	configsCreateCmd.Flags().String("name", "", "config name")
 	configsCreateCmd.Flags().String("environment", "", "config environment")
 	configsCreateCmd.Flags().Bool("defaults", true, "populate config with environment's default secrets")
-	configsCreateCmd.Flags().Bool("json", false, "output json")
 	configsCreateCmd.Flags().Bool("silent", false, "don't output the response")
 	configsCreateCmd.MarkFlagRequired("environment")
 	configsCmd.AddCommand(configsCreateCmd)
@@ -209,34 +204,29 @@ func init() {
 	configsUpdateCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	configsUpdateCmd.Flags().String("config", "", "doppler config (e.g. dev)")
 	configsUpdateCmd.Flags().String("name", "", "config name")
-	configsUpdateCmd.Flags().Bool("json", false, "output json")
 	configsUpdateCmd.Flags().Bool("silent", false, "don't output the response")
 	configsUpdateCmd.MarkFlagRequired("name")
 	configsCmd.AddCommand(configsUpdateCmd)
 
 	configsDeleteCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	configsDeleteCmd.Flags().String("config", "", "doppler config (e.g. dev)")
-	configsDeleteCmd.Flags().Bool("json", false, "output json")
 	configsDeleteCmd.Flags().Bool("silent", false, "don't output the response")
 	configsDeleteCmd.Flags().Bool("yes", false, "proceed without confirmation")
 	configsCmd.AddCommand(configsDeleteCmd)
 
 	configsLogsCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	configsLogsCmd.Flags().String("config", "", "doppler config (e.g. dev)")
-	configsLogsCmd.Flags().Bool("json", false, "output json")
 	configsLogsCmd.Flags().IntP("number", "n", 5, "max number of logs to display")
 	configsCmd.AddCommand(configsLogsCmd)
 
 	configsLogsGetCmd.Flags().String("log", "", "audit log id")
 	configsLogsGetCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	configsLogsGetCmd.Flags().String("config", "", "doppler config (e.g. dev)")
-	configsLogsGetCmd.Flags().Bool("json", false, "output json")
 	configsLogsCmd.AddCommand(configsLogsGetCmd)
 
 	configsLogsRollbackCmd.Flags().String("log", "", "audit log id")
 	configsLogsRollbackCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	configsLogsRollbackCmd.Flags().String("config", "", "doppler config (e.g. dev)")
-	configsLogsRollbackCmd.Flags().Bool("json", false, "output json")
 	configsLogsRollbackCmd.Flags().Bool("silent", false, "don't output the response")
 	configsLogsCmd.AddCommand(configsLogsRollbackCmd)
 

--- a/cmd/configs.go
+++ b/cmd/configs.go
@@ -34,7 +34,7 @@ var configsCmd = &cobra.Command{
 	Use:   "configs",
 	Short: "List configs",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		localConfig := configuration.LocalConfig(cmd)
 
 		_, configs := api.GetAPIConfigs(cmd, localConfig.Key.Value, localConfig.Project.Value)
@@ -47,7 +47,7 @@ var configsGetCmd = &cobra.Command{
 	Use:   "get [config]",
 	Short: "Get info for a config",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		localConfig := configuration.LocalConfig(cmd)
 
 		config := localConfig.Config.Value
@@ -65,7 +65,7 @@ var configsCreateCmd = &cobra.Command{
 	Use:   "create [name]",
 	Short: "Create a config",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		defaults := utils.GetBoolFlag(cmd, "defaults")
 		environment := cmd.Flag("environment").Value.String()
@@ -88,7 +88,7 @@ var configsDeleteCmd = &cobra.Command{
 	Use:   "delete [config]",
 	Short: "Delete a config",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
 		localConfig := configuration.LocalConfig(cmd)
@@ -113,7 +113,7 @@ var configsUpdateCmd = &cobra.Command{
 	Use:   "update [config]",
 	Short: "Update a config",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		name := cmd.Flag("name").Value.String()
 		localConfig := configuration.LocalConfig(cmd)
@@ -135,7 +135,7 @@ var configsLogsCmd = &cobra.Command{
 	Use:   "logs",
 	Short: "List config audit logs",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		localConfig := configuration.LocalConfig(cmd)
 		number := utils.GetIntFlag(cmd, "number", 16)
 
@@ -149,7 +149,7 @@ var configsLogsGetCmd = &cobra.Command{
 	Use:   "get [log_id]",
 	Short: "Get config audit log",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		localConfig := configuration.LocalConfig(cmd)
 
 		log := cmd.Flag("log").Value.String()
@@ -168,7 +168,7 @@ var configsLogsRollbackCmd = &cobra.Command{
 	Use:   "rollback [log_id]",
 	Short: "Rollback a config change",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		localConfig := configuration.LocalConfig(cmd)
 

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -37,12 +37,7 @@ var configureCmd = &cobra.Command{
 			allConfigs := configuration.AllConfigs()
 
 			if jsonFlag {
-				resp, err := json.Marshal(allConfigs)
-				if err != nil {
-					utils.Err(err)
-				}
-
-				fmt.Println(string(resp))
+				utils.PrintJSON(allConfigs)
 				return
 			}
 
@@ -99,12 +94,7 @@ var configureCmd = &cobra.Command{
 				confMap[scope]["key"] = value
 			}
 
-			resp, err := json.Marshal(confMap)
-			if err != nil {
-				utils.Err(err)
-			}
-
-			fmt.Println(string(resp))
+			utils.PrintJSON(confMap)
 			return
 		}
 
@@ -172,12 +162,7 @@ doppler configure get key otherkey`,
 				}
 			}
 
-			resp, err := json.Marshal(filteredConfMap)
-			if err != nil {
-				utils.Err(err)
-			}
-
-			fmt.Println(string(resp))
+			utils.PrintJSON(filteredConfMap)
 			return
 		}
 

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -30,7 +30,7 @@ var configureCmd = &cobra.Command{
 	Short: "View cli configuration",
 	Run: func(cmd *cobra.Command, args []string) {
 		all := utils.GetBoolFlag(cmd, "all")
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 
 		if all {
 			allConfigs := configuration.AllConfigs()
@@ -114,7 +114,7 @@ doppler configure get key otherkey`,
 			dopplerErrors.CommandMissingArgument(cmd)
 		}
 
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		plain := utils.GetBoolFlag(cmd, "plain")
 
 		scope := cmd.Flag("scope").Value.String()

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -19,7 +19,6 @@ import (
 	configuration "doppler-cli/config"
 	dopplerErrors "doppler-cli/errors"
 	"doppler-cli/utils"
-	"encoding/json"
 	"fmt"
 	"strings"
 
@@ -233,7 +232,6 @@ doppler configure unset key otherkey`,
 
 func init() {
 	configureGetCmd.Flags().Bool("plain", false, "print values without formatting. values will be printed in the same order as specified	")
-	configureGetCmd.Flags().Bool("json", false, "output json")
 	configureCmd.AddCommand(configureGetCmd)
 
 	configureSetCmd.Flags().Bool("silent", false, "don't output the new config")
@@ -243,6 +241,5 @@ func init() {
 	configureCmd.AddCommand(configureUnsetCmd)
 
 	configureCmd.Flags().Bool("all", false, "print all saved options")
-	configureCmd.Flags().Bool("json", false, "output json")
 	rootCmd.AddCommand(configureCmd)
 }

--- a/cmd/configure.go
+++ b/cmd/configure.go
@@ -19,6 +19,7 @@ import (
 	configuration "doppler-cli/config"
 	dopplerErrors "doppler-cli/errors"
 	"doppler-cli/utils"
+	"errors"
 	"fmt"
 	"strings"
 
@@ -195,7 +196,15 @@ doppler configure set key=123 otherkey=456`,
 		silent := utils.GetBoolFlag(cmd, "silent")
 
 		scope := cmd.Flag("scope").Value.String()
-		configuration.Set(scope, args)
+		options := make(map[string]string)
+		for _, option := range args {
+			arr := strings.Split(option, "=")
+			if len(arr) < 2 {
+				utils.Err(errors.New("invalid option "+option), "")
+			}
+			options[arr[0]] = arr[1]
+		}
+		configuration.Set(scope, options)
 
 		if !silent {
 			conf := configuration.Get(scope)

--- a/cmd/environments.go
+++ b/cmd/environments.go
@@ -75,12 +75,7 @@ func init() {
 
 func printEnvironmentsInfo(info []models.EnvironmentInfo, jsonFlag bool) {
 	if jsonFlag {
-		resp, err := json.Marshal(info)
-		if err != nil {
-			utils.Err(err)
-		}
-
-		fmt.Println(string(resp))
+		utils.PrintJSON(info)
 		return
 	}
 
@@ -93,12 +88,7 @@ func printEnvironmentsInfo(info []models.EnvironmentInfo, jsonFlag bool) {
 
 func printEnvironmentInfo(info models.EnvironmentInfo, jsonFlag bool) {
 	if jsonFlag {
-		resp, err := json.Marshal(info)
-		if err != nil {
-			utils.Err(err)
-		}
-
-		fmt.Println(string(resp))
+		utils.PrintJSON(info)
 		return
 	}
 

--- a/cmd/environments.go
+++ b/cmd/environments.go
@@ -30,7 +30,7 @@ var environmentsCmd = &cobra.Command{
 	Use:   "environments",
 	Short: "List environments",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		localConfig := configuration.LocalConfig(cmd)
 
 		project := localConfig.Project.Value
@@ -52,7 +52,7 @@ var environmentsGetCmd = &cobra.Command{
 			dopplerErrors.CommandMissingArgument(cmd)
 		}
 
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		localConfig := configuration.LocalConfig(cmd)
 		environment := args[0]
 

--- a/cmd/environments.go
+++ b/cmd/environments.go
@@ -19,9 +19,7 @@ import (
 	api "doppler-cli/api"
 	configuration "doppler-cli/config"
 	dopplerErrors "doppler-cli/errors"
-	"doppler-cli/models"
 	"doppler-cli/utils"
-	"strings"
 
 	"github.com/spf13/cobra"
 )
@@ -40,7 +38,7 @@ var environmentsCmd = &cobra.Command{
 
 		_, info := api.GetAPIEnvironments(cmd, localConfig.Key.Value, project)
 
-		printEnvironmentsInfo(info, jsonFlag)
+		utils.PrintEnvironmentsInfo(info, jsonFlag)
 	},
 }
 
@@ -58,7 +56,7 @@ var environmentsGetCmd = &cobra.Command{
 
 		_, info := api.GetAPIEnvironment(cmd, localConfig.Key.Value, localConfig.Project.Value, environment)
 
-		printEnvironmentInfo(info, jsonFlag)
+		utils.PrintEnvironmentInfo(info, jsonFlag)
 	},
 }
 
@@ -67,27 +65,4 @@ func init() {
 	environmentsCmd.AddCommand(environmentsGetCmd)
 
 	rootCmd.AddCommand(environmentsCmd)
-}
-
-func printEnvironmentsInfo(info []models.EnvironmentInfo, jsonFlag bool) {
-	if jsonFlag {
-		utils.PrintJSON(info)
-		return
-	}
-
-	var rows [][]string
-	for _, environmentInfo := range info {
-		rows = append(rows, []string{environmentInfo.ID, environmentInfo.Name, environmentInfo.SetupAt, environmentInfo.FirstDeployAt, environmentInfo.CreatedAt, strings.Join(environmentInfo.MissingVariables, ", "), environmentInfo.Project})
-	}
-	utils.PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows)
-}
-
-func printEnvironmentInfo(info models.EnvironmentInfo, jsonFlag bool) {
-	if jsonFlag {
-		utils.PrintJSON(info)
-		return
-	}
-
-	rows := [][]string{{info.ID, info.Name, info.SetupAt, info.FirstDeployAt, info.CreatedAt, strings.Join(info.MissingVariables, ", "), info.Project}}
-	utils.PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows)
 }

--- a/cmd/environments.go
+++ b/cmd/environments.go
@@ -21,8 +21,6 @@ import (
 	dopplerErrors "doppler-cli/errors"
 	"doppler-cli/models"
 	"doppler-cli/utils"
-	"encoding/json"
-	"fmt"
 	"strings"
 
 	"github.com/spf13/cobra"
@@ -65,11 +63,9 @@ var environmentsGetCmd = &cobra.Command{
 }
 
 func init() {
-	environmentsGetCmd.Flags().Bool("json", false, "output json")
 	environmentsGetCmd.Flags().String("project", "", "output json")
 	environmentsCmd.AddCommand(environmentsGetCmd)
 
-	environmentsCmd.Flags().Bool("json", false, "output json")
 	rootCmd.AddCommand(environmentsCmd)
 }
 

--- a/cmd/open.go
+++ b/cmd/open.go
@@ -33,7 +33,7 @@ var openDashboardCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := open.Run("https://doppler.com")
 		if err != nil {
-			utils.Err(err)
+			utils.Err(err, "")
 		}
 	},
 }
@@ -44,7 +44,7 @@ var openStatusCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := open.Run("https://status.doppler.com")
 		if err != nil {
-			utils.Err(err)
+			utils.Err(err, "")
 		}
 	},
 }
@@ -55,7 +55,7 @@ var openSlackCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := open.Run("https://doppler.com/slack")
 		if err != nil {
-			utils.Err(err)
+			utils.Err(err, "")
 		}
 	},
 }
@@ -66,7 +66,7 @@ var openGithubCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		err := open.Run("https://doppler.com/github")
 		if err != nil {
-			utils.Err(err)
+			utils.Err(err, "")
 		}
 	},
 }

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -20,8 +20,6 @@ import (
 	configuration "doppler-cli/config"
 	"doppler-cli/models"
 	"doppler-cli/utils"
-	"encoding/json"
-	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -129,22 +127,18 @@ var projectsUpdateCmd = &cobra.Command{
 }
 
 func init() {
-	projectsGetCmd.Flags().Bool("json", false, "output json")
 	projectsGetCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	projectsCmd.AddCommand(projectsGetCmd)
 
-	projectsCreateCmd.Flags().Bool("json", false, "output json")
 	projectsCreateCmd.Flags().Bool("silent", false, "don't output the response")
 	projectsCreateCmd.Flags().String("name", "", "project name")
 	projectsCreateCmd.Flags().String("description", "", "project description")
 	projectsCmd.AddCommand(projectsCreateCmd)
 
-	projectsDeleteCmd.Flags().Bool("json", false, "output json")
 	projectsDeleteCmd.Flags().Bool("silent", false, "don't output the response")
 	projectsDeleteCmd.Flags().Bool("yes", false, "proceed without confirmation")
 	projectsCmd.AddCommand(projectsDeleteCmd)
 
-	projectsUpdateCmd.Flags().Bool("json", false, "output json")
 	projectsUpdateCmd.Flags().Bool("silent", false, "don't output the response")
 	projectsUpdateCmd.Flags().String("name", "", "project name")
 	projectsUpdateCmd.Flags().String("description", "", "project description")
@@ -152,7 +146,6 @@ func init() {
 	projectsUpdateCmd.MarkFlagRequired("description")
 	projectsCmd.AddCommand(projectsUpdateCmd)
 
-	projectsCmd.Flags().Bool("json", false, "output json")
 	rootCmd.AddCommand(projectsCmd)
 }
 

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -28,7 +28,7 @@ var projectsCmd = &cobra.Command{
 	Use:   "projects",
 	Short: "List projects",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 
 		localConfig := configuration.LocalConfig(cmd)
 		_, info := api.GetAPIProjects(cmd, localConfig.Key.Value)
@@ -41,7 +41,7 @@ var projectsGetCmd = &cobra.Command{
 	Use:   "get [project_id]",
 	Short: "Get info for a project",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		localConfig := configuration.LocalConfig(cmd)
 
 		project := localConfig.Project.Value
@@ -59,7 +59,7 @@ var projectsCreateCmd = &cobra.Command{
 	Use:   "create [name]",
 	Short: "Create a project",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		description := cmd.Flag("description").Value.String()
 
@@ -81,7 +81,7 @@ var projectsDeleteCmd = &cobra.Command{
 	Use:   "delete [project_id]",
 	Short: "Delete a project",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
 		localConfig := configuration.LocalConfig(cmd)
@@ -106,7 +106,7 @@ var projectsUpdateCmd = &cobra.Command{
 	Use:   "update [project_id]",
 	Short: "Update a project",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		localConfig := configuration.LocalConfig(cmd)
 

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -18,7 +18,6 @@ package cmd
 import (
 	api "doppler-cli/api"
 	configuration "doppler-cli/config"
-	"doppler-cli/models"
 	"doppler-cli/utils"
 
 	"github.com/spf13/cobra"
@@ -33,7 +32,7 @@ var projectsCmd = &cobra.Command{
 		localConfig := configuration.LocalConfig(cmd)
 		_, info := api.GetAPIProjects(cmd, localConfig.Key.Value)
 
-		printProjectsInfo(info, jsonFlag)
+		utils.PrintProjectsInfo(info, jsonFlag)
 	},
 }
 
@@ -51,7 +50,7 @@ var projectsGetCmd = &cobra.Command{
 
 		_, info := api.GetAPIProject(cmd, localConfig.Key.Value, project)
 
-		printProjectInfo(info, jsonFlag)
+		utils.PrintProjectInfo(info, jsonFlag)
 	},
 }
 
@@ -72,7 +71,7 @@ var projectsCreateCmd = &cobra.Command{
 		_, info := api.CreateAPIProject(cmd, localConfig.Key.Value, name, description)
 
 		if !silent {
-			printProjectInfo(info, jsonFlag)
+			utils.PrintProjectInfo(info, jsonFlag)
 		}
 	},
 }
@@ -96,7 +95,7 @@ var projectsDeleteCmd = &cobra.Command{
 
 			if !silent {
 				_, info := api.GetAPIProjects(cmd, localConfig.Key.Value)
-				printProjectsInfo(info, jsonFlag)
+				utils.PrintProjectsInfo(info, jsonFlag)
 			}
 		}
 	},
@@ -121,7 +120,7 @@ var projectsUpdateCmd = &cobra.Command{
 		_, info := api.UpdateAPIProject(cmd, localConfig.Key.Value, project, name, description)
 
 		if !silent {
-			printProjectInfo(info, jsonFlag)
+			utils.PrintProjectInfo(info, jsonFlag)
 		}
 	},
 }
@@ -147,27 +146,4 @@ func init() {
 	projectsCmd.AddCommand(projectsUpdateCmd)
 
 	rootCmd.AddCommand(projectsCmd)
-}
-
-func printProjectsInfo(info []models.ProjectInfo, jsonFlag bool) {
-	if jsonFlag {
-		utils.PrintJSON(info)
-		return
-	}
-
-	var rows [][]string
-	for _, projectInfo := range info {
-		rows = append(rows, []string{projectInfo.ID, projectInfo.Name, projectInfo.Description, projectInfo.SetupAt, projectInfo.CreatedAt})
-	}
-	utils.PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows)
-}
-
-func printProjectInfo(info models.ProjectInfo, jsonFlag bool) {
-	if jsonFlag {
-		utils.PrintJSON(info)
-		return
-	}
-
-	rows := [][]string{{info.ID, info.Name, info.Description, info.SetupAt, info.CreatedAt}}
-	utils.PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows)
 }

--- a/cmd/projects.go
+++ b/cmd/projects.go
@@ -158,12 +158,7 @@ func init() {
 
 func printProjectsInfo(info []models.ProjectInfo, jsonFlag bool) {
 	if jsonFlag {
-		resp, err := json.Marshal(info)
-		if err != nil {
-			utils.Err(err)
-		}
-
-		fmt.Println(string(resp))
+		utils.PrintJSON(info)
 		return
 	}
 
@@ -176,12 +171,7 @@ func printProjectsInfo(info []models.ProjectInfo, jsonFlag bool) {
 
 func printProjectInfo(info models.ProjectInfo, jsonFlag bool) {
 	if jsonFlag {
-		resp, err := json.Marshal(info)
-		if err != nil {
-			utils.Err(err)
-		}
-
-		fmt.Println(string(resp))
+		utils.PrintJSON(info)
 		return
 	}
 

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -19,6 +19,7 @@ import (
 	dopplerErrors "doppler-cli/errors"
 	"doppler-cli/utils"
 	"fmt"
+	"os"
 
 	"github.com/spf13/cobra"
 )
@@ -48,6 +49,9 @@ var rootCmd = &cobra.Command{
 func Execute() {
 	args := os.Args[1:]
 	rootCmd.ParseFlags(args)
+	if rootCmd.Flags().Changed("debug") {
+		utils.Debug = utils.GetBoolFlag(rootCmd, "debug")
+	}
 	if rootCmd.Flags().Changed("json") {
 		utils.JSON = utils.GetBoolFlag(rootCmd, "json")
 	}
@@ -69,6 +73,7 @@ func init() {
 	rootCmd.PersistentFlags().String("scope", ".", "the directory to scope your config to")
 	rootCmd.PersistentFlags().String("configuration", "$HOME/.doppler.yaml", "config file")
 	rootCmd.PersistentFlags().Bool("json", false, "output json")
+	rootCmd.PersistentFlags().Bool("debug", false, "output additional information when encountering errors")
 
 	rootCmd.Flags().BoolP("version", "V", false, "")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -69,7 +69,7 @@ func init() {
 	rootCmd.PersistentFlags().String("api-host", "https://staging-api.doppler.com", "api host")
 	rootCmd.PersistentFlags().String("deploy-host", "https://staging-deploy.doppler.com", "deploy host")
 
-	rootCmd.PersistentFlags().Bool("enable-env", true, "support reading doppler config from the environment")
+	rootCmd.PersistentFlags().Bool("no-read-env", false, "don't read doppler config from the environment")
 	rootCmd.PersistentFlags().String("scope", ".", "the directory to scope your config to")
 	rootCmd.PersistentFlags().String("configuration", "$HOME/.doppler.yaml", "config file")
 	rootCmd.PersistentFlags().Bool("json", false, "output json")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -46,6 +46,12 @@ var rootCmd = &cobra.Command{
 }
 
 func Execute() {
+	args := os.Args[1:]
+	rootCmd.ParseFlags(args)
+	if rootCmd.Flags().Changed("json") {
+		utils.JSON = utils.GetBoolFlag(rootCmd, "json")
+	}
+
 	if err := rootCmd.Execute(); err != nil {
 		utils.Err(err)
 	}
@@ -62,6 +68,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("enable-env", true, "support reading doppler config from the environment")
 	rootCmd.PersistentFlags().String("scope", ".", "the directory to scope your config to")
 	rootCmd.PersistentFlags().String("configuration", "$HOME/.doppler.yaml", "config file")
+	rootCmd.PersistentFlags().Bool("json", false, "output json")
 
 	rootCmd.Flags().BoolP("version", "V", false, "")
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -53,7 +53,7 @@ func Execute() {
 	}
 
 	if err := rootCmd.Execute(); err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 }
 

--- a/cmd/run.go
+++ b/cmd/run.go
@@ -54,7 +54,7 @@ doppler run --key=123 -- printenv`,
 		fallbackPath := utils.GetFilePath(cmd.Flag("fallback").Value.String(), "")
 
 		if cmd.Flags().Changed("fallback") && fallbackPath == "" {
-			utils.Err(errors.New("invalid fallback file path"))
+			utils.Err(errors.New("invalid fallback file path"), "")
 		}
 
 		localConfig := configuration.LocalConfig(cmd)
@@ -78,8 +78,7 @@ doppler run --key=123 -- printenv`,
 
 		err := utils.RunCommand(args, env, !silent)
 		if err != nil {
-			fmt.Println(fmt.Sprintf("Error trying to execute command: %s", args))
-			utils.Err(err)
+			utils.Err(err, fmt.Sprintf("Error trying to execute command: %s", args))
 		}
 	},
 }
@@ -93,7 +92,7 @@ func getSecrets(cmd *cobra.Command, localConfig configuration.ScopedConfig, fall
 	response, err := api.GetDeploySecrets(cmd, localConfig.Key.Value, localConfig.Project.Value, localConfig.Config.Value)
 
 	if !useFallbackFile && err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	if useFallbackFile {
@@ -104,33 +103,29 @@ func getSecrets(cmd *cobra.Command, localConfig configuration.ScopedConfig, fall
 		if !fallbackReadonly {
 			err := ioutil.WriteFile(fallbackPath, response, 0600)
 			if err != nil {
-				fmt.Println("Unable to write fallback file")
-				utils.Err(err)
+				utils.Err(err, "Unable to write fallback file")
 			}
 		}
 	}
 
 	secrets, err := api.ParseDeploySecrets(response)
 	if err != nil {
-		fmt.Println("Unable to parse response")
-		utils.Err(err)
+		utils.Err(err, "Unable to parse response")
 	}
 
 	return secrets
 }
 
 func readFallbackFile(path string) map[string]string {
-	fmt.Println("Using fallback file")
+	utils.Log("Using fallback file")
 	response, err := ioutil.ReadFile(path)
 	if err != nil {
-		fmt.Println("Unable to read fallback file")
-		utils.Err(err)
+		utils.Err(err, "Unable to read fallback file")
 	}
 
 	secrets, err := api.ParseDeploySecrets(response)
 	if err != nil {
-		fmt.Println("Unable to parse fallback file")
-		utils.Err(err)
+		utils.Err(err, "Unable to parse fallback file")
 	}
 
 	return secrets

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -164,7 +164,7 @@ doppler secrets download /root/test.env`,
 
 		err := ioutil.WriteFile(filePath, body, 0600)
 		if err != nil {
-			utils.Err(err)
+			utils.Err(err, "")
 		}
 	},
 }

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -38,7 +38,7 @@ var secretsCmd = &cobra.Command{
 	Use:   "secrets",
 	Short: "Fetch all Doppler secrets",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		plain := utils.GetBoolFlag(cmd, "plain")
 		raw := utils.GetBoolFlag(cmd, "raw")
 
@@ -61,7 +61,7 @@ doppler secrets get api_key crypto_key`,
 			dopplerErrors.CommandMissingArgument(cmd)
 		}
 
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		plain := utils.GetBoolFlag(cmd, "plain")
 		raw := utils.GetBoolFlag(cmd, "raw")
 
@@ -84,7 +84,7 @@ doppler secrets set api_key=123 crypto_key=456`,
 			dopplerErrors.CommandMissingArgument(cmd)
 		}
 
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		plain := utils.GetBoolFlag(cmd, "plain")
 		raw := utils.GetBoolFlag(cmd, "raw")
 		silent := utils.GetBoolFlag(cmd, "silent")
@@ -122,7 +122,7 @@ doppler secrets delete api_key crypto_key`,
 			dopplerErrors.CommandMissingArgument(cmd)
 		}
 
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		plain := utils.GetBoolFlag(cmd, "plain")
 		raw := utils.GetBoolFlag(cmd, "raw")
 		silent := utils.GetBoolFlag(cmd, "silent")

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -229,12 +229,7 @@ func printSecrets(secrets map[string]models.ComputedSecret, secretsToPrint []str
 			}
 		}
 
-		resp, err := json.Marshal(secretsMap)
-		if err != nil {
-			utils.Err(err)
-		}
-
-		fmt.Println(string(resp))
+		utils.PrintJSON(secretsMap)
 		return
 	}
 

--- a/cmd/secrets.go
+++ b/cmd/secrets.go
@@ -21,7 +21,6 @@ import (
 	dopplerErrors "doppler-cli/errors"
 	"doppler-cli/models"
 	"doppler-cli/utils"
-	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"sort"
@@ -175,20 +174,17 @@ func init() {
 	secretsCmd.Flags().String("config", "", "doppler config (e.g. dev)")
 	secretsCmd.Flags().Bool("plain", false, "print values without formatting")
 	secretsCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
-	secretsCmd.Flags().Bool("json", false, "output json")
 
 	secretsGetCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	secretsGetCmd.Flags().String("config", "", "doppler config (e.g. dev)")
 	secretsGetCmd.Flags().Bool("plain", false, "print values without formatting")
 	secretsGetCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
-	secretsGetCmd.Flags().Bool("json", false, "output json")
 	secretsCmd.AddCommand(secretsGetCmd)
 
 	secretsSetCmd.Flags().String("project", "", "doppler project (e.g. backend)")
 	secretsSetCmd.Flags().String("config", "", "doppler config (e.g. dev)")
 	secretsSetCmd.Flags().Bool("plain", false, "print values without formatting")
 	secretsSetCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
-	secretsSetCmd.Flags().Bool("json", false, "output json")
 	secretsSetCmd.Flags().Bool("silent", false, "don't output the response")
 	secretsCmd.AddCommand(secretsSetCmd)
 
@@ -196,7 +192,6 @@ func init() {
 	secretsDeleteCmd.Flags().String("config", "", "doppler config (e.g. dev)")
 	secretsDeleteCmd.Flags().Bool("plain", false, "print values without formatting")
 	secretsDeleteCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
-	secretsDeleteCmd.Flags().Bool("json", false, "output json")
 	secretsDeleteCmd.Flags().Bool("silent", false, "don't output the response")
 	secretsDeleteCmd.Flags().Bool("yes", false, "proceed without confirmation")
 	secretsCmd.AddCommand(secretsDeleteCmd)

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -34,7 +34,7 @@ var settingsCmd = &cobra.Command{
 		localConfig := configuration.LocalConfig(cmd)
 		_, info := api.GetAPIWorkplaceSettings(cmd, localConfig.Key.Value)
 
-		printSettings(info, jsonFlag)
+		utils.PrintSettings(info, jsonFlag)
 	},
 }
 
@@ -58,7 +58,7 @@ var settingsUpdateCmd = &cobra.Command{
 		_, info := api.SetAPIWorkplaceSettings(cmd, localConfig.Key.Value, settings)
 
 		if !silent {
-			printSettings(info, jsonFlag)
+			utils.PrintSettings(info, jsonFlag)
 		}
 	},
 }
@@ -70,14 +70,4 @@ func init() {
 	settingsCmd.AddCommand(settingsUpdateCmd)
 
 	rootCmd.AddCommand(settingsCmd)
-}
-
-func printSettings(settings models.WorkplaceSettings, jsonFlag bool) {
-	if jsonFlag {
-		utils.PrintJSON(settings)
-		return
-	}
-
-	rows := [][]string{{settings.ID, settings.Name, settings.BillingEmail}}
-	utils.PrintTable([]string{"id", "name", "billing_email"}, rows)
 }

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -21,8 +21,6 @@ import (
 	dopplerErrors "doppler-cli/errors"
 	"doppler-cli/models"
 	"doppler-cli/utils"
-	"encoding/json"
-	"fmt"
 
 	"github.com/spf13/cobra"
 )
@@ -78,12 +76,7 @@ func init() {
 
 func printSettings(settings models.WorkplaceSettings, jsonFlag bool) {
 	if jsonFlag {
-		resp, err := json.Marshal(settings)
-		if err != nil {
-			utils.Err(err)
-		}
-
-		fmt.Println(string(resp))
+		utils.PrintJSON(settings)
 		return
 	}
 

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -66,11 +66,9 @@ var settingsUpdateCmd = &cobra.Command{
 func init() {
 	settingsUpdateCmd.Flags().String("name", "", "set the workplace's name")
 	settingsUpdateCmd.Flags().String("email", "", "set the workplace's billing email")
-	settingsUpdateCmd.Flags().Bool("json", false, "output json")
 	settingsUpdateCmd.Flags().Bool("silent", false, "don't output the response")
 	settingsCmd.AddCommand(settingsUpdateCmd)
 
-	settingsCmd.Flags().Bool("json", false, "output json")
 	rootCmd.AddCommand(settingsCmd)
 }
 

--- a/cmd/settings.go
+++ b/cmd/settings.go
@@ -29,7 +29,7 @@ var settingsCmd = &cobra.Command{
 	Use:   "settings",
 	Short: "Get workplace settings",
 	Run: func(cmd *cobra.Command, args []string) {
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 
 		localConfig := configuration.LocalConfig(cmd)
 		_, info := api.GetAPIWorkplaceSettings(cmd, localConfig.Key.Value)
@@ -49,7 +49,7 @@ var settingsUpdateCmd = &cobra.Command{
 			dopplerErrors.CommandMissingFlag(cmd)
 		}
 
-		jsonFlag := utils.GetBoolFlag(cmd, "json")
+		jsonFlag := utils.JSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 
 		settings := models.WorkplaceSettings{Name: name, BillingEmail: email}

--- a/cmd/setup.go
+++ b/cmd/setup.go
@@ -1,0 +1,97 @@
+/*
+Copyright © 2019 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	api "doppler-cli/api"
+	configuration "doppler-cli/config"
+	"doppler-cli/utils"
+	"strings"
+
+	"github.com/AlecAivazis/survey"
+	"github.com/spf13/cobra"
+)
+
+var setupCmd = &cobra.Command{
+	Use:   "setup",
+	Short: "Setup the doppler cli",
+	Run: func(cmd *cobra.Command, args []string) {
+		silent := utils.GetBoolFlag(cmd, "silent")
+		scope := cmd.Flag("scope").Value.String()
+		localConfig := configuration.LocalConfig(cmd)
+		_, projects := api.GetAPIProjects(cmd, localConfig.Key.Value)
+
+		project := ""
+		if cmd.Flags().Changed("project") {
+			project = localConfig.Project.Value
+		} else {
+			var projectOptions []string
+			for _, val := range projects {
+				projectOptions = append(projectOptions, val.Name+" ("+val.ID+")")
+			}
+			prompt := &survey.Select{
+				Message: "Select a project:",
+				Options: projectOptions,
+			}
+			err := survey.AskOne(prompt, &project)
+			if err != nil {
+				utils.Err(err, "")
+			}
+
+			for _, val := range projects {
+				if strings.HasSuffix(project, "("+val.ID+")") {
+					project = val.ID
+					break
+				}
+			}
+		}
+
+		config := ""
+		if cmd.Flags().Changed("config") {
+			config = localConfig.Config.Value
+		} else {
+			_, configs := api.GetAPIConfigs(cmd, localConfig.Key.Value, project)
+
+			var configOptions []string
+			for _, val := range configs {
+				configOptions = append(configOptions, val.Name)
+			}
+			prompt := &survey.Select{
+				Message: "Select a config:",
+				Options: configOptions,
+			}
+			err := survey.AskOne(prompt, &config)
+			if err != nil {
+				utils.Err(err, "")
+			}
+		}
+
+		configuration.Set(scope, map[string]string{"project": project, "config": config})
+		if !silent {
+			// don't fetch the LocalConfig since we don't care about env variables or cmd flags
+			conf := configuration.Get(scope)
+			rows := [][]string{{"key", conf.Key.Value, conf.Key.Scope}, {"project", conf.Project.Value, conf.Project.Scope}, {"config", conf.Config.Value, conf.Config.Scope}}
+			utils.PrintTable([]string{"name", "value", "scope"}, rows)
+		}
+	},
+}
+
+func init() {
+	setupCmd.Flags().String("project", "", "doppler project (e.g. backend)")
+	setupCmd.Flags().String("config", "", "doppler config (e.g. dev)")
+	setupCmd.Flags().Bool("silent", false, "don't output the response")
+	rootCmd.AddCommand(setupCmd)
+}

--- a/config/config.go
+++ b/config/config.go
@@ -116,7 +116,7 @@ func LocalConfig(cmd *cobra.Command) ScopedConfig {
 	localConfig := Get(cmd.Flag("scope").Value.String())
 
 	// environment variables
-	if utils.GetBoolFlag(cmd, "enable-env") {
+	if !utils.GetBoolFlag(cmd, "no-read-env") {
 		key := os.Getenv("DOPPLER_API_KEY")
 		if key != "" {
 			localConfig.Key.Value = key

--- a/config/config.go
+++ b/config/config.go
@@ -68,7 +68,7 @@ func init() {
 func Get(scope string) ScopedConfig {
 	scope, err := parseScope(scope)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 	scope = path.Join(scope, "/")
 	var scopedConfig ScopedConfig
@@ -166,7 +166,7 @@ func Set(scope string, options []string) {
 		var err error
 		scope, err = parseScope(scope)
 		if err != nil {
-			utils.Err(err)
+			utils.Err(err, "")
 		}
 	}
 
@@ -174,7 +174,7 @@ func Set(scope string, options []string) {
 		optionArr := strings.Split(option, "=")
 		key := optionArr[0]
 		if len(optionArr) < 2 || (key != "key" && key != "project" && key != "config") {
-			utils.Err(errors.New("invalid option " + option))
+			utils.Err(errors.New("invalid option "+option), "")
 		}
 	}
 
@@ -209,13 +209,13 @@ func Unset(scope string, options []string) {
 		var err error
 		scope, err = parseScope(scope)
 		if err != nil {
-			utils.Err(err)
+			utils.Err(err, "")
 		}
 	}
 
 	for _, key := range options {
 		if key != "key" && key != "project" && key != "config" {
-			utils.Err(errors.New("invalid option " + key))
+			utils.Err(errors.New("invalid option "+key), "")
 		}
 	}
 
@@ -252,12 +252,12 @@ func Unset(scope string, options []string) {
 func writeYAML(config map[string]Config) {
 	bytes, err := yaml.Marshal(config)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	err = ioutil.WriteFile(yamlFile, bytes, os.FileMode(0600))
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 }
 
@@ -268,7 +268,7 @@ func exists() bool {
 func readYAML() map[string]Config {
 	fileContents, err := ioutil.ReadFile(yamlFile)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	var config map[string]Config

--- a/config/config.go
+++ b/config/config.go
@@ -161,7 +161,7 @@ func AllConfigs() map[string]Config {
 }
 
 // Set a local config
-func Set(scope string, options []string) {
+func Set(scope string, options map[string]string) {
 	if scope != "*" {
 		var err error
 		scope, err = parseScope(scope)
@@ -170,33 +170,21 @@ func Set(scope string, options []string) {
 		}
 	}
 
-	for _, option := range options {
-		optionArr := strings.Split(option, "=")
-		key := optionArr[0]
-		if len(optionArr) < 2 || (key != "key" && key != "project" && key != "config") {
-			utils.Err(errors.New("invalid option "+option), "")
-		}
-	}
-
-	for _, option := range options {
-		optionArr := strings.Split(option, "=")
-		key := optionArr[0]
-		value := optionArr[1]
-
+	for key, value := range options {
 		if key == "key" {
 			scopedConfig := configContents[scope]
 			scopedConfig.Key = value
 			configContents[scope] = scopedConfig
-		}
-		if key == "project" {
+		} else if key == "project" {
 			scopedConfig := configContents[scope]
 			scopedConfig.Project = value
 			configContents[scope] = scopedConfig
-		}
-		if key == "config" {
+		} else if key == "config" {
 			scopedConfig := configContents[scope]
 			scopedConfig.Config = value
 			configContents[scope] = scopedConfig
+		} else {
+			utils.Err(errors.New("invalid option "+key), "")
 		}
 	}
 
@@ -213,12 +201,6 @@ func Unset(scope string, options []string) {
 		}
 	}
 
-	for _, key := range options {
-		if key != "key" && key != "project" && key != "config" {
-			utils.Err(errors.New("invalid option "+key), "")
-		}
-	}
-
 	if configContents[scope] == (Config{}) {
 		return
 	}
@@ -228,16 +210,16 @@ func Unset(scope string, options []string) {
 			scopedConfig := configContents[scope]
 			scopedConfig.Key = ""
 			configContents[scope] = scopedConfig
-		}
-		if key == "project" {
+		} else if key == "project" {
 			scopedConfig := configContents[scope]
 			scopedConfig.Project = ""
 			configContents[scope] = scopedConfig
-		}
-		if key == "config" {
+		} else if key == "config" {
 			scopedConfig := configContents[scope]
 			scopedConfig.Config = ""
 			configContents[scope] = scopedConfig
+		} else {
+			utils.Err(errors.New("invalid option "+key), "")
 		}
 	}
 

--- a/config/migration.go
+++ b/config/migration.go
@@ -53,13 +53,13 @@ func convertOldConfig(oldConfig map[string]oldConfig) map[string]Config {
 func parseJSONConfig() map[string]oldConfig {
 	fileContents, err := ioutil.ReadFile(jsonFile)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	var config map[string]oldConfig
 	err = json.Unmarshal(fileContents, &config)
 	if err != nil {
-		utils.Err(err)
+		utils.Err(err, "")
 	}
 
 	return config

--- a/errors/cmd.go
+++ b/errors/cmd.go
@@ -16,31 +16,35 @@ limitations under the License.
 package errors
 
 import (
-	"fmt"
+	"doppler-cli/utils"
 	"os"
 
 	"github.com/spf13/cobra"
 )
 
+// CommandMissingArgument command missing an argument
 func CommandMissingArgument(cmd *cobra.Command) {
-	fmt.Println("Error: command needs an argument")
+	utils.Log("Error: command needs an argument")
 	cmd.Help()
 	os.Exit(1)
 }
 
-func CommandMissingSubcommand(cmd *cobra.Command) { 
+// CommandMissingSubcommand command missing a subcommand
+func CommandMissingSubcommand(cmd *cobra.Command) {
 	cmd.Help()
 	os.Exit(1)
 }
 
+// CommandMissingFlag command missing a flag
 func CommandMissingFlag(cmd *cobra.Command) {
-	fmt.Println("Error: command needs a flag")
+	utils.Log("Error: command needs a flag")
 	cmd.Help()
 	os.Exit(1)
 }
 
+// ApplicationMissingCommand application missing a command
 func ApplicationMissingCommand(cmd *cobra.Command) {
-	fmt.Println("Error: application needs a command")
+	utils.Log("Error: application needs a command")
 	cmd.Help()
 	os.Exit(1)
 }

--- a/utils/http.go
+++ b/utils/http.go
@@ -39,7 +39,7 @@ type errorResponse struct {
 
 // GetRequest perform HTTP GET
 func GetRequest(host string, uri string, params []QueryParam, apiKey string) ([]byte, error) {
-	url := fmt.Sprintf("%s/%s", host, uri)
+	url := fmt.Sprintf("%s%s", host, uri)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
 		return nil, err
@@ -95,7 +95,7 @@ func GetRequest(host string, uri string, params []QueryParam, apiKey string) ([]
 
 // PostRequest perform HTTP POST
 func PostRequest(host string, uri string, params []QueryParam, apiKey string, body []byte) ([]byte, error) {
-	url := fmt.Sprintf("%s/%s", host, uri)
+	url := fmt.Sprintf("%s%s", host, uri)
 	req, err := http.NewRequest("POST", url, bytes.NewReader(body))
 	if err != nil {
 		return nil, err
@@ -150,7 +150,7 @@ func PostRequest(host string, uri string, params []QueryParam, apiKey string, bo
 
 // DeleteRequest perform HTTP DELETE
 func DeleteRequest(host string, uri string, params []QueryParam, apiKey string) ([]byte, error) {
-	url := fmt.Sprintf("%s/%s", host, uri)
+	url := fmt.Sprintf("%s%s", host, uri)
 	req, err := http.NewRequest("DELETE", url, nil)
 	if err != nil {
 		return nil, err

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
+	"runtime/debug"
 )
 
 // Debug whether we're running in debug mode
@@ -46,11 +47,13 @@ func Err(e error, message string) {
 		if message != "" {
 			fmt.Println(message)
 		}
+
 		fmt.Println("Error:", e)
 	}
 
 	if Debug {
-		panic(e)
+		fmt.Println("")
+		debug.PrintStack()
 	}
 
 	os.Exit(1)

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -16,6 +16,7 @@ limitations under the License.
 package utils
 
 import (
+	"encoding/json"
 	"fmt"
 	"os"
 )
@@ -23,8 +24,28 @@ import (
 
 // JSON whether to print JSON
 var JSON = false
+
+// Log info
+func Log(info string) {
+	if !JSON {
+		fmt.Println(info)
+	}
+}
+
 // Err prints the error and exits
-func Err(e error) {
-	fmt.Println("Error:", e)
+func Err(e error, message string) {
+	if JSON {
+		resp, err := json.Marshal(map[string]string{"error": e.Error()})
+		if err != nil {
+			panic(err)
+		}
+		fmt.Println(string(resp))
+	} else {
+		if message != "" {
+			fmt.Println(message)
+		}
+		fmt.Println("Error:", e)
+	}
+
 	os.Exit(1)
 }

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -21,6 +21,8 @@ import (
 	"os"
 )
 
+// Debug whether we're running in debug mode
+var Debug = false
 
 // JSON whether to print JSON
 var JSON = false
@@ -45,6 +47,10 @@ func Err(e error, message string) {
 			fmt.Println(message)
 		}
 		fmt.Println("Error:", e)
+	}
+
+	if Debug {
+		panic(e)
 	}
 
 	os.Exit(1)

--- a/utils/logger.go
+++ b/utils/logger.go
@@ -20,6 +20,9 @@ import (
 	"os"
 )
 
+
+// JSON whether to print JSON
+var JSON = false
 // Err prints the error and exits
 func Err(e error) {
 	fmt.Println("Error:", e)

--- a/utils/print.go
+++ b/utils/print.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"math"
 	"os"
+	"sort"
+	"strings"
 	"time"
 
 	"github.com/jedib0t/go-pretty/table"
@@ -89,4 +91,162 @@ func PrintJSON(structure interface{}) {
 	}
 
 	fmt.Println(string(resp))
+}
+
+// PrintConfigInfo print config
+func PrintConfigInfo(info models.ConfigInfo, jsonFlag bool) {
+	if jsonFlag {
+		PrintJSON(info)
+		return
+	}
+
+	rows := [][]string{{info.Name, strings.Join(info.MissingVariables, ", "), info.DeployedAt, info.CreatedAt, info.Environment, info.Project}}
+	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows)
+}
+
+// PrintConfigsInfo print configs
+func PrintConfigsInfo(info []models.ConfigInfo, jsonFlag bool) {
+	if jsonFlag {
+		PrintJSON(info)
+		return
+	}
+
+	var rows [][]string
+	for _, configInfo := range info {
+		rows = append(rows, []string{configInfo.Name, strings.Join(configInfo.MissingVariables, ", "), configInfo.DeployedAt, configInfo.CreatedAt, configInfo.Environment, configInfo.Project})
+	}
+	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows)
+}
+
+// PrintEnvironmentsInfo print environments
+func PrintEnvironmentsInfo(info []models.EnvironmentInfo, jsonFlag bool) {
+	if jsonFlag {
+		PrintJSON(info)
+		return
+	}
+
+	var rows [][]string
+	for _, environmentInfo := range info {
+		rows = append(rows, []string{environmentInfo.ID, environmentInfo.Name, environmentInfo.SetupAt, environmentInfo.FirstDeployAt, environmentInfo.CreatedAt, strings.Join(environmentInfo.MissingVariables, ", "), environmentInfo.Project})
+	}
+	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows)
+}
+
+// PrintEnvironmentInfo print environment
+func PrintEnvironmentInfo(info models.EnvironmentInfo, jsonFlag bool) {
+	if jsonFlag {
+		PrintJSON(info)
+		return
+	}
+
+	rows := [][]string{{info.ID, info.Name, info.SetupAt, info.FirstDeployAt, info.CreatedAt, strings.Join(info.MissingVariables, ", "), info.Project}}
+	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows)
+}
+
+// PrintProjectsInfo print projects info
+// highest availability secrets storage on the planet
+func PrintProjectsInfo(info []models.ProjectInfo, jsonFlag bool) {
+	if jsonFlag {
+		PrintJSON(info)
+		return
+	}
+
+	var rows [][]string
+	for _, projectInfo := range info {
+		rows = append(rows, []string{projectInfo.ID, projectInfo.Name, projectInfo.Description, projectInfo.SetupAt, projectInfo.CreatedAt})
+	}
+	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows)
+}
+
+// PrintProjectInfo print project info
+func PrintProjectInfo(info models.ProjectInfo, jsonFlag bool) {
+	if jsonFlag {
+		PrintJSON(info)
+		return
+	}
+
+	rows := [][]string{{info.ID, info.Name, info.Description, info.SetupAt, info.CreatedAt}}
+	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows)
+}
+
+// PrintSecrets print secrets
+func PrintSecrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, jsonFlag bool, plain bool, raw bool) {
+	if len(secretsToPrint) == 0 {
+		for name := range secrets {
+			secretsToPrint = append(secretsToPrint, name)
+		}
+		sort.Strings(secretsToPrint)
+	}
+
+	if jsonFlag {
+		secretsMap := make(map[string]map[string]string)
+		for _, name := range secretsToPrint {
+			if secrets[name] != (models.ComputedSecret{}) {
+				secretsMap[name] = make(map[string]string)
+				secretsMap[name]["computed"] = secrets[name].ComputedValue
+				if raw {
+					secretsMap[name]["raw"] = secrets[name].RawValue
+				}
+			}
+		}
+
+		PrintJSON(secretsMap)
+		return
+	}
+
+	var matchedSecrets []models.ComputedSecret
+	for _, name := range secretsToPrint {
+		if secrets[name] != (models.ComputedSecret{}) {
+			matchedSecrets = append(matchedSecrets, secrets[name])
+		}
+	}
+
+	if plain {
+		sbEmpty := true
+		var sb strings.Builder
+		for _, secret := range matchedSecrets {
+			if sbEmpty {
+				sbEmpty = false
+			} else {
+				sb.WriteString("\n")
+			}
+
+			if raw {
+				sb.WriteString(strings.ReplaceAll(secret.RawValue, `\r\n`, `\n`))
+			} else {
+				sb.WriteString(secret.ComputedValue)
+			}
+		}
+
+		fmt.Println(sb.String())
+		return
+	}
+
+	headers := []string{"name", "value"}
+	if raw {
+		headers = append(headers, "raw")
+	}
+
+	var rows [][]string
+	for _, secret := range matchedSecrets {
+		row := []string{secret.Name, secret.ComputedValue}
+		if raw {
+			row = append(row, strings.ReplaceAll(secret.RawValue, `\r\n`, `\n`))
+		}
+
+		rows = append(rows, row)
+	}
+
+	PrintTable(headers, rows)
+}
+
+// PrintSettings print settings
+func PrintSettings(settings models.WorkplaceSettings, jsonFlag bool) {
+	if jsonFlag {
+		PrintJSON(settings)
+		return
+	}
+
+	rows := [][]string{{settings.ID, settings.Name, settings.BillingEmail}}
+	PrintTable([]string{"id", "name", "billing_email"}, rows)
 }

--- a/utils/print.go
+++ b/utils/print.go
@@ -42,12 +42,7 @@ func PrintLogs(logs []models.Log, number int, jsonFlag bool) {
 	maxLogs := int(math.Min(float64(len(logs)), float64(number)))
 
 	if jsonFlag {
-		resp, err := json.Marshal(logs[0:maxLogs])
-		if err != nil {
-			Err(err)
-		}
-
-		fmt.Println(string(resp))
+		PrintJSON(logs[0:maxLogs])
 		return
 	}
 
@@ -59,12 +54,7 @@ func PrintLogs(logs []models.Log, number int, jsonFlag bool) {
 // PrintLog print log
 func PrintLog(log models.Log, jsonFlag bool) {
 	if jsonFlag {
-		resp, err := json.Marshal(log)
-		if err != nil {
-			Err(err)
-		}
-
-		fmt.Println(string(resp))
+		PrintJSON(log)
 		return
 	}
 
@@ -78,4 +68,14 @@ func PrintLog(log models.Log, jsonFlag bool) {
 	fmt.Println("")
 	fmt.Println("\t" + log.Text)
 	fmt.Println("")
+}
+
+// PrintJSON print object as json
+func PrintJSON(structure interface{}) {
+	resp, err := json.Marshal(structure)
+	if err != nil {
+		Err(err, "")
+	}
+
+	fmt.Println(string(resp))
 }

--- a/utils/print.go
+++ b/utils/print.go
@@ -23,18 +23,29 @@ import (
 	"os"
 	"time"
 
-	"github.com/olekukonko/tablewriter"
+	"github.com/jedib0t/go-pretty/table"
 )
 
 // PrintTable prints table
 func PrintTable(headers []string, rows [][]string) {
-	// TODO doesn't handle multi line secrets well
-	table := tablewriter.NewWriter(os.Stdout)
+	t := table.NewWriter()
+	t.SetOutputMirror(os.Stdout)
 
-	table.SetHeader(headers)
-	table.AppendBulk(rows)
+	tableHeaders := table.Row{}
+	for _, header := range headers {
+		tableHeaders = append(tableHeaders, header)
+	}
+	t.AppendHeader(tableHeaders)
 
-	table.Render()
+	for _, row := range rows {
+		tableRow := table.Row{}
+		for _, val := range row {
+			tableRow = append(tableRow, val)
+		}
+		t.AppendRow(tableRow)
+	}
+
+	t.Render()
 }
 
 // PrintLogs print logs

--- a/utils/util.go
+++ b/utils/util.go
@@ -89,11 +89,11 @@ func RunCommand(command []string, env []string, output bool) error {
 
 // GetBoolFlag get flag parsed as a boolean
 func GetBoolFlag(cmd *cobra.Command, flag string) bool {
-	jsonFlag, err := strconv.ParseBool(cmd.Flag(flag).Value.String())
+	value, err := strconv.ParseBool(cmd.Flag(flag).Value.String())
 	if err != nil {
 		Err(err, "")
 	}
-	return jsonFlag
+	return value
 }
 
 // GetIntFlag get flag parsed as an int

--- a/utils/util.go
+++ b/utils/util.go
@@ -33,8 +33,7 @@ import (
 func Home() string {
 	home, err := homedir.Dir()
 	if err != nil {
-		fmt.Println(err)
-		os.Exit(1)
+		Err(err, "")
 	}
 
 	return home
@@ -52,7 +51,7 @@ func Exists(path string) bool {
 func Cwd() string {
 	cwd, err := os.Executable()
 	if err != nil {
-		Err(err)
+		Err(err, "")
 	}
 	return path.Dir(cwd)
 }
@@ -67,8 +66,7 @@ func RunCommand(command []string, env []string, output bool) error {
 
 	err := cmd.Start()
 	if err != nil {
-		fmt.Println(fmt.Sprintf("Error trying to execute command: %s", command))
-		Err(err)
+		Err(err, fmt.Sprintf("Error trying to execute command: %s", command))
 		return err
 	}
 
@@ -93,7 +91,7 @@ func RunCommand(command []string, env []string, output bool) error {
 func GetBoolFlag(cmd *cobra.Command, flag string) bool {
 	jsonFlag, err := strconv.ParseBool(cmd.Flag(flag).Value.String())
 	if err != nil {
-		Err(err)
+		Err(err, "")
 	}
 	return jsonFlag
 }
@@ -102,7 +100,7 @@ func GetBoolFlag(cmd *cobra.Command, flag string) bool {
 func GetIntFlag(cmd *cobra.Command, flag string, bits int) int {
 	number, err := strconv.ParseInt(cmd.Flag(flag).Value.String(), 10, bits)
 	if err != nil {
-		Err(err)
+		Err(err, "")
 	}
 
 	return int(number)


### PR DESCRIPTION
  - Implement setup command
   - Consolidate print functions in print.go
   - Rename enable-env flag to no-read-env
   - Don't double-print the error when in debug mode
   - Swap table library to improve multi-line text support
   - Move argument parsing out of config
   - Add debug flag to print more info when encountering errors
  -  Don't re-parse value
 -   Consolidate logging logic
-    Make JSON a global flag
-  Move printing json to separate function
