### PR TITLE
Support parsing home directory-based paths

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,3 +18,7 @@ jobs:
       run: go build
       env:
         GOPATH: ${{ runner.workspace }}
+    - name: Test
+      run: make test
+      env:
+        GOPATH: ${{ runner.workspace }}

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,5 @@
+.PHONY: build release test
+
 build:
 	go build -o doppler main.go
 
@@ -6,5 +8,9 @@ release:
 	doppler run -- ./scripts/release.sh
 	doppler run -- ./scripts/post-release.sh
 
+test:
+	go test ./pkg/... -v
+
 test-release:
 	goreleaser release --snapshot --skip-publish --skip-sign --rm-dist
+

--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -234,9 +234,10 @@ $ doppler enclave secrets download --format=env --no-file`,
 
 		var filePath string
 		if len(args) > 0 {
-			filePath = utils.GetFilePath(args[0], "")
-			if filePath == "" {
-				utils.HandleError(errors.New("invalid file path"))
+			var err error
+			filePath, err = utils.GetFilePath(args[0])
+			if err != nil {
+				utils.HandleError(err, "Unable to parse download file path")
 			}
 		} else if format == "env" {
 			filePath = filepath.Join(".", "doppler.env")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -83,7 +83,7 @@ func checkVersion(command string, silent bool, print bool) {
 }
 
 func loadFlags(cmd *cobra.Command) {
-	configuration.UserConfigFile = utils.GetFlagIfChanged(cmd, "configuration", configuration.UserConfigFile)
+	configuration.UserConfigFile = utils.GetPathFlagIfChanged(cmd, "configuration", configuration.UserConfigFile)
 	http.TimeoutDuration = utils.GetDurationFlagIfChanged(cmd, "timeout", http.TimeoutDuration)
 	http.UseTimeout = !utils.GetBoolFlagIfChanged(cmd, "no-timeout", !http.UseTimeout)
 	utils.Debug = utils.GetBoolFlagIfChanged(cmd, "debug", utils.Debug)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -59,7 +59,11 @@ doppler run --token=123 -- YOUR_COMMAND --your-flag`,
 
 		fallbackPath := ""
 		if cmd.Flags().Changed("fallback") {
-			fallbackPath = utils.GetFilePath(cmd.Flag("fallback").Value.String(), "")
+			var err error
+			fallbackPath, err = utils.GetFilePath(cmd.Flag("fallback").Value.String())
+			if err != nil {
+				utils.HandleError(err, "Unable to parse --fallback flag")
+			}
 		} else {
 			fallbackPath = defaultFallbackFile(localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 
@@ -69,9 +73,6 @@ doppler run --token=123 -- YOUR_COMMAND --your-flag`,
 					utils.HandleError(err, "Unable to create directory for fallback file", strings.Join(writeFailureMessage(), "\n"))
 				}
 			}
-		}
-		if fallbackPath == "" {
-			utils.HandleError(errors.New("invalid fallback file path"))
 		}
 		absFallbackPath, err := filepath.Abs(fallbackPath)
 		if err == nil {

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -98,11 +98,11 @@ func SetVersionCheck(version models.VersionCheck) {
 
 // Get the config at the specified scope
 func Get(scope string) models.ScopedOptions {
-	scope, err := parseScope(scope)
+	scope, err := utils.ParsePath(scope)
 	if err != nil {
 		utils.HandleError(err)
 	}
-	scope = filepath.Clean(scope) + string(filepath.Separator)
+	scope = scope + string(filepath.Separator)
 	var scopedConfig models.ScopedOptions
 
 	for confScope, conf := range configContents.Scoped {
@@ -233,7 +233,7 @@ func AllConfigs() map[string]models.FileScopedOptions {
 func Set(scope string, options map[string]string) {
 	if scope != "*" {
 		var err error
-		scope, err = parseScope(scope)
+		scope, err = utils.ParsePath(scope)
 		if err != nil {
 			utils.HandleError(err)
 		}
@@ -256,7 +256,7 @@ func Set(scope string, options map[string]string) {
 func Unset(scope string, options []string) {
 	if scope != "*" {
 		var err error
-		scope, err = parseScope(scope)
+		scope, err = utils.ParsePath(scope)
 		if err != nil {
 			utils.HandleError(err)
 		}
@@ -308,15 +308,6 @@ func readConfig() models.ConfigFile {
 	var config models.ConfigFile
 	yaml.Unmarshal(fileContents, &config)
 	return config
-}
-
-func parseScope(scope string) (string, error) {
-	absScope, err := filepath.Abs(scope)
-	if err != nil {
-		return "", err
-	}
-
-	return absScope, nil
 }
 
 // IsValidConfigOption whether the specified key is a valid config option

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -16,6 +16,7 @@ limitations under the License.
 package utils
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"os/exec"
@@ -170,10 +171,10 @@ func GetDurationFlagIfChanged(cmd *cobra.Command, flag string, def time.Duration
 	return GetDurationFlag(cmd, flag)
 }
 
-// GetFilePath verify file path and name are provided
-func GetFilePath(fullPath string, defaultPath string) string {
+// GetFilePath verify a file path and name are provided
+func GetFilePath(fullPath string) (string, error) {
 	if fullPath == "" {
-		return defaultPath
+		return "", errors.New("Invalid file path")
 	}
 
 	parsedPath := filepath.Dir(fullPath)
@@ -181,10 +182,10 @@ func GetFilePath(fullPath string, defaultPath string) string {
 
 	isNameValid := (parsedName != ".") && (parsedName != "..") && (parsedName != "/") && (parsedName != string(filepath.Separator))
 	if !isNameValid {
-		return defaultPath
+		return "", errors.New("Invalid file path")
 	}
 
-	return filepath.Join(parsedPath, parsedName)
+	return filepath.Join(parsedPath, parsedName), nil
 }
 
 // ConfirmationPrompt prompt user to confirm yes/no

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -170,6 +170,20 @@ func GetFlagIfChanged(cmd *cobra.Command, flag string, def string) string {
 	return cmd.Flag(flag).Value.String()
 }
 
+// GetPathFlagIfChanged gets the flag's path, if specified;
+// always returns an absolute path
+func GetPathFlagIfChanged(cmd *cobra.Command, flag string, def string) string {
+	if !cmd.Flags().Changed(flag) {
+		return def
+	}
+
+	path, err := ParsePath(cmd.Flag(flag).Value.String())
+	if err != nil {
+		HandleError(err, "Unable to parse path")
+	}
+	return path
+}
+
 // GetIntFlag gets the flag's int value
 func GetIntFlag(cmd *cobra.Command, flag string, bits int) int {
 	number, err := strconv.ParseInt(cmd.Flag(flag).Value.String(), 10, bits)

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -1,0 +1,138 @@
+/*
+Copyright © 2019 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"fmt"
+	"os"
+	"os/user"
+	"path/filepath"
+	"testing"
+)
+
+var username string
+var homeDir string
+var cwd string
+
+func init() {
+	currentUser, err := user.Current()
+	if err != nil {
+		panic(err)
+	}
+	username = currentUser.Username
+
+	homeDir, err = os.UserHomeDir()
+	if err != nil {
+		panic(err)
+	}
+
+	cwd, err = filepath.Abs(".")
+	if err != nil {
+		panic(err)
+	}
+}
+
+func TestParsePathTilde(t *testing.T) {
+	path, err := ParsePath("~")
+	if err != nil || path != homeDir {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, homeDir))
+	}
+
+	path, err = ParsePath("~/")
+	if err != nil || path != homeDir {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, homeDir))
+	}
+
+	path, err = ParsePath(fmt.Sprintf("~%s", username))
+	if err != nil || path != homeDir {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, homeDir))
+	}
+
+	path, err = ParsePath(fmt.Sprintf("~%s/", username))
+	if err != nil || path != homeDir {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, homeDir))
+	}
+
+	// expect error
+	path, err = ParsePath(fmt.Sprintf("~%s/", username+"1"))
+	if err == nil || path != "" {
+		t.Error(fmt.Sprintf("Got %s, expected error", path))
+	}
+
+	path, err = ParsePath("")
+	if err == nil || path != "" {
+		t.Error(fmt.Sprintf("Got %s, expected error", path))
+	}
+}
+
+func TestParsePathRelative(t *testing.T) {
+	parentDir := filepath.Join(cwd, "..")
+
+	path, err := ParsePath(".")
+	if err != nil || path != cwd {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, cwd))
+	}
+
+	path, err = ParsePath("./")
+	if err != nil || path != cwd {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, cwd))
+	}
+
+	path, err = ParsePath("..")
+	if err != nil || path != parentDir {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, parentDir))
+	}
+
+	path, err = ParsePath("../")
+	if err != nil || path != parentDir {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, parentDir))
+	}
+
+	path, err = ParsePath("./..")
+	if err != nil || path != parentDir {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, parentDir))
+	}
+}
+
+func TestParsePathAbsolute(t *testing.T) {
+	path, err := ParsePath("/")
+	if err != nil || path != "/" {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, "/"))
+	}
+
+	path, err = ParsePath("/root")
+	if err != nil || path != "/root" {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, "/root"))
+	}
+
+	path, err = ParsePath("root")
+	if err != nil || path != filepath.Join(cwd, "root") {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, filepath.Join(cwd, "root")))
+	}
+}
+
+func TestGetFilePath(t *testing.T) {
+	expected := filepath.Join(cwd, "doppler.env")
+	path, err := GetFilePath("./doppler.env")
+	if err != nil || path != expected {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, expected))
+	}
+
+	path, err = GetFilePath("/root/")
+	if err != nil || path != "/root" {
+		t.Error(fmt.Sprintf("Got %s, expected %s", path, "/root"))
+	}
+}


### PR DESCRIPTION
In some cases, like `--scope=PATH`, the shell won't parse the path. This means we'll need to manually parse the path ourselves, like expanding `~/test` to `/Users/thomas/test`.

For example, calling `doppler enclave secrets download ~/doppler.json` works, but `doppler enclave secrets download "~/doppler.json"` results in an error `open ~/doppler.json: no such file or directory`.

The one case we don't (and can't easily) support parsing is a path like `~USERNAME/` where `USERNAME` is NOT the current user. In that case we detect our inability to parse it and print an error asking the user to provide an absolute path.