### PR TITLE
Check for required values before executing logic

### DIFF
--- a/pkg/cmd/activity.go
+++ b/pkg/cmd/activity.go
@@ -32,6 +32,8 @@ var activityCmd = &cobra.Command{
 		localConfig := configuration.LocalConfig(cmd)
 		// number := utils.GetIntFlag(cmd, "number", 16)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+
 		activity, err := http.GetActivityLogs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -48,6 +50,8 @@ var activityGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
 
 		log := cmd.Flag("log").Value.String()
 		if len(args) > 0 {

--- a/pkg/cmd/enclave_configs.go
+++ b/pkg/cmd/enclave_configs.go
@@ -34,6 +34,9 @@ var configsCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+
 		configs, err := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -51,10 +54,14 @@ var configsGetCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+
 		config := localConfig.EnclaveConfig.Value
 		if len(args) > 0 {
 			config = args[0]
 		}
+		utils.RequireValue("config", config)
 
 		configInfo, err := http.GetConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config)
 		if !err.IsNil() {
@@ -74,6 +81,10 @@ var configsCreateCmd = &cobra.Command{
 		silent := utils.GetBoolFlag(cmd, "silent")
 		defaults := !utils.GetBoolFlag(cmd, "no-defaults")
 		environment := cmd.Flag("environment").Value.String()
+		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
 
 		name := cmd.Flag("name").Value.String()
 		if len(args) > 0 {
@@ -92,7 +103,6 @@ var configsCreateCmd = &cobra.Command{
 			utils.HandleError(errors.New("you must specify an environment"))
 		}
 
-		localConfig := configuration.LocalConfig(cmd)
 		info, err := http.CreateConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, name, environment, defaults)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -114,10 +124,14 @@ var configsDeleteCmd = &cobra.Command{
 		yes := utils.GetBoolFlag(cmd, "yes")
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+
 		config := localConfig.EnclaveConfig.Value
 		if len(args) > 0 {
 			config = args[0]
 		}
+		utils.RequireValue("config", config)
 
 		if yes || utils.ConfirmationPrompt("Delete config "+config, false) {
 			err := http.DeleteConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config)
@@ -147,10 +161,15 @@ var configsUpdateCmd = &cobra.Command{
 		name := cmd.Flag("name").Value.String()
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("name", name)
+
 		config := localConfig.EnclaveConfig.Value
 		if len(args) > 0 {
 			config = args[0]
 		}
+		utils.RequireValue("config", config)
 
 		info, err := http.UpdateConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config, name)
 		if !err.IsNil() {

--- a/pkg/cmd/enclave_configs_logs.go
+++ b/pkg/cmd/enclave_configs_logs.go
@@ -32,6 +32,10 @@ var configsLogsCmd = &cobra.Command{
 		localConfig := configuration.LocalConfig(cmd)
 		// number := utils.GetIntFlag(cmd, "number", 16)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
+
 		logs, err := http.GetConfigLogs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -48,6 +52,10 @@ var configsLogsGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 		log := cmd.Flag("log").Value.String()
 		if len(args) > 0 {
@@ -71,6 +79,10 @@ var configsLogsRollbackCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 		log := cmd.Flag("log").Value.String()
 		if len(args) > 0 {

--- a/pkg/cmd/enclave_configs_tokens.go
+++ b/pkg/cmd/enclave_configs_tokens.go
@@ -33,6 +33,10 @@ var configsTokensCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
+
 		tokens, err := http.GetConfigServiceTokens(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -49,6 +53,10 @@ var configsTokensGetCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 		slug := cmd.Flag("slug").Value.String()
 		if len(args) > 0 {
@@ -81,6 +89,10 @@ var configsTokensCreateCmd = &cobra.Command{
 		copy := utils.GetBoolFlag(cmd, "copy")
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
+
 		name := cmd.Flag("name").Value.String()
 		if len(args) > 0 {
 			name = args[0]
@@ -104,6 +116,10 @@ var configsTokensRevokeCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 		slug := cmd.Flag("slug").Value.String()
 		if len(args) > 0 {

--- a/pkg/cmd/enclave_environments.go
+++ b/pkg/cmd/enclave_environments.go
@@ -31,10 +31,13 @@ var environmentsCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+
 		project := localConfig.EnclaveProject.Value
 		if len(args) > 0 {
 			project = args[0]
 		}
+		utils.RequireValue("project", project)
 
 		info, err := http.GetEnvironments(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, project)
 		if !err.IsNil() {
@@ -53,6 +56,10 @@ var environmentsGetCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
 		environment := args[0]
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("environment", environment)
 
 		info, err := http.GetEnvironment(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, environment)
 		if !err.IsNil() {

--- a/pkg/cmd/enclave_environments.go
+++ b/pkg/cmd/enclave_environments.go
@@ -74,5 +74,6 @@ func init() {
 	environmentsGetCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	environmentsCmd.AddCommand(environmentsGetCmd)
 
+	environmentsCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	enclaveCmd.AddCommand(environmentsCmd)
 }

--- a/pkg/cmd/enclave_projects.go
+++ b/pkg/cmd/enclave_projects.go
@@ -16,8 +16,6 @@ limitations under the License.
 package cmd
 
 import (
-	"errors"
-
 	"github.com/DopplerHQ/cli/pkg/configuration"
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/printer"
@@ -31,8 +29,10 @@ var projectsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+
 		info, err := http.GetProjects(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -50,10 +50,13 @@ var projectsGetCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+
 		project := localConfig.EnclaveProject.Value
 		if len(args) > 0 {
 			project = args[0]
 		}
+		utils.RequireValue("project", project)
 
 		info, err := http.GetProject(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, project)
 		if !err.IsNil() {
@@ -72,16 +75,17 @@ var projectsCreateCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		silent := utils.GetBoolFlag(cmd, "silent")
 		description := cmd.Flag("description").Value.String()
+		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("description", description)
 
 		name := cmd.Flag("name").Value.String()
 		if len(args) > 0 {
 			name = args[0]
 		}
-		if name == "" {
-			utils.HandleError(errors.New("you must provide a name"))
-		}
+		utils.RequireValue("name", name)
 
-		localConfig := configuration.LocalConfig(cmd)
 		info, err := http.CreateProject(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, name, description)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -103,10 +107,13 @@ var projectsDeleteCmd = &cobra.Command{
 		yes := utils.GetBoolFlag(cmd, "yes")
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+
 		project := localConfig.EnclaveProject.Value
 		if len(args) > 0 {
 			project = args[0]
 		}
+		utils.RequireValue("project", project)
 
 		if yes || utils.ConfirmationPrompt("Delete project "+project, false) {
 			err := http.DeleteProject(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, project)
@@ -133,15 +140,19 @@ var projectsUpdateCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
 		silent := utils.GetBoolFlag(cmd, "silent")
+		name := cmd.Flag("name").Value.String()
+		description := cmd.Flag("description").Value.String()
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("name", name)
+		utils.RequireValue("description", description)
 
 		project := localConfig.EnclaveProject.Value
 		if len(args) > 0 {
 			project = args[0]
 		}
-
-		name := cmd.Flag("name").Value.String()
-		description := cmd.Flag("description").Value.String()
+		utils.RequireValue("project", project)
 
 		info, err := http.UpdateProject(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, project, name, description)
 		if !err.IsNil() {

--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -44,8 +44,12 @@ var secretsCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 		raw := utils.GetBoolFlag(cmd, "raw")
 		onlyNames := utils.GetBoolFlag(cmd, "only-names")
-
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
+
 		response, err := http.GetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -76,8 +80,12 @@ doppler enclave secrets get API_KEY CRYPTO_KEY`,
 		plain := utils.GetBoolFlag(cmd, "plain")
 		copy := utils.GetBoolFlag(cmd, "copy")
 		raw := utils.GetBoolFlag(cmd, "raw")
-
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
+
 		response, err := http.GetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -103,6 +111,11 @@ doppler enclave secrets set API_KEY=123 CRYPTO_KEY=456`,
 		jsonFlag := utils.OutputJSON
 		raw := utils.GetBoolFlag(cmd, "raw")
 		silent := utils.GetBoolFlag(cmd, "silent")
+		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 		secrets := map[string]interface{}{}
 		var keys []string
@@ -116,7 +129,6 @@ doppler enclave secrets set API_KEY=123 CRYPTO_KEY=456`,
 			}
 		}
 
-		localConfig := configuration.LocalConfig(cmd)
 		response, err := http.SetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, secrets)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -141,6 +153,11 @@ doppler enclave secrets delete API_KEY CRYPTO_KEY`,
 		raw := utils.GetBoolFlag(cmd, "raw")
 		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
+		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 		if yes || utils.ConfirmationPrompt("Delete secret(s)", false) {
 			secrets := map[string]interface{}{}
@@ -148,7 +165,6 @@ doppler enclave secrets delete API_KEY CRYPTO_KEY`,
 				secrets[arg] = nil
 			}
 
-			localConfig := configuration.LocalConfig(cmd)
 			response, err := http.SetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, secrets)
 			if !err.IsNil() {
 				utils.HandleError(err.Unwrap(), err.Message)
@@ -184,6 +200,11 @@ $ doppler enclave secrets download --format=env --no-file`,
 		silent := utils.GetBoolFlag(cmd, "silent")
 		saveFile := !utils.GetBoolFlag(cmd, "no-file")
 		jsonFlag := utils.OutputJSON
+		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 		format := cmd.Flag("format").Value.String()
 		if jsonFlag {
@@ -206,7 +227,6 @@ $ doppler enclave secrets download --format=env --no-file`,
 			}
 		}
 
-		localConfig := configuration.LocalConfig(cmd)
 		body, apiError := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format == "json")
 		if !apiError.IsNil() {
 			utils.HandleError(apiError.Unwrap(), apiError.Message)

--- a/pkg/cmd/enclave_setup.go
+++ b/pkg/cmd/enclave_setup.go
@@ -40,6 +40,8 @@ var setupCmd = &cobra.Command{
 		localConfig := configuration.LocalConfig(cmd)
 		scopedConfig := configuration.Get(scope)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+
 		flagsFromEnvironment := []string{}
 
 		project := ""

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -161,13 +161,9 @@ Your saved configuration will be updated.`,
 		silent := utils.GetBoolFlag(cmd, "silent")
 		updateConfig := !utils.GetBoolFlag(cmd, "no-update-config")
 
+		utils.RequireValue("token", localConfig.Token.Value)
+
 		oldToken := localConfig.Token.Value
-		if oldToken == "" {
-			if !silent {
-				fmt.Println("You must provide an auth token")
-			}
-			os.Exit(1)
-		}
 
 		response, err := http.RollAuthToken(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), oldToken)
 		if !err.IsNil() {

--- a/pkg/cmd/logout.go
+++ b/pkg/cmd/logout.go
@@ -17,7 +17,6 @@ package cmd
 
 import (
 	"fmt"
-	"os"
 
 	"github.com/DopplerHQ/cli/pkg/configuration"
 	"github.com/DopplerHQ/cli/pkg/http"
@@ -45,12 +44,7 @@ func revokeToken(cmd *cobra.Command, args []string) {
 	yes := utils.GetBoolFlag(cmd, "yes")
 	token := localConfig.Token.Value
 
-	if token == "" {
-		if !silent {
-			fmt.Println("You must provide an auth token")
-		}
-		os.Exit(1)
-	}
+	utils.RequireValue("token", localConfig.Token.Value)
 
 	if !yes && !utils.ConfirmationPrompt(fmt.Sprintf("Revoke auth token scoped to %s?", localConfig.Token.Scope), false) {
 		return

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -55,6 +55,10 @@ doppler run --token=123 -- YOUR_COMMAND --your-flag`,
 		exitOnWriteFailure := !utils.GetBoolFlag(cmd, "no-exit-on-write-failure")
 		localConfig := configuration.LocalConfig(cmd)
 
+		utils.RequireValue("token", localConfig.Token.Value)
+		utils.RequireValue("project", localConfig.EnclaveProject.Value)
+		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
+
 		fallbackPath := ""
 		if cmd.Flags().Changed("fallback") {
 			fallbackPath = utils.GetFilePath(cmd.Flag("fallback").Value.String(), "")

--- a/pkg/cmd/settings.go
+++ b/pkg/cmd/settings.go
@@ -32,8 +32,10 @@ var settingsCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-
 		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
+
 		info, err := http.GetWorkplaceSettings(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -56,7 +58,7 @@ var settingsUpdateCmd = &cobra.Command{
 		name := cmd.Flag("name").Value.String()
 		email := cmd.Flag("email").Value.String()
 		if name == "" && email == "" {
-			return errors.New("Error: command needs a flag")
+			return errors.New("Error: command needs flag --name or --email")
 		}
 
 		return nil
@@ -66,10 +68,12 @@ var settingsUpdateCmd = &cobra.Command{
 		name := cmd.Flag("name").Value.String()
 		email := cmd.Flag("email").Value.String()
 		jsonFlag := utils.OutputJSON
+		localConfig := configuration.LocalConfig(cmd)
+
+		utils.RequireValue("token", localConfig.Token.Value)
 
 		settings := models.WorkplaceSettings{Name: name, BillingEmail: email}
 
-		localConfig := configuration.LocalConfig(cmd)
 		info, err := http.SetWorkplaceSettings(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, settings)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -16,6 +16,7 @@ limitations under the License.
 package utils
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -88,6 +89,14 @@ func RunCommand(command []string, env []string) (int, error) {
 	}
 
 	return 0, nil
+}
+
+// RequireValue throws an error if a value is blank
+func RequireValue(name string, value string) {
+	value = strings.TrimSpace(value)
+	if value == "" {
+		HandleError(fmt.Errorf("you must provide a %s", name))
+	}
 }
 
 // GetBool parse string into a boolean


### PR DESCRIPTION
Before:
```sh
$ doppler enclave secrets --config=
Unable to fetch secrets
Error: Invalid API endpoint.
```

After:
```sh
$ doppler enclave secrets --config=
Error: you must provide a config
```