### PR TITLE
Fix bug where global flags had to be specified before local flags

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -29,11 +29,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var deployHost string
-var key string
-var project string
-var config string
-
 var runCmd = &cobra.Command{
 	Use:   "run [command]",
 	Short: "Run a command with secrets injected into the environment",

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -39,12 +39,10 @@ var runCmd = &cobra.Command{
 	Short: "Run a command with secrets injected into the environment",
 	Long: `Run a command with secrets injected into the environment
 
-Usage:
-doppler run printenv
-doppler run -- printenv
-doppler run --key=123 -- printenv
-
 To view the CLI's active configuration, run ` + "`doppler configure debug`",
+	Example: `doppler run printenv
+doppler run -- printenv
+doppler run --token=123 -- printenv`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		fallbackReadonly := utils.GetBoolFlag(cmd, "fallback-readonly")


### PR DESCRIPTION
Due to how we were parsing flags, you had to specify local flags before global flags. Example: (notice the order of the `project` and `json` flags)

```
$ doppler enclave secrets --project=820e4c138be --json
┌─────────┬────────┐
│ NAME    │ VALUE  │
├─────────┼────────┤
│ API_KEY │ abc123 │
└─────────┴────────┘

$ doppler enclave secrets --json --project=820e4c138be
{"API_KEY":{"computed":"abc123"}}
```

You can now specify the flags in any order.