### PR TITLE
Make current config one option in the config yaml

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -213,7 +213,7 @@ func init() {
 	rootCmd.AddCommand(configureCmd)
 }
 
-func printScopedConfigArgs(conf models.ScopedConfig, args []string) {
+func printScopedConfigArgs(conf models.ScopedOptions, args []string) {
 	var rows [][]string
 	for _, arg := range args {
 		if configuration.IsValidConfigOption(arg) {

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -100,7 +100,7 @@ var loginCmd = &cobra.Command{
 		token := response["token"].(string)
 		name := response["name"].(string)
 		dashboard := response["dashboard_url"].(string)
-		configuration.SetFromConfig(scope, models.Config{Token: token, APIHost: localConfig.APIHost.Value,
+		configuration.SetFromConfig(scope, models.FileScopedOptions{Token: token, APIHost: localConfig.APIHost.Value,
 			DashboardHost: dashboard, VerifyTLS: localConfig.VerifyTLS.Value})
 
 		if !silent {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -79,7 +79,7 @@ doppler run --key=123 -- printenv`,
 	},
 }
 
-func getSecrets(cmd *cobra.Command, localConfig models.ScopedConfig, fallbackPath string, fallbackReadonly bool, fallbackOnly bool) map[string]string {
+func getSecrets(cmd *cobra.Command, localConfig models.ScopedOptions, fallbackPath string, fallbackReadonly bool, fallbackOnly bool) map[string]string {
 	useFallbackFile := (fallbackPath != "")
 	if useFallbackFile && fallbackOnly {
 		return readFallbackFile(fallbackPath)

--- a/pkg/configuration/migration.go
+++ b/pkg/configuration/migration.go
@@ -43,14 +43,14 @@ func migrateJSONToYaml() {
 	writeYAML(newConfig)
 }
 
-func convertOldConfig(oldConfig map[string]oldConfig) map[string]models.Config {
-	config := map[string]models.Config{}
+func convertOldConfig(oldConfig map[string]oldConfig) models.ConfigFile {
+	config := map[string]models.FileScopedOptions{}
 
 	for key, val := range oldConfig {
-		config[key] = models.Config{Project: val.Pipeline, Config: val.Environment, Token: val.Key}
+		config[key] = models.FileScopedOptions{Project: val.Pipeline, Config: val.Environment, Token: val.Key}
 	}
 
-	return config
+	return models.ConfigFile{ScopedOptions: config}
 }
 
 func parseJSONConfig() map[string]oldConfig {

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -15,8 +15,13 @@ limitations under the License.
 */
 package models
 
-// Config options
-type Config struct {
+// ConfigFile structure of the config file
+type ConfigFile struct {
+	ScopedOptions map[string]FileScopedOptions `yaml:"scoped"`
+}
+
+// FileScopedOptions config options
+type FileScopedOptions struct {
 	Token         string `json:"token"`
 	Project       string `json:"project"`
 	Config        string `json:"config"`
@@ -25,18 +30,18 @@ type Config struct {
 	VerifyTLS     string `json:"verify-tls"`
 }
 
-// ScopedConfig options with their scope
-type ScopedConfig struct {
-	Token         Pair `json:"token"`
-	Project       Pair `json:"project"`
-	Config        Pair `json:"config"`
-	APIHost       Pair `json:"api-host"`
-	DashboardHost Pair `json:"dashboard-host"`
-	VerifyTLS     Pair `json:"verify-tls"`
+// ScopedOptions options with their scope
+type ScopedOptions struct {
+	Token         ScopedOption `json:"token"`
+	Project       ScopedOption `json:"project"`
+	Config        ScopedOption `json:"config"`
+	APIHost       ScopedOption `json:"api-host"`
+	DashboardHost ScopedOption `json:"dashboard-host"`
+	VerifyTLS     ScopedOption `json:"verify-tls"`
 }
 
-// Pair value and its scope
-type Pair struct {
+// ScopedOption value and its scope
+type ScopedOption struct {
 	Value  string `json:"value"`
 	Scope  string `json:"scope"`
 	Source string `json:"source"`
@@ -45,6 +50,7 @@ type Pair struct {
 // Source where the value came from
 type Source int
 
+// the source of the value
 const (
 	FlagSource Source = iota
 	ConfigFileSource
@@ -57,7 +63,7 @@ func (s Source) String() string {
 }
 
 // Pairs get the pairs for the given config
-func Pairs(conf Config) map[string]string {
+func Pairs(conf FileScopedOptions) map[string]string {
 	return map[string]string{
 		"token":          conf.Token,
 		"project":        conf.Project,
@@ -69,8 +75,8 @@ func Pairs(conf Config) map[string]string {
 }
 
 // ScopedPairs get the pairs for the given scoped config
-func ScopedPairs(conf *ScopedConfig) map[string]*Pair {
-	return map[string]*Pair{
+func ScopedPairs(conf *ScopedOptions) map[string]*ScopedOption {
+	return map[string]*ScopedOption{
 		"token":          &conf.Token,
 		"project":        &conf.Project,
 		"config":         &conf.Config,
@@ -81,8 +87,8 @@ func ScopedPairs(conf *ScopedConfig) map[string]*Pair {
 }
 
 // EnvPairs get the scoped config pairs for each environment variable
-func EnvPairs(conf *ScopedConfig) map[string]*Pair {
-	return map[string]*Pair{
+func EnvPairs(conf *ScopedOptions) map[string]*ScopedOption {
+	return map[string]*ScopedOption{
 		"DOPPLER_TOKEN":          &conf.Token,
 		"DOPPLER_PROJECT":        &conf.Project,
 		"DOPPLER_CONFIG":         &conf.Config,

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -22,22 +22,22 @@ type ConfigFile struct {
 
 // FileScopedOptions config options
 type FileScopedOptions struct {
-	Token         string `json:"token,omitempty"`
-	Project       string `json:"project,omitempty"`
-	Config        string `json:"config,omitempty"`
-	APIHost       string `json:"api-host,omitempty"`
-	DashboardHost string `json:"dashboard-host,omitempty"`
-	VerifyTLS     string `json:"verify-tls,omitempty"`
+	Token         string `json:"token,omitempty" yaml:"token,omitempty"`
+	Project       string `json:"project,omitempty" yaml:"project,omitempty"`
+	Config        string `json:"config,omitempty" yaml:"config,omitempty"`
+	APIHost       string `json:"api-host,omitempty" yaml:"api-host,omitempty"`
+	DashboardHost string `json:"dashboard-host,omitempty" yaml:"dashboard-host,omitempty"`
+	VerifyTLS     string `json:"verify-tls,omitempty" yaml:"verify-tls,omitempty"`
 }
 
 // ScopedOptions options with their scope
 type ScopedOptions struct {
-	Token         ScopedOption `json:"token,omitempty"`
-	Project       ScopedOption `json:"project,omitempty"`
-	Config        ScopedOption `json:"config,omitempty"`
-	APIHost       ScopedOption `json:"api-host,omitempty"`
-	DashboardHost ScopedOption `json:"dashboard-host,omitempty"`
-	VerifyTLS     ScopedOption `json:"verify-tls,omitempty"`
+	Token         ScopedOption `json:"token,omitempty" yaml:"token,omitempty"`
+	Project       ScopedOption `json:"project,omitempty" yaml:"project,omitempty"`
+	Config        ScopedOption `json:"config,omitempty" yaml:"config,omitempty"`
+	APIHost       ScopedOption `json:"api-host,omitempty" yaml:"api-host,omitempty"`
+	DashboardHost ScopedOption `json:"dashboard-host,omitempty" yaml:"dashboard-host,omitempty"`
+	VerifyTLS     ScopedOption `json:"verify-tls,omitempty" yaml:"verify-tls,omitempty"`
 }
 
 // ScopedOption value and its scope

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -22,22 +22,22 @@ type ConfigFile struct {
 
 // FileScopedOptions config options
 type FileScopedOptions struct {
-	Token         string `json:"token"`
-	Project       string `json:"project"`
-	Config        string `json:"config"`
-	APIHost       string `json:"api-host"`
-	DashboardHost string `json:"dashboard-host"`
-	VerifyTLS     string `json:"verify-tls"`
+	Token         string `json:"token,omitempty"`
+	Project       string `json:"project,omitempty"`
+	Config        string `json:"config,omitempty"`
+	APIHost       string `json:"api-host,omitempty"`
+	DashboardHost string `json:"dashboard-host,omitempty"`
+	VerifyTLS     string `json:"verify-tls,omitempty"`
 }
 
 // ScopedOptions options with their scope
 type ScopedOptions struct {
-	Token         ScopedOption `json:"token"`
-	Project       ScopedOption `json:"project"`
-	Config        ScopedOption `json:"config"`
-	APIHost       ScopedOption `json:"api-host"`
-	DashboardHost ScopedOption `json:"dashboard-host"`
-	VerifyTLS     ScopedOption `json:"verify-tls"`
+	Token         ScopedOption `json:"token,omitempty"`
+	Project       ScopedOption `json:"project,omitempty"`
+	Config        ScopedOption `json:"config,omitempty"`
+	APIHost       ScopedOption `json:"api-host,omitempty"`
+	DashboardHost ScopedOption `json:"dashboard-host,omitempty"`
+	VerifyTLS     ScopedOption `json:"verify-tls,omitempty"`
 }
 
 // ScopedOption value and its scope

--- a/pkg/utils/print.go
+++ b/pkg/utils/print.go
@@ -298,14 +298,14 @@ func PrintSettings(settings models.WorkplaceSettings, jsonFlag bool) {
 }
 
 // PrintScopedConfig print scoped config
-func PrintScopedConfig(conf models.ScopedConfig, jsonFlag bool) {
+func PrintScopedConfig(conf models.ScopedOptions, jsonFlag bool) {
 	pairs := models.ScopedPairs(&conf)
 
 	if jsonFlag {
 		confMap := map[string]map[string]string{}
 
 		for name, pair := range pairs {
-			if *pair != (models.Pair{}) {
+			if *pair != (models.ScopedOption{}) {
 				scope := pair.Scope
 				value := pair.Value
 
@@ -323,7 +323,7 @@ func PrintScopedConfig(conf models.ScopedConfig, jsonFlag bool) {
 	var rows [][]string
 
 	for name, pair := range pairs {
-		if *pair != (models.Pair{}) {
+		if *pair != (models.ScopedOption{}) {
 			rows = append(rows, []string{name, pair.Value, pair.Scope})
 		}
 	}
@@ -336,7 +336,7 @@ func PrintScopedConfig(conf models.ScopedConfig, jsonFlag bool) {
 }
 
 // PrintConfigs print configs
-func PrintConfigs(configs map[string]models.Config, jsonFlag bool) {
+func PrintConfigs(configs map[string]models.FileScopedOptions, jsonFlag bool) {
 	if jsonFlag {
 		PrintJSON(configs)
 		return


### PR DESCRIPTION
This allows us to add other config options that live outside the normal scoping (like user name).

Prev YAML:

```yaml
'*':
    token: 1234567890
/Users/thomas/Documents/projects:
    project: "myproject"
    config: "myconfig"
    apihost: "https://example.com"
```

New YAML:

```yaml
scoped:
    '*':
        token: 1234567890
    /Users/thomas/Documents/projects:
        project: "myproject"
        config: "myconfig"
        apihost: "https://example.com"
```
