### PR TITLE
Add support for the CLI v2 config path

### DIFF
--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -36,13 +36,21 @@ var UserConfigPath string
 var configContents models.ConfigFile
 
 func init() {
-	fileName := ".doppler.yaml"
 	configDir := utils.ConfigDir()
-	if utils.Exists(configDir) {
-		UserConfigPath = filepath.Join(configDir, fileName)
-	} else {
-		UserConfigPath = filepath.Join(utils.HomeDir(), fileName)
+	if !utils.Exists(configDir) {
+		configDir = utils.HomeDir()
 	}
+
+	fileName := ".doppler.yaml"
+	filePath := filepath.Join(configDir, fileName)
+
+	// support the cli v2 config path to allow downgrades
+	cliV2Path := filepath.Join(configDir, "doppler", fileName)
+	if !utils.Exists(filePath) && utils.Exists(cliV2Path) {
+		filePath = cliV2Path
+	}
+
+	UserConfigPath = filePath
 
 	if !exists() {
 		if jsonExists() {


### PR DESCRIPTION
This is to support downgrades from CLI v2 back to v1.
The CLI will still default to using the old path, and the new path will only be used if a file doesn't exist at the old path BUT does exist at the new path.