### PR TITLE
Organize all user config within a 'doppler' directory

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -59,7 +59,7 @@ and your config file. Flags have the highest priority; config file has the least
 		jsonFlag := utils.OutputJSON
 
 		if !jsonFlag {
-			color.Green.Printf("Configuration file: %s\n\n", configuration.UserConfigPath)
+			color.Green.Printf("Configuration file: %s\n\n", configuration.UserConfigFile)
 		}
 
 		config := configuration.LocalConfig(cmd)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -35,6 +35,7 @@ var rootCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	PersistentPreRun: func(cmd *cobra.Command, args []string) {
 		loadFlags(cmd)
+		configuration.Setup()
 		configuration.LoadConfig()
 
 		if utils.Debug {
@@ -82,7 +83,7 @@ func checkVersion(command string, silent bool, plain bool, print bool) {
 }
 
 func loadFlags(cmd *cobra.Command) {
-	configuration.UserConfigPath = utils.GetFlagIfChanged(cmd, "configuration", configuration.UserConfigPath)
+	configuration.UserConfigFile = utils.GetFlagIfChanged(cmd, "configuration", configuration.UserConfigFile)
 	http.TimeoutDuration = utils.GetDurationFlagIfChanged(cmd, "timeout", http.TimeoutDuration)
 	http.UseTimeout = !utils.GetBoolFlagIfChanged(cmd, "no-timeout", !http.UseTimeout)
 	utils.Debug = utils.GetBoolFlagIfChanged(cmd, "debug", utils.Debug)
@@ -124,7 +125,7 @@ func init() {
 
 	rootCmd.PersistentFlags().Bool("no-read-env", false, "do not read enclave config from the environment")
 	rootCmd.PersistentFlags().String("scope", ".", "the directory to scope your config to")
-	rootCmd.PersistentFlags().String("configuration", configuration.UserConfigPath, "config file")
+	rootCmd.PersistentFlags().String("configuration", configuration.UserConfigFile, "config file")
 	rootCmd.PersistentFlags().Bool("json", false, "output json")
 	rootCmd.PersistentFlags().Bool("debug", false, "output additional information when encountering errors")
 }


### PR DESCRIPTION
This is to help organize our files as we put more things in the config directory, like fallback files.
This change includes automatic config migration for CLI v1 users, as well as a continued migration path for node cli users.

Example:
before /Users/thomas/Library/Application Support/.doppler.yaml
after /Users/thomas/Library/Application Support/doppler/.doppler.yaml

**I also plan to add support for this new location in CLI v1 to maintain backwards compatibility.**