### PR TITLE
Fix macOS .pkg file name

### DIFF
--- a/scripts/post-release.sh
+++ b/scripts/post-release.sh
@@ -3,8 +3,6 @@
 set -e
 
 VERSION=$(git describe --abbrev=0)
-# remove leading 'v'
-VERSION=${VERSION:1}
 
 echo "Building macOS pkg"
 


### PR DESCRIPTION
The version's major number was getting cut off (e.g. '3.0.0' became '.0.0').