### PR TITLE
Allow executing string-wrapped commands via --command flag

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -91,7 +91,7 @@ You can find all source Dockerfiles in the `/docker` folder ([here](https://gith
 Here's an example Dockerfile for a Node app:
 
 ```dockerfile
-FROM dopplerhq/cli:2-node
+FROM dopplerhq/cli:3-node
 
 # doppler args must be passed at runtime
 ENV DOPPLER_TOKEN="" ENCLAVE_PROJECT="" ENCLAVE_CONFIG=""
@@ -102,7 +102,7 @@ COPY . .
 ENTRYPOINT doppler run -- node index.js
 ```
 
-Build the Dockerfile: 
+Build the Dockerfile:
 
 ```sh
 docker build -t mytestapp .

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ test-release:
 	goreleaser release --snapshot --skip-publish --skip-sign --rm-dist
 
 scan:
-	if [ ! -f "$$GOPATH/bin/gosec1" ]; then echo "Error: gosec is not installed\n\nYou can install gosec with 'go get github.com/securego/gosec/cmd/gosec'\n" && exit 1; fi
+	if [ ! -f "$$GOPATH/bin/gosec" ]; then echo "Error: gosec is not installed\n\nYou can install gosec with 'go get github.com/securego/gosec/cmd/gosec'\n" && exit 1; fi
 	$$GOPATH/bin/gosec -quiet ./pkg/...

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -43,9 +43,26 @@ var runCmd = &cobra.Command{
 	Long: `Run a command with secrets injected into the environment
 
 To view the CLI's active configuration, run ` + "`doppler configure debug`",
-	Example: `doppler run -- YOUR_COMMAND
-doppler run --token=123 -- YOUR_COMMAND --your-flag`,
-	Args: cobra.MinimumNArgs(1),
+	Example: `doppler run -- YOUR_COMMAND --YOUR-FLAG
+doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
+	Args: func(cmd *cobra.Command, args []string) error {
+		// The --command flag and args are mututally exclusive
+		usingCommandFlag := cmd.Flags().Changed("command")
+		if usingCommandFlag {
+			command := cmd.Flag("command").Value.String()
+			if command == "" {
+				return errors.New("--command flag requires a value")
+			}
+
+			if len(args) > 0 {
+				return errors.New("arg(s) may not be set when using --command flag")
+			}
+		} else if len(args) == 0 {
+			return errors.New("requires at least 1 arg(s), only received 0")
+		}
+
+		return nil
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		enableFallback := !utils.GetBoolFlag(cmd, "no-fallback")
 		fallbackReadonly := utils.GetBoolFlag(cmd, "fallback-readonly")
@@ -115,12 +132,21 @@ doppler run --token=123 -- YOUR_COMMAND --your-flag`,
 			}
 		}
 
-		exitCode, err := utils.RunCommand(args, env, os.Stdin, os.Stdout, os.Stderr)
+		exitCode := 0
+		err = nil
+
+		if cmd.Flags().Changed("command") {
+			command := cmd.Flag("command").Value.String()
+			exitCode, err = utils.RunCommandString(command, env, os.Stdin, os.Stdout, os.Stderr)
+		} else {
+			exitCode, err = utils.RunCommand(args, env, os.Stdin, os.Stdout, os.Stderr)
+		}
+
 		if err != nil || exitCode != 0 {
 			if silent {
 				os.Exit(exitCode)
 			}
-			utils.ErrExit(err, exitCode, fmt.Sprintf("Error trying to execute command: %s", strings.Join(args, " ")))
+			utils.ErrExit(err, exitCode)
 		}
 	},
 }
@@ -329,6 +355,7 @@ func init() {
 	runCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
 	runCmd.Flags().String("fallback", "", "path to the fallback file.write secrets to this file after connecting to Doppler. secrets will be read from this file if subsequent connections are unsuccessful.")
 	runCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the fallback file. by default the passphrase is computed using your current configuration.")
+	runCmd.Flags().String("command", "", "command to execute (e.g. \"echo hi\")")
 	runCmd.Flags().Bool("no-fallback", false, "disable reading and writing the fallback file")
 	runCmd.Flags().Bool("fallback-readonly", false, "disable modifying the fallback file. secrets can still be read from the file.")
 	runCmd.Flags().Bool("fallback-only", false, "read all secrets directly from the fallback file, without contacting Doppler. secrets will not be updated. (implies --fallback-readonly)")

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -115,7 +115,7 @@ doppler run --token=123 -- YOUR_COMMAND --your-flag`,
 			}
 		}
 
-		exitCode, err := utils.RunCommand(args, env)
+		exitCode, err := utils.RunCommand(args, env, os.Stdin, os.Stdout, os.Stderr)
 		if err != nil || exitCode != 0 {
 			if silent {
 				os.Exit(exitCode)

--- a/pkg/cmd/settings.go
+++ b/pkg/cmd/settings.go
@@ -58,7 +58,7 @@ var settingsUpdateCmd = &cobra.Command{
 		name := cmd.Flag("name").Value.String()
 		email := cmd.Flag("email").Value.String()
 		if name == "" && email == "" {
-			return errors.New("Error: command needs flag --name or --email")
+			return errors.New("command needs flag --name or --email")
 		}
 
 		return nil

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -101,7 +101,7 @@ func Cwd() string {
 }
 
 // RunCommand runs the specified command
-func RunCommand(command []string, env []string) (int, error) {
+func RunCommand(command []string, env []string, inFile *os.File, outFile *os.File, errFile *os.File) (int, error) {
 	shell := [2]string{"sh", "-c"}
 	if IsWindows() {
 		shell = [2]string{"cmd", "/C"}
@@ -109,9 +109,9 @@ func RunCommand(command []string, env []string) (int, error) {
 
 	cmd := exec.Command(shell[0], shell[1], strings.Join(command, " ")) // #nosec G204
 	cmd.Env = env
-	cmd.Stdin = os.Stdin
-	cmd.Stdout = os.Stdout
-	cmd.Stderr = os.Stderr
+	cmd.Stdin = inFile
+	cmd.Stdout = outFile
+	cmd.Stderr = errFile
 
 	if err := cmd.Run(); err != nil {
 		if exitError, ok := err.(*exec.ExitError); ok {


### PR DESCRIPTION
`doppler run` can now execute sequences of commands like `node && node` via the --command flag. Without quoting that sequence, the shell interprets `doppler run -- node && node` as `(doppler run -- node) && node`. The second node process executes outside of the context of the CLI and thus will not have access to any Doppler secrets. By encapsulating the command in quotes, it allows the CLI to receive and execute the entire sequence of commands.

Note that this is a breaking change and will require a major version bump (v3).