### PR TITLE
Timeout incomplete login flow after 5 minutes

### DIFF
--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -68,8 +68,17 @@ var loginCmd = &cobra.Command{
 			fmt.Println("Waiting...")
 		}
 
+		// auth flow must complete within 5 minutes
+		timeout := 5 * time.Minute
+		completeBy := time.Now().Add(timeout)
+
 		response = nil
 		for {
+			// we don't respect --no-timeout here
+			if time.Now().After(completeBy) {
+				utils.HandleError(fmt.Errorf("login timed out after %d minutes", int(timeout.Minutes())))
+			}
+
 			resp, err := http.GetAuthToken(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), code)
 			if !err.IsNil() {
 				if err.Code == 409 {


### PR DESCRIPTION
This is in addition to our server-side timeouts