### PR TITLE
Exit with non-zero status if unknown command is provided

### DIFF
--- a/pkg/cmd/enclave.go
+++ b/pkg/cmd/enclave.go
@@ -23,6 +23,9 @@ var enclaveCmd = &cobra.Command{
 	Use:   "enclave",
 	Short: "Control Enclave",
 	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
 }
 
 func init() {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -54,6 +54,9 @@ var rootCmd = &cobra.Command{
 			}
 		}
 	},
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
 }
 
 func loadFlags(cmd *cobra.Command) {


### PR DESCRIPTION
Before:
```sh
$ doppler fakecommand
// prints usage...
$ echo $?
0
```

After:
```sh
$ doppler fakecommand
Error: unknown command "fakecommand" for "doppler"
// prints usage...
$ echo $?
1
```