### PR TITLE
Add "configure options" command to view all supported config options

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -63,6 +63,16 @@ and the config file (in order from highest to lowest precedence)`,
 	},
 }
 
+var configureOptionsCmd = &cobra.Command{
+	Use:   "options",
+	Short: "List all supported config options",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonFlag := utils.OutputJSON
+		printer.ConfigOptionNames(models.ConfigOptions, jsonFlag)
+	},
+}
+
 var configureGetCmd = &cobra.Command{
 	Use:   "get [options]",
 	Short: "Get the value of one or more options in the config file",
@@ -218,6 +228,8 @@ doppler configure unset key otherkey`,
 
 func init() {
 	configureCmd.AddCommand(configureDebugCmd)
+
+	configureCmd.AddCommand(configureOptionsCmd)
 
 	configureGetCmd.Flags().Bool("plain", false, "print values without formatting. values will be printed in the same order as specified")
 	configureCmd.AddCommand(configureGetCmd)

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -71,6 +71,16 @@ func (s Source) String() string {
 	return [...]string{"Flag", "Config File", "Environment", "Default Value"}[s]
 }
 
+// ConfigOptions all supported options
+var ConfigOptions = []string{
+	"token",
+	"project",
+	"config",
+	"api-host",
+	"dashboard-host",
+	"verify-tls",
+}
+
 // Pairs get the pairs for the given config
 func Pairs(conf FileScopedOptions) map[string]string {
 	return map[string]string{

--- a/pkg/printer/print.go
+++ b/pkg/printer/print.go
@@ -389,3 +389,17 @@ func Configs(configs map[string]models.FileScopedOptions, jsonFlag bool) {
 
 	Table([]string{"name", "value", "scope"}, rows)
 }
+
+// ConfigOptionNames prints all supported config options
+func ConfigOptionNames(options []string, jsonFlag bool) {
+	if jsonFlag {
+		JSON(options)
+		return
+	}
+
+	rows := [][]string{}
+	for _, option := range options {
+		rows = append(rows, []string{option})
+	}
+	Table([]string{"name"}, rows)
+}


### PR DESCRIPTION
```sh
$ doppler configure options
┌────────────────┐
│ NAME           │
├────────────────┤
│ token          │
│ project        │
│ config         │
│ api-host       │
│ dashboard-host │
│ verify-tls     │
└────────────────┘
```