### PR TITLE
Add ability to manage config service tokens

### DIFF
--- a/pkg/cmd/enclave_configs_logs.go
+++ b/pkg/cmd/enclave_configs_logs.go
@@ -1,0 +1,110 @@
+/*
+Copyright © 2019 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"github.com/DopplerHQ/cli/pkg/configuration"
+	"github.com/DopplerHQ/cli/pkg/http"
+	"github.com/DopplerHQ/cli/pkg/printer"
+	"github.com/DopplerHQ/cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var configsLogsCmd = &cobra.Command{
+	Use:   "logs",
+	Short: "List config audit logs",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonFlag := utils.OutputJSON
+		localConfig := configuration.LocalConfig(cmd)
+		// number := utils.GetIntFlag(cmd, "number", 16)
+
+		logs, err := http.GetConfigLogs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		printer.ConfigLogs(logs, len(logs), jsonFlag)
+	},
+}
+
+var configsLogsGetCmd = &cobra.Command{
+	Use:   "get [log_id]",
+	Short: "Get config audit log",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonFlag := utils.OutputJSON
+		localConfig := configuration.LocalConfig(cmd)
+
+		log := cmd.Flag("log").Value.String()
+		if len(args) > 0 {
+			log = args[0]
+		}
+
+		configLog, err := http.GetConfigLog(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, log)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		printer.ConfigLog(configLog, jsonFlag, true)
+	},
+}
+
+var configsLogsRollbackCmd = &cobra.Command{
+	Use:   "rollback [log_id]",
+	Short: "Rollback a config change",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonFlag := utils.OutputJSON
+		silent := utils.GetBoolFlag(cmd, "silent")
+		localConfig := configuration.LocalConfig(cmd)
+
+		log := cmd.Flag("log").Value.String()
+		if len(args) > 0 {
+			log = args[0]
+		}
+
+		configLog, err := http.RollbackConfigLog(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, log)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		if !silent {
+			printer.ConfigLog(configLog, jsonFlag, true)
+		}
+	},
+}
+
+func init() {
+	configsLogsCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
+	configsLogsCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
+	// TODO: hide this flag until the api supports it
+	// configsLogsCmd.Flags().IntP("number", "n", 5, "max number of logs to display")
+	configsCmd.AddCommand(configsLogsCmd)
+
+	configsLogsGetCmd.Flags().String("log", "", "audit log id")
+	configsLogsGetCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
+	configsLogsGetCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
+	configsLogsCmd.AddCommand(configsLogsGetCmd)
+
+	configsLogsRollbackCmd.Flags().String("log", "", "audit log id")
+	configsLogsRollbackCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
+	configsLogsRollbackCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
+	configsLogsRollbackCmd.Flags().Bool("silent", false, "do not output the response")
+	configsLogsCmd.AddCommand(configsLogsRollbackCmd)
+
+	enclaveCmd.AddCommand(configsCmd)
+}

--- a/pkg/cmd/enclave_configs_tokens.go
+++ b/pkg/cmd/enclave_configs_tokens.go
@@ -1,0 +1,148 @@
+/*
+Copyright © 2019 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"errors"
+
+	"github.com/DopplerHQ/cli/pkg/configuration"
+	"github.com/DopplerHQ/cli/pkg/http"
+	"github.com/DopplerHQ/cli/pkg/printer"
+	"github.com/DopplerHQ/cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var configsTokensCmd = &cobra.Command{
+	Use:   "tokens",
+	Short: "List a config's service tokens",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonFlag := utils.OutputJSON
+		localConfig := configuration.LocalConfig(cmd)
+
+		tokens, err := http.GetConfigServiceTokens(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		printer.ConfigServiceTokens(tokens, len(tokens), jsonFlag)
+	},
+}
+
+var configsTokensGetCmd = &cobra.Command{
+	Use:   "get [slug]",
+	Short: "Get a config's service token",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonFlag := utils.OutputJSON
+		localConfig := configuration.LocalConfig(cmd)
+
+		slug := cmd.Flag("slug").Value.String()
+		if len(args) > 0 {
+			slug = args[0]
+		}
+
+		tokens, err := http.GetConfigServiceTokens(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		for _, token := range tokens {
+			if token.Slug == slug {
+				printer.ConfigServiceToken(token, jsonFlag, true)
+				return
+			}
+		}
+
+		utils.HandleError(errors.New("invalid service token slug"), err.Message)
+	},
+}
+
+var configsTokensCreateCmd = &cobra.Command{
+	Use:   "create [name]",
+	Short: "Create a service token for a config",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonFlag := utils.OutputJSON
+		localConfig := configuration.LocalConfig(cmd)
+
+		name := cmd.Flag("name").Value.String()
+		if len(args) > 0 {
+			name = args[0]
+		}
+
+		configToken, err := http.CreateConfigServiceToken(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, name)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		printer.ConfigServiceToken(configToken, jsonFlag, true)
+	},
+}
+
+var configsTokensDeleteCmd = &cobra.Command{
+	Use:   "delete [slug]",
+	Short: "Delete a service token from a config",
+	Args:  cobra.MaximumNArgs(1),
+	Run: func(cmd *cobra.Command, args []string) {
+		jsonFlag := utils.OutputJSON
+		silent := utils.GetBoolFlag(cmd, "silent")
+		localConfig := configuration.LocalConfig(cmd)
+
+		slug := cmd.Flag("slug").Value.String()
+		if len(args) > 0 {
+			slug = args[0]
+		}
+
+		err := http.DeleteConfigServiceToken(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, slug)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		if !silent {
+			tokens, err := http.GetConfigServiceTokens(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+			if !err.IsNil() {
+				utils.HandleError(err.Unwrap(), err.Message)
+			}
+
+			printer.ConfigServiceTokens(tokens, len(tokens), jsonFlag)
+		}
+	},
+}
+
+func init() {
+	configsTokensCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
+	configsTokensCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
+	configsCmd.AddCommand(configsTokensCmd)
+
+	configsTokensGetCmd.Flags().String("slug", "", "service token slug")
+	configsTokensGetCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
+	configsTokensGetCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
+	configsTokensCmd.AddCommand(configsTokensGetCmd)
+
+	configsTokensCreateCmd.Flags().String("name", "", "service token name")
+	configsTokensCreateCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
+	configsTokensCreateCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
+	configsTokensCmd.AddCommand(configsTokensCreateCmd)
+
+	configsTokensDeleteCmd.Flags().String("slug", "", "service token slug")
+	configsTokensDeleteCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
+	configsTokensDeleteCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
+	configsTokensDeleteCmd.Flags().Bool("silent", false, "do not output the response")
+	configsTokensCmd.AddCommand(configsTokensDeleteCmd)
+
+	enclaveCmd.AddCommand(configsCmd)
+}

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -95,3 +95,10 @@ type LogDiff struct {
 	Added   string `json:"added"`
 	Removed string `json:"removed"`
 }
+
+// ConfigServiceToken a service token
+type ConfigServiceToken struct {
+	Name      string `json:"name"`
+	Slug      string `json:"slug"`
+	CreatedAt string `json:"created_at"`
+}

--- a/pkg/models/parse.go
+++ b/pkg/models/parse.go
@@ -210,3 +210,20 @@ func ParseSecrets(response []byte) (map[string]ComputedSecret, error) {
 
 	return computed, nil
 }
+
+// ParseConfigServiceToken parse config service token
+func ParseConfigServiceToken(token map[string]interface{}) ConfigServiceToken {
+	var parsedToken ConfigServiceToken
+
+	if token["name"] != nil {
+		parsedToken.Name = token["name"].(string)
+	}
+	if token["slug"] != nil {
+		parsedToken.Slug = token["slug"].(string)
+	}
+	if token["created_at"] != nil {
+		parsedToken.CreatedAt = token["created_at"].(string)
+	}
+
+	return parsedToken
+}

--- a/pkg/printer/print.go
+++ b/pkg/printer/print.go
@@ -76,13 +76,14 @@ func Table(headers []string, rows [][]string, options tableOptions) {
 // ConfigLogs print config logs
 func ConfigLogs(logs []models.ConfigLog, number int, jsonFlag bool) {
 	maxLogs := int(math.Min(float64(len(logs)), float64(number)))
+	logs = logs[0:maxLogs]
 
 	if jsonFlag {
-		JSON(logs[0:maxLogs])
+		JSON(logs)
 		return
 	}
 
-	for _, log := range logs[0:maxLogs] {
+	for _, log := range logs {
 		ConfigLog(log, false, false)
 	}
 }
@@ -127,13 +128,14 @@ func ConfigLog(log models.ConfigLog, jsonFlag bool, diff bool) {
 // ActivityLogs print activity logs
 func ActivityLogs(logs []models.ActivityLog, number int, jsonFlag bool) {
 	maxLogs := int(math.Min(float64(len(logs)), float64(number)))
+	logs = logs[0:maxLogs]
 
 	if jsonFlag {
-		JSON(logs[0:maxLogs])
+		JSON(logs)
 		return
 	}
 
-	for _, log := range logs[0:maxLogs] {
+	for _, log := range logs {
 		ActivityLog(log, false, false)
 	}
 }

--- a/pkg/printer/print.go
+++ b/pkg/printer/print.go
@@ -507,3 +507,30 @@ func ConfigOptionNames(options []string, jsonFlag bool) {
 	}
 	Table([]string{"name"}, rows, TableOptions())
 }
+
+// ConfigServiceTokens print config service tokens
+func ConfigServiceTokens(tokens []models.ConfigServiceToken, number int, jsonFlag bool) {
+	maxTokens := int(math.Min(float64(len(tokens)), float64(number)))
+	tokens = tokens[0:maxTokens]
+
+	if jsonFlag {
+		JSON(tokens)
+		return
+	}
+
+	rows := [][]string{}
+	for _, token := range tokens {
+		rows = append(rows, []string{token.Name, token.Slug, token.CreatedAt})
+	}
+	Table([]string{"name", "slug", "created at"}, rows, TableOptions())
+}
+
+// ConfigServiceToken print config service token
+func ConfigServiceToken(token models.ConfigServiceToken, jsonFlag bool, diff bool) {
+	if jsonFlag {
+		JSON(token)
+		return
+	}
+
+	ConfigServiceTokens([]models.ConfigServiceToken{token}, 1, false)
+}


### PR DESCRIPTION
This is a new, backward-compatible feature and will thus result in a minor version bump from v1.2.0 to v1.3.0

```sh
$ ./doppler enclave configs tokens --help
List a config's service tokens

Usage:
  doppler enclave configs tokens [flags]
  doppler enclave configs tokens [command]

Available Commands:
  create      Create a service token for a config
  delete      Delete a service token from a config
  get         Get a config's service token

Flags:
  -c, --config string    enclave config (e.g. dev)
  -h, --help             help for tokens
  -p, --project string   enclave project (e.g. backend)

Global Flags:
      --api-host string         The host address for the Doppler API (default "https://api.doppler.com")
      --configuration string    config file (default "/Users/thomas/Library/Application Support/.doppler.yaml")
      --dashboard-host string   The host address for the Doppler Dashboard (default "https://doppler.com")
      --debug                   output additional information when encountering errors
      --json                    output json
      --no-check-version        do not check for updates to the Doppler CLI
      --no-read-env             do not read enclave config from the environment
      --no-timeout              do not timeout long-running requests
      --no-verify-tls           do not verify the validity of TLS certificates on HTTP requests
      --scope string            the directory to scope your config to (default ".")
      --timeout duration        how long to wait for a request to complete before timing out (default 10s)
  -t, --token string            doppler token

Use "doppler enclave configs tokens [command] --help" for more information about a command.
```