### PR TITLE
Support the re-worked v2 config path

### DIFF
--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -45,7 +45,7 @@ func init() {
 	filePath := filepath.Join(configDir, fileName)
 
 	// support the cli v2 config path to allow downgrades
-	cliV2Path := filepath.Join(configDir, "doppler", fileName)
+	cliV2Path := filepath.Join(utils.HomeDir(), ".doppler", fileName)
 	if !utils.Exists(filePath) && utils.Exists(cliV2Path) {
 		filePath = cliV2Path
 	}


### PR DESCRIPTION
This is the downside of releasing the v1 change before the v2 change is stable.