### PR TITLE
Provide more options for downloading secrets

### DIFF
--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -41,7 +41,6 @@ var secretsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		plain := utils.GetBoolFlag(cmd, "plain")
 		raw := utils.GetBoolFlag(cmd, "raw")
 		onlyNames := utils.GetBoolFlag(cmd, "only-names")
 
@@ -56,9 +55,9 @@ var secretsCmd = &cobra.Command{
 		}
 
 		if onlyNames {
-			printer.SecretsNames(secrets, jsonFlag, plain)
+			printer.SecretsNames(secrets, jsonFlag, false)
 		} else {
-			printer.Secrets(secrets, []string{}, jsonFlag, plain, raw)
+			printer.Secrets(secrets, []string{}, jsonFlag, false, raw)
 		}
 	},
 }
@@ -68,8 +67,8 @@ var secretsGetCmd = &cobra.Command{
 	Short: "Get the value of one or more secrets",
 	Long: `Get the value of one or more secrets.
 
-Ex: output the secrets "api_key" and "crypto_key":
-doppler secrets get api_key crypto_key`,
+Ex: output the secrets "API_KEY" and "CRYPTO_KEY":
+doppler enclave secrets get API_KEY CRYPTO_KEY`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
@@ -95,12 +94,11 @@ var secretsSetCmd = &cobra.Command{
 	Short: "Set the value of one or more secrets",
 	Long: `Set the value of one or more secrets.
 
-Ex: set the secrets "api_key" and "crypto_key":
-doppler secrets set api_key=123 crypto_key=456`,
+Ex: set the secrets "API_KEY" and "CRYPTO_KEY":
+doppler enclave secrets set API_KEY=123 CRYPTO_KEY=456`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		plain := utils.GetBoolFlag(cmd, "plain")
 		raw := utils.GetBoolFlag(cmd, "raw")
 		silent := utils.GetBoolFlag(cmd, "silent")
 
@@ -123,7 +121,7 @@ doppler secrets set api_key=123 crypto_key=456`,
 		}
 
 		if !silent {
-			printer.Secrets(response, keys, jsonFlag, plain, raw)
+			printer.Secrets(response, keys, jsonFlag, false, raw)
 		}
 	},
 }
@@ -133,12 +131,11 @@ var secretsDeleteCmd = &cobra.Command{
 	Short: "Delete the value of one or more secrets",
 	Long: `Delete the value of one or more secrets.
 
-Ex: delete the secrets "api_key" and "crypto_key":
-doppler secrets delete api_key crypto_key`,
+Ex: delete the secrets "API_KEY" and "CRYPTO_KEY":
+doppler enclave secrets delete API_KEY CRYPTO_KEY`,
 	Args: cobra.MinimumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		plain := utils.GetBoolFlag(cmd, "plain")
 		raw := utils.GetBoolFlag(cmd, "raw")
 		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
@@ -156,7 +153,7 @@ doppler secrets delete api_key crypto_key`,
 			}
 
 			if !silent {
-				printer.Secrets(response, []string{}, jsonFlag, plain, raw)
+				printer.Secrets(response, []string{}, jsonFlag, false, raw)
 			}
 		}
 	},
@@ -247,7 +244,6 @@ $ doppler enclave secrets download --format=env --no-file`,
 func init() {
 	secretsCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	secretsCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
-	secretsCmd.Flags().Bool("plain", false, "print values without formatting")
 	secretsCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
 	secretsCmd.Flags().Bool("only-names", false, "only print the secret names; omit all values")
 
@@ -259,14 +255,12 @@ func init() {
 
 	secretsSetCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	secretsSetCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
-	secretsSetCmd.Flags().Bool("plain", false, "print values without formatting")
 	secretsSetCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
 	secretsSetCmd.Flags().Bool("silent", false, "do not output the response")
 	secretsCmd.AddCommand(secretsSetCmd)
 
 	secretsDeleteCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	secretsDeleteCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
-	secretsDeleteCmd.Flags().Bool("plain", false, "print values without formatting")
 	secretsDeleteCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
 	secretsDeleteCmd.Flags().Bool("silent", false, "do not output the response")
 	secretsDeleteCmd.Flags().Bool("yes", false, "proceed without confirmation")

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -19,7 +19,6 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
-	"strconv"
 
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/version"
@@ -135,14 +134,18 @@ func RevokeAuthToken(host string, verifyTLS bool, token string) (map[string]inte
 }
 
 // DownloadSecrets for specified project and config
-func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string, config string, metadata bool) ([]byte, Error) {
+func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string, config string, jsonFlag bool) ([]byte, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
-	params = append(params, queryParam{Key: "metadata", Value: strconv.FormatBool(metadata)})
 
 	headers := apiKeyHeader(apiKey)
-	headers["Accept"] = "text/plain"
-	statusCode, response, err := GetRequest(host, verifyTLS, headers, "/enclave/v1/configs/"+config+"/secrets", params)
+	if jsonFlag {
+		headers["Accept"] = "application/json"
+	} else {
+		headers["Accept"] = "text/plain"
+	}
+
+	statusCode, response, err := GetRequest(host, verifyTLS, headers, "/enclave/v1/configs/"+config+"/secrets/download", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to download secrets", Code: statusCode}
 	}

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -15,7 +15,7 @@ limitations under the License.
 */
 package models
 
-// ComputedSecret holds computed and raw value
+// ComputedSecret holds all info about a secret
 type ComputedSecret struct {
 	Name          string `json:"name"`
 	RawValue      string `json:"raw"`

--- a/pkg/models/parse.go
+++ b/pkg/models/parse.go
@@ -193,7 +193,7 @@ func ParseActivityLog(log map[string]interface{}) ActivityLog {
 	return parsedLog
 }
 
-// ParseSecrets for specified project and config
+// ParseSecrets parse secrets
 func ParseSecrets(response []byte) (map[string]ComputedSecret, error) {
 	var result map[string]interface{}
 	err := json.Unmarshal(response, &result)


### PR DESCRIPTION
Secrets can now be downloaded in json format, in addition to env format. The downloaded secrets can also now printed to stdout instead of a file.

Usage:
```
$ doppler enclave secrets download && cat doppler.env
# This is the metadata
A="B"

$ doppler enclave secrets download --json && cat doppler.json
{
  "A": "B"
}

$ doppler enclave secrets download --no-file
# This is the metadata
A="B"

$ doppler enclave secrets download --json --no-file
{
  "A": "B"
}
```