### PR TITLE
Change default configuration file path

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -34,9 +34,7 @@ import (
 	"gopkg.in/gookit/color.v1"
 )
 
-// DefaultFallbackDir path to the default fallback dir
-var DefaultFallbackDir string
-
+var defaultFallbackDir string
 var defaultFallbackFileMaxAge = 72 * time.Hour
 
 var runCmd = &cobra.Command{
@@ -65,8 +63,8 @@ doppler run --token=123 -- YOUR_COMMAND --your-flag`,
 		} else {
 			fallbackPath = defaultFallbackFile(localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 
-			if enableFallback && !utils.Exists(DefaultFallbackDir) {
-				err := os.Mkdir(DefaultFallbackDir, 0700)
+			if enableFallback && !utils.Exists(defaultFallbackDir) {
+				err := os.Mkdir(defaultFallbackDir, 0700)
 				if err != nil && exitOnWriteFailure {
 					utils.HandleError(err, "Unable to create directory for fallback file", strings.Join(writeFailureMessage(), "\n"))
 				}
@@ -133,9 +131,9 @@ var runCleanCmd = &cobra.Command{
 		silent := utils.GetBoolFlag(cmd, "silent")
 		dryRun := utils.GetBoolFlag(cmd, "dry-run")
 
-		utils.LogDebug(fmt.Sprintf("Using fallback directory %s", DefaultFallbackDir))
+		utils.LogDebug(fmt.Sprintf("Using fallback directory %s", defaultFallbackDir))
 
-		if _, err := os.Stat(DefaultFallbackDir); err != nil {
+		if _, err := os.Stat(defaultFallbackDir); err != nil {
 			if os.IsNotExist(err) {
 				utils.LogDebug("Fallback directory does not exist")
 				if !silent {
@@ -147,7 +145,7 @@ var runCleanCmd = &cobra.Command{
 			utils.HandleError(err, "Unable to read fallback directory")
 		}
 
-		entries, err := ioutil.ReadDir(DefaultFallbackDir)
+		entries, err := ioutil.ReadDir(defaultFallbackDir)
 		if err != nil {
 			utils.HandleError(err, "Unable to read fallback directory")
 		}
@@ -165,7 +163,7 @@ var runCleanCmd = &cobra.Command{
 				if dryRun {
 					deleted++
 				} else {
-					file := filepath.Join(DefaultFallbackDir, entry.Name())
+					file := filepath.Join(defaultFallbackDir, entry.Name())
 					utils.LogDebug(fmt.Sprintf("Deleting fallback file %s", file))
 
 					err := os.Remove(file)
@@ -316,11 +314,11 @@ func parseSecrets(response []byte) (map[string]string, error) {
 
 func defaultFallbackFile(project string, config string) string {
 	fileName := fmt.Sprintf(".run-%s.json", crypto.Hash(fmt.Sprintf("%s:%s", project, config)))
-	return filepath.Join(DefaultFallbackDir, fileName)
+	return filepath.Join(defaultFallbackDir, fileName)
 }
 
 func init() {
-	DefaultFallbackDir = filepath.Join(configuration.UserConfigDir, "fallback")
+	defaultFallbackDir = filepath.Join(configuration.UserConfigDir, "fallback")
 
 	runCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	runCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -30,13 +30,13 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// baseConfigDir path to the base configuration directory (e.g. /home/user/.config)
+// baseConfigDir (e.g. /home/user/)
 var baseConfigDir string
 
-// UserConfigDir path to the user's configuration directory (e.g. /home/user/.config/doppler)
+// UserConfigDir (e.g. /home/user/.doppler)
 var UserConfigDir string
 
-// UserConfigFile path to the user's configuration file (e.g. /home/user/.config/doppler/.doppler.yaml)
+// UserConfigFile (e.g. /home/user/doppler/.doppler.yaml)
 var UserConfigFile string
 
 var configFileName = ".doppler.yaml"

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -43,12 +43,8 @@ var configFileName = ".doppler.yaml"
 var configContents models.ConfigFile
 
 func init() {
-	baseConfigDir = utils.ConfigDir()
-	if !utils.Exists(baseConfigDir) {
-		baseConfigDir = utils.HomeDir()
-	}
-
-	UserConfigDir = filepath.Join(baseConfigDir, "doppler")
+	baseConfigDir = utils.HomeDir()
+	UserConfigDir = filepath.Join(baseConfigDir, ".doppler")
 	UserConfigFile = filepath.Join(UserConfigDir, configFileName)
 }
 
@@ -65,10 +61,14 @@ func Setup() {
 	}
 
 	if !utils.Exists(UserConfigFile) {
-		v1Config := filepath.Join(baseConfigDir, configFileName)
-		if utils.Exists(v1Config) {
+		v1ConfigA := filepath.Join(utils.ConfigDir(), configFileName)
+		v1ConfigB := filepath.Join(utils.HomeDir(), configFileName)
+		if utils.Exists(v1ConfigA) {
 			utils.LogDebug("Migrating the config from CLI v1")
-			os.Rename(v1Config, UserConfigFile)
+			os.Rename(v1ConfigA, UserConfigFile)
+		} else if utils.Exists(v1ConfigB) {
+			utils.LogDebug("Migrating the config from CLI v1")
+			os.Rename(v1ConfigB, UserConfigFile)
 		} else if jsonExists() {
 			utils.LogDebug("Migrating the config from the Node CLI")
 			migrateJSONToYaml()

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -30,8 +30,12 @@ import (
 	"github.com/spf13/cobra"
 )
 
-// ConfigDir get configuration directory
+// ConfigDir DEPRECATED get configuration directory
 func ConfigDir() string {
+	// this function is deprecated and should not be used.
+	// in testing, node:12-alpine creates the ~/.config directory at some indeterminate point
+	// in the build. this means some doppler commands called by docker RUN may use the home
+	// directory to store config, while doppler commands called by ENTRYPOINT will use ~/config.
 	dir, err := os.UserConfigDir()
 	if err != nil {
 		HandleError(err, "Unable to determine configuration directory")


### PR DESCRIPTION
In testing, node:12-alpine creates the ~/.config directory at some indeterminate point
in the build. This means some doppler commands called by docker RUN may use the home
directory to store config, while doppler commands called by ENTRYPOINT will use ~/.config.

This change only affects the as-of-yet unreleased v2 path, so no migration is needed.