### PR TITLE
Add "configure debug" command to view the active configuration

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -28,7 +28,7 @@ import (
 
 var configureCmd = &cobra.Command{
 	Use:   "configure",
-	Short: "View cli configuration",
+	Short: "View the config file",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		all := utils.GetBoolFlag(cmd, "all")
@@ -46,10 +46,27 @@ var configureCmd = &cobra.Command{
 	},
 }
 
+var configureDebugCmd = &cobra.Command{
+	Use:   "debug",
+	Short: "View active configuration utilizing all config sources",
+	Long: `View active configuration utilizing all config sources.
+
+This prints the active configuration that will be used by other CLI commands.
+This factors in command line flags (--token=123), environment variables (DOPPLER_TOKEN=123),
+and the config file (in order from highest to lowest precedence)`,
+	Args: cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonFlag := utils.JSON
+
+		config := configuration.LocalConfig(cmd)
+		utils.PrintScopedConfigSource(config, jsonFlag, true)
+	},
+}
+
 var configureGetCmd = &cobra.Command{
 	Use:   "get [options]",
-	Short: "Get the value of one or more config options",
-	Long: `Get the value of one or more config options.
+	Short: "Get the value of one or more options in the config file",
+	Long: `Get the value of one or more options in the config file.
 
 Ex: output the options "key" and "otherkey":
 doppler configure get key otherkey`,
@@ -114,8 +131,8 @@ doppler configure get key otherkey`,
 
 var configureSetCmd = &cobra.Command{
 	Use:   "set [options]",
-	Short: "Set the value of one or more config options",
-	Long: `Set the value of one or more config options.
+	Short: "Set the value of one or more options in the config file",
+	Long: `Set the value of one or more options in the config file.
 
 Ex: set the options "key" and "otherkey":
 doppler configure set key=123 otherkey=456`,
@@ -168,8 +185,8 @@ doppler configure set key=123 otherkey=456`,
 
 var configureUnsetCmd = &cobra.Command{
 	Use:   "unset [options]",
-	Short: "Unset the value of one or more config options",
-	Long: `Unset the value of one or more config options.
+	Short: "Unset the value of one or more options in the config file",
+	Long: `Unset the value of one or more options in the config file.
 
 Ex: unset the options "key" and "otherkey":
 doppler configure unset key otherkey`,
@@ -200,6 +217,8 @@ doppler configure unset key otherkey`,
 }
 
 func init() {
+	configureCmd.AddCommand(configureDebugCmd)
+
 	configureGetCmd.Flags().Bool("plain", false, "print values without formatting. values will be printed in the same order as specified")
 	configureCmd.AddCommand(configureGetCmd)
 

--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -125,7 +125,7 @@ doppler configure get key otherkey`,
 			rows = append(rows, []string{arg, value, scope})
 		}
 
-		utils.PrintTable([]string{"name", "value", "scope"}, rows, "")
+		utils.PrintTable([]string{"name", "value", "scope"}, rows)
 	},
 }
 
@@ -241,5 +241,5 @@ func printScopedConfigArgs(conf models.ScopedOptions, args []string) {
 		}
 	}
 
-	utils.PrintTable([]string{"name", "value", "scope"}, rows, "")
+	utils.PrintTable([]string{"name", "value", "scope"}, rows)
 }

--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -59,7 +59,7 @@ and the config file (in order from highest to lowest precedence)`,
 		jsonFlag := utils.JSON
 
 		config := configuration.LocalConfig(cmd)
-		utils.PrintScopedConfigSource(config, jsonFlag, true)
+		utils.PrintScopedConfigSource(config, "", jsonFlag, true)
 	},
 }
 
@@ -125,7 +125,7 @@ doppler configure get key otherkey`,
 			rows = append(rows, []string{arg, value, scope})
 		}
 
-		utils.PrintTable([]string{"name", "value", "scope"}, rows)
+		utils.PrintTable([]string{"name", "value", "scope"}, rows, "")
 	},
 }
 
@@ -241,5 +241,5 @@ func printScopedConfigArgs(conf models.ScopedOptions, args []string) {
 		}
 	}
 
-	utils.PrintTable([]string{"name", "value", "scope"}, rows)
+	utils.PrintTable([]string{"name", "value", "scope"}, rows, "")
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -28,6 +28,11 @@ var rootCmd = &cobra.Command{
 	Use:   "doppler",
 	Short: "The official Doppler CLI",
 	Args:  cobra.NoArgs,
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		if utils.Debug {
+			utils.PrintScopedConfigSource(configuration.LocalConfig(cmd), "Active configuration", utils.JSON, true)
+		}
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -91,7 +91,7 @@ var setupCmd = &cobra.Command{
 			// don't fetch the LocalConfig since we don't care about env variables or cmd flags
 			conf := configuration.Get(scope)
 			rows := [][]string{{"token", conf.Token.Value, conf.Token.Scope}, {"project", conf.Project.Value, conf.Project.Scope}, {"config", conf.Config.Value, conf.Config.Scope}}
-			utils.PrintTable([]string{"name", "value", "scope"}, rows, "")
+			utils.PrintTable([]string{"name", "value", "scope"}, rows)
 		}
 	},
 }

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -91,7 +91,7 @@ var setupCmd = &cobra.Command{
 			// don't fetch the LocalConfig since we don't care about env variables or cmd flags
 			conf := configuration.Get(scope)
 			rows := [][]string{{"token", conf.Token.Value, conf.Token.Scope}, {"project", conf.Project.Value, conf.Project.Scope}, {"config", conf.Config.Value, conf.Config.Scope}}
-			utils.PrintTable([]string{"name", "value", "scope"}, rows)
+			utils.PrintTable([]string{"name", "value", "scope"}, rows, "")
 		}
 	},
 }

--- a/pkg/utils/print.go
+++ b/pkg/utils/print.go
@@ -299,6 +299,11 @@ func PrintSettings(settings models.WorkplaceSettings, jsonFlag bool) {
 
 // PrintScopedConfig print scoped config
 func PrintScopedConfig(conf models.ScopedOptions, jsonFlag bool) {
+	PrintScopedConfigSource(conf, jsonFlag, false)
+}
+
+// PrintScopedConfigSource print scoped config with source
+func PrintScopedConfigSource(conf models.ScopedOptions, jsonFlag bool, source bool) {
 	pairs := models.ScopedPairs(&conf)
 
 	if jsonFlag {
@@ -324,7 +329,11 @@ func PrintScopedConfig(conf models.ScopedOptions, jsonFlag bool) {
 
 	for name, pair := range pairs {
 		if *pair != (models.ScopedOption{}) {
-			rows = append(rows, []string{name, pair.Value, pair.Scope})
+			row := []string{name, pair.Value, pair.Scope}
+			if source {
+				row = append(row, pair.Source)
+			}
+			rows = append(rows, row)
 		}
 	}
 
@@ -332,7 +341,13 @@ func PrintScopedConfig(conf models.ScopedOptions, jsonFlag bool) {
 	sort.Slice(rows, func(a, b int) bool {
 		return rows[a][0] < rows[b][0]
 	})
-	PrintTable([]string{"name", "value", "scope"}, rows)
+
+	headers := []string{"name", "value", "scope"}
+	if source {
+		headers = append(headers, "source")
+	}
+
+	PrintTable(headers, rows)
 }
 
 // PrintConfigs print configs

--- a/pkg/utils/print.go
+++ b/pkg/utils/print.go
@@ -32,9 +32,13 @@ import (
 const maxTableWidth = 100
 
 // PrintTable prints table
-func PrintTable(headers []string, rows [][]string) {
+func PrintTable(headers []string, rows [][]string, title string) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
+
+	if title != "" {
+		t.SetTitle(title)
+	}
 
 	tableHeaders := table.Row{}
 	for _, header := range headers {
@@ -104,7 +108,7 @@ func PrintConfigInfo(info models.ConfigInfo, jsonFlag bool) {
 	}
 
 	rows := [][]string{{info.Name, strings.Join(info.MissingVariables, ", "), info.DeployedAt, info.CreatedAt, info.Environment, info.Project}}
-	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows)
+	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows, "")
 }
 
 // PrintConfigsInfo print configs
@@ -119,7 +123,7 @@ func PrintConfigsInfo(info []models.ConfigInfo, jsonFlag bool) {
 		rows = append(rows, []string{configInfo.Name, strings.Join(configInfo.MissingVariables, ", "), configInfo.DeployedAt, configInfo.CreatedAt,
 			configInfo.Environment, configInfo.Project})
 	}
-	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows)
+	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows, "")
 }
 
 // PrintEnvironmentsInfo print environments
@@ -134,7 +138,7 @@ func PrintEnvironmentsInfo(info []models.EnvironmentInfo, jsonFlag bool) {
 		rows = append(rows, []string{environmentInfo.ID, environmentInfo.Name, environmentInfo.SetupAt, environmentInfo.FirstDeployAt,
 			environmentInfo.CreatedAt, strings.Join(environmentInfo.MissingVariables, ", "), environmentInfo.Project})
 	}
-	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows)
+	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows, "")
 }
 
 // PrintEnvironmentInfo print environment
@@ -145,7 +149,7 @@ func PrintEnvironmentInfo(info models.EnvironmentInfo, jsonFlag bool) {
 	}
 
 	rows := [][]string{{info.ID, info.Name, info.SetupAt, info.FirstDeployAt, info.CreatedAt, strings.Join(info.MissingVariables, ", "), info.Project}}
-	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows)
+	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows, "")
 }
 
 // PrintProjectsInfo print projects info
@@ -160,7 +164,7 @@ func PrintProjectsInfo(info []models.ProjectInfo, jsonFlag bool) {
 	for _, projectInfo := range info {
 		rows = append(rows, []string{projectInfo.ID, projectInfo.Name, projectInfo.Description, projectInfo.SetupAt, projectInfo.CreatedAt})
 	}
-	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows)
+	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows, "")
 }
 
 // PrintProjectInfo print project info
@@ -171,7 +175,7 @@ func PrintProjectInfo(info models.ProjectInfo, jsonFlag bool) {
 	}
 
 	rows := [][]string{{info.ID, info.Name, info.Description, info.SetupAt, info.CreatedAt}}
-	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows)
+	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows, "")
 }
 
 // PrintSecrets print secrets
@@ -241,7 +245,7 @@ func PrintSecrets(secrets map[string]models.ComputedSecret, secretsToPrint []str
 		rows = append(rows, row)
 	}
 
-	PrintTable(headers, rows)
+	PrintTable(headers, rows, "")
 }
 
 // PrintSecretsNames print secrets
@@ -283,7 +287,7 @@ func PrintSecretsNames(secrets map[string]models.ComputedSecret, jsonFlag bool, 
 	for _, name := range secretsNames {
 		rows = append(rows, []string{name})
 	}
-	PrintTable([]string{"name"}, rows)
+	PrintTable([]string{"name"}, rows, "")
 }
 
 // PrintSettings print settings
@@ -294,16 +298,16 @@ func PrintSettings(settings models.WorkplaceSettings, jsonFlag bool) {
 	}
 
 	rows := [][]string{{settings.ID, settings.Name, settings.BillingEmail}}
-	PrintTable([]string{"id", "name", "billing_email"}, rows)
+	PrintTable([]string{"id", "name", "billing_email"}, rows, "")
 }
 
 // PrintScopedConfig print scoped config
 func PrintScopedConfig(conf models.ScopedOptions, jsonFlag bool) {
-	PrintScopedConfigSource(conf, jsonFlag, false)
+	PrintScopedConfigSource(conf, "", jsonFlag, false)
 }
 
 // PrintScopedConfigSource print scoped config with source
-func PrintScopedConfigSource(conf models.ScopedOptions, jsonFlag bool, source bool) {
+func PrintScopedConfigSource(conf models.ScopedOptions, title string, jsonFlag bool, source bool) {
 	pairs := models.ScopedPairs(&conf)
 
 	if jsonFlag {
@@ -347,7 +351,7 @@ func PrintScopedConfigSource(conf models.ScopedOptions, jsonFlag bool, source bo
 		headers = append(headers, "source")
 	}
 
-	PrintTable(headers, rows)
+	PrintTable(headers, rows, title)
 }
 
 // PrintConfigs print configs
@@ -376,5 +380,5 @@ func PrintConfigs(configs map[string]models.FileScopedOptions, jsonFlag bool) {
 		return rows[a][0] < rows[b][0]
 	})
 
-	PrintTable([]string{"name", "value", "scope"}, rows)
+	PrintTable([]string{"name", "value", "scope"}, rows, "")
 }

--- a/pkg/utils/print.go
+++ b/pkg/utils/print.go
@@ -31,8 +31,13 @@ import (
 
 const maxTableWidth = 100
 
-// PrintTable prints table
-func PrintTable(headers []string, rows [][]string, title string) {
+// PrintTable print table
+func PrintTable(headers []string, rows [][]string) {
+	PrintTableWithTitle(headers, rows, "")
+}
+
+// PrintTableWithTitle print table with a title
+func PrintTableWithTitle(headers []string, rows [][]string, title string) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
 	t.SetStyle(table.StyleLight)
@@ -109,7 +114,7 @@ func PrintConfigInfo(info models.ConfigInfo, jsonFlag bool) {
 	}
 
 	rows := [][]string{{info.Name, strings.Join(info.MissingVariables, ", "), info.DeployedAt, info.CreatedAt, info.Environment, info.Project}}
-	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows, "")
+	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows)
 }
 
 // PrintConfigsInfo print configs
@@ -124,7 +129,7 @@ func PrintConfigsInfo(info []models.ConfigInfo, jsonFlag bool) {
 		rows = append(rows, []string{configInfo.Name, strings.Join(configInfo.MissingVariables, ", "), configInfo.DeployedAt, configInfo.CreatedAt,
 			configInfo.Environment, configInfo.Project})
 	}
-	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows, "")
+	PrintTable([]string{"name", "missing_variables", "deployed_at", "created_at", "stage", "project"}, rows)
 }
 
 // PrintEnvironmentsInfo print environments
@@ -139,7 +144,7 @@ func PrintEnvironmentsInfo(info []models.EnvironmentInfo, jsonFlag bool) {
 		rows = append(rows, []string{environmentInfo.ID, environmentInfo.Name, environmentInfo.SetupAt, environmentInfo.FirstDeployAt,
 			environmentInfo.CreatedAt, strings.Join(environmentInfo.MissingVariables, ", "), environmentInfo.Project})
 	}
-	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows, "")
+	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows)
 }
 
 // PrintEnvironmentInfo print environment
@@ -150,7 +155,7 @@ func PrintEnvironmentInfo(info models.EnvironmentInfo, jsonFlag bool) {
 	}
 
 	rows := [][]string{{info.ID, info.Name, info.SetupAt, info.FirstDeployAt, info.CreatedAt, strings.Join(info.MissingVariables, ", "), info.Project}}
-	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows, "")
+	PrintTable([]string{"id", "name", "setup_at", "first_deploy_at", "created_at", "missing_variables", "project"}, rows)
 }
 
 // PrintProjectsInfo print projects info
@@ -165,7 +170,7 @@ func PrintProjectsInfo(info []models.ProjectInfo, jsonFlag bool) {
 	for _, projectInfo := range info {
 		rows = append(rows, []string{projectInfo.ID, projectInfo.Name, projectInfo.Description, projectInfo.SetupAt, projectInfo.CreatedAt})
 	}
-	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows, "")
+	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows)
 }
 
 // PrintProjectInfo print project info
@@ -176,7 +181,7 @@ func PrintProjectInfo(info models.ProjectInfo, jsonFlag bool) {
 	}
 
 	rows := [][]string{{info.ID, info.Name, info.Description, info.SetupAt, info.CreatedAt}}
-	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows, "")
+	PrintTable([]string{"id", "name", "description", "setup_at", "created_at"}, rows)
 }
 
 // PrintSecrets print secrets
@@ -246,7 +251,7 @@ func PrintSecrets(secrets map[string]models.ComputedSecret, secretsToPrint []str
 		rows = append(rows, row)
 	}
 
-	PrintTable(headers, rows, "")
+	PrintTable(headers, rows)
 }
 
 // PrintSecretsNames print secrets
@@ -288,7 +293,7 @@ func PrintSecretsNames(secrets map[string]models.ComputedSecret, jsonFlag bool, 
 	for _, name := range secretsNames {
 		rows = append(rows, []string{name})
 	}
-	PrintTable([]string{"name"}, rows, "")
+	PrintTable([]string{"name"}, rows)
 }
 
 // PrintSettings print settings
@@ -299,7 +304,7 @@ func PrintSettings(settings models.WorkplaceSettings, jsonFlag bool) {
 	}
 
 	rows := [][]string{{settings.ID, settings.Name, settings.BillingEmail}}
-	PrintTable([]string{"id", "name", "billing_email"}, rows, "")
+	PrintTable([]string{"id", "name", "billing_email"}, rows)
 }
 
 // PrintScopedConfig print scoped config
@@ -352,7 +357,7 @@ func PrintScopedConfigSource(conf models.ScopedOptions, title string, jsonFlag b
 		headers = append(headers, "source")
 	}
 
-	PrintTable(headers, rows, title)
+	PrintTableWithTitle(headers, rows, title)
 }
 
 // PrintConfigs print configs
@@ -381,5 +386,5 @@ func PrintConfigs(configs map[string]models.FileScopedOptions, jsonFlag bool) {
 		return rows[a][0] < rows[b][0]
 	})
 
-	PrintTable([]string{"name", "value", "scope"}, rows, "")
+	PrintTable([]string{"name", "value", "scope"}, rows)
 }

--- a/pkg/utils/print.go
+++ b/pkg/utils/print.go
@@ -35,6 +35,7 @@ const maxTableWidth = 100
 func PrintTable(headers []string, rows [][]string, title string) {
 	t := table.NewWriter()
 	t.SetOutputMirror(os.Stdout)
+	t.SetStyle(table.StyleLight)
 
 	if title != "" {
 		t.SetTitle(title)


### PR DESCRIPTION
- Add "configure debug" command to view the active configuration
- Print active configuration when --debug flag is specified
- Use "smoother" format for tables 


Before:
<img width="662" alt="Screen Shot 2019-12-05 at 3 54 39 PM" src="https://user-images.githubusercontent.com/8296030/70284059-95ccde80-1777-11ea-9d34-3afce99f3039.png">

After:
<img width="659" alt="Screen Shot 2019-12-05 at 3 54 33 PM" src="https://user-images.githubusercontent.com/8296030/70284064-99f8fc00-1777-11ea-971f-0c4651d228be.png">
