### PR TITLE
Encrypt all files containing secrets

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/spf13/cobra v0.0.5
 	github.com/spf13/pflag v1.0.5 // indirect
 	go.mongodb.org/mongo-driver v1.1.2 // indirect
+	golang.org/x/crypto v0.0.0-20190530122614-20be4c3c3ed5
 	golang.org/x/sys v0.0.0-20191029155521-f43be2a4598c // indirect
 	gopkg.in/gookit/color.v1 v1.1.6
 	gopkg.in/yaml.v3 v3.0.0-20191026110619-0b21df46bc1d

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -59,6 +59,12 @@ func Setup() {
 	utils.LogDebug(fmt.Sprintf("Using config file %s", UserConfigFile))
 
 	usingCustomConfigFile := UserConfigFile != defaultUserConfigFile
+	path1, err1 := filepath.Abs(UserConfigFile)
+	path2, err2 := filepath.Abs(defaultUserConfigFile)
+	if err1 == nil && err2 == nil {
+		usingCustomConfigFile = path1 != path2
+	}
+
 	if !usingCustomConfigFile && !utils.Exists(UserConfigDir) {
 		utils.LogDebug("Creating the config directory")
 		err := os.Mkdir(UserConfigDir, 0700)

--- a/pkg/crypto/aes.go
+++ b/pkg/crypto/aes.go
@@ -1,0 +1,114 @@
+/*
+Copyright © 2020 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+// From https://gist.github.com/tscholl2/dc7dc15dc132ea70a98e8542fefffa28
+
+package crypto
+
+import (
+	"crypto/aes"
+	"crypto/cipher"
+	"crypto/rand"
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+
+	"golang.org/x/crypto/pbkdf2"
+)
+
+func deriveKey(passphrase string, salt []byte) ([]byte, []byte, error) {
+	if salt == nil {
+		salt = make([]byte, 8)
+		// http://www.ietf.org/rfc/rfc2898.txt
+		// Salt.
+		_, err := rand.Read(salt)
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+
+	return pbkdf2.Key([]byte(passphrase), salt, 50000, 32, sha256.New), salt, nil
+}
+
+// Encrypt plaintext with a passphrase; uses pbkdf2 for key deriv and aes-gcm for encryption
+func Encrypt(passphrase string, plaintext []byte) (string, error) {
+	key, salt, err := deriveKey(passphrase, nil)
+	if err != nil {
+		return "", err
+	}
+
+	iv := make([]byte, 12)
+	// http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf
+	// Section 8.2
+	_, err = rand.Read(iv)
+	if err != nil {
+		return "", err
+	}
+
+	b, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	aesgcm, err := cipher.NewGCM(b)
+	if err != nil {
+		return "", err
+	}
+
+	data := aesgcm.Seal(nil, iv, plaintext, nil)
+	return hex.EncodeToString(salt) + "-" + hex.EncodeToString(iv) + "-" + hex.EncodeToString(data), nil
+}
+
+// Decrypt ciphertext with a passphrase
+func Decrypt(passphrase string, ciphertext []byte) (string, error) {
+	arr := strings.Split(string(ciphertext), "-")
+	salt, err := hex.DecodeString(arr[0])
+	if err != nil {
+		return "", err
+	}
+
+	iv, err := hex.DecodeString(arr[1])
+	if err != nil {
+		return "", err
+	}
+
+	data, err := hex.DecodeString(arr[2])
+	if err != nil {
+		return "", err
+	}
+
+	key, _, err := deriveKey(passphrase, salt)
+	if err != nil {
+		return "", err
+	}
+
+	b, err := aes.NewCipher(key)
+	if err != nil {
+		return "", err
+	}
+
+	aesgcm, err := cipher.NewGCM(b)
+	if err != nil {
+		return "", err
+	}
+
+	data, err = aesgcm.Open(nil, iv, data, nil)
+	if err != nil {
+		return "", err
+	}
+
+	return string(data), nil
+}

--- a/pkg/crypto/util.go
+++ b/pkg/crypto/util.go
@@ -13,7 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package utils
+
+package crypto
 
 import (
 	"crypto/sha256"

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -51,7 +51,7 @@ func HomeDir() string {
 
 // Exists whether path exists and the user has permission
 func Exists(path string) bool {
-	if _, err := os.Stat(path); os.IsNotExist(err) || os.IsPermission(err) {
+	if _, err := os.Stat(path); err != nil {
 		return false
 	}
 	return true


### PR DESCRIPTION
Fallback files and downloaded secrets will now be encrypted before touching the filesystem.
PBKDF2 is used against the (token, project, config) to generate the key.
AES-GCM is used with a random salt to encrypt the file.