### PR TITLE
Increase the verbosity of the doppler run command

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -90,6 +90,7 @@ func loadFlags(cmd *cobra.Command) {
 	http.TimeoutDuration = utils.GetDurationFlagIfChanged(cmd, "timeout", http.TimeoutDuration)
 	http.UseTimeout = !utils.GetBoolFlagIfChanged(cmd, "no-timeout", !http.UseTimeout)
 	utils.Debug = utils.GetBoolFlagIfChanged(cmd, "debug", utils.Debug)
+	utils.Silent = utils.GetBoolFlagIfChanged(cmd, "silent", utils.Silent)
 	utils.OutputJSON = utils.GetBoolFlagIfChanged(cmd, "json", utils.OutputJSON)
 	version.PerformVersionCheck = !utils.GetBoolFlagIfChanged(cmd, "no-check-version", !version.PerformVersionCheck)
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -181,6 +181,11 @@ var runCleanCmd = &cobra.Command{
 		deleted := 0
 		now := time.Now()
 
+		action := "Deleted"
+		if dryRun {
+			action = "Would have deleted"
+		}
+
 		for _, entry := range entries {
 			if entry.IsDir() {
 				continue
@@ -188,27 +193,23 @@ var runCleanCmd = &cobra.Command{
 
 			validUntil := entry.ModTime().Add(maxAge)
 			if validUntil.Before(now) {
+				file := filepath.Join(defaultFallbackDir, entry.Name())
+				utils.LogDebug(fmt.Sprintf("%s %s", action, file))
+
 				if dryRun {
 					deleted++
-				} else {
-					file := filepath.Join(defaultFallbackDir, entry.Name())
-					utils.LogDebug(fmt.Sprintf("Deleting fallback file %s", file))
+					continue
+				}
 
-					err := os.Remove(file)
-					if err != nil {
-						// don't exit
-						utils.Log(fmt.Sprintf("Unable to delete fallback file %s\n", file))
-						utils.LogDebugError(err)
-					} else {
-						deleted++
-					}
+				err := os.Remove(file)
+				if err != nil {
+					// don't exit
+					utils.Log(fmt.Sprintf("Unable to delete fallback file %s\n", file))
+					utils.LogDebugError(err)
+				} else {
+					deleted++
 				}
 			}
-		}
-
-		action := "Deleted"
-		if dryRun {
-			action = "Would have deleted"
 		}
 
 		if deleted == 1 {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -115,7 +115,7 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 			}
 		}
 
-		secrets := getSecrets(cmd, localConfig, enableFallback, fallbackPath, fallbackReadonly, fallbackOnly, exitOnWriteFailure, passphrase)
+		secrets := getSecrets(localConfig, enableFallback, fallbackPath, fallbackReadonly, fallbackOnly, exitOnWriteFailure, passphrase)
 
 		env := os.Environ()
 		excludedKeys := []string{"PATH", "PS1", "HOME"}
@@ -224,7 +224,7 @@ var runCleanCmd = &cobra.Command{
 	},
 }
 
-func getSecrets(cmd *cobra.Command, localConfig models.ScopedOptions, enableFallback bool, fallbackPath string, fallbackReadonly bool, fallbackOnly bool, exitOnWriteFailure bool, passphrase string) map[string]string {
+func getSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbackPath string, fallbackReadonly bool, fallbackOnly bool, exitOnWriteFailure bool, passphrase string) map[string]string {
 	fetchSecrets := !(enableFallback && fallbackOnly)
 	if !fetchSecrets {
 		return readFallbackFile(fallbackPath, localConfig, passphrase)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -69,6 +69,7 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 		fallbackOnly := utils.GetBoolFlag(cmd, "fallback-only")
 		exitOnWriteFailure := !utils.GetBoolFlag(cmd, "no-exit-on-write-failure")
 		silent := utils.GetBoolFlag(cmd, "silent")
+		silentExit := utils.GetBoolFlag(cmd, "silent-exit")
 		localConfig := configuration.LocalConfig(cmd)
 
 		utils.RequireValue("token", localConfig.Token.Value)
@@ -143,7 +144,7 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 		}
 
 		if err != nil || exitCode != 0 {
-			if silent {
+			if silentExit {
 				os.Exit(exitCode)
 			}
 			utils.ErrExit(err, exitCode)
@@ -360,7 +361,8 @@ func init() {
 	runCmd.Flags().Bool("fallback-readonly", false, "disable modifying the fallback file. secrets can still be read from the file.")
 	runCmd.Flags().Bool("fallback-only", false, "read all secrets directly from the fallback file, without contacting Doppler. secrets will not be updated. (implies --fallback-readonly)")
 	runCmd.Flags().Bool("no-exit-on-write-failure", false, "do not exit if unable to write the fallback file")
-	runCmd.Flags().Bool("silent", false, "disable error output if the supplied command exits non-zero")
+	runCmd.Flags().Bool("silent", false, "disable output of info messages")
+	runCmd.Flags().Bool("silent-exit", false, "disable error output if the supplied command exits non-zero")
 	rootCmd.AddCommand(runCmd)
 
 	runCleanCmd.Flags().Duration("max-age", defaultFallbackFileMaxAge, "delete fallback files that exceed this age")

--- a/pkg/http/github.go
+++ b/pkg/http/github.go
@@ -52,12 +52,8 @@ func CheckCLIVersion(versionCheck models.VersionCheck, silent bool, json bool, d
 	utils.LogDebug("Checking for latest version of the CLI")
 	tag, err := getLatestVersion()
 	if err != nil {
-		if debug && !json {
-			utils.LogError(err)
-		}
-		if !silent && !json {
-			utils.LogError(errors.New("Unable to check for CLI updates"))
-		}
+		utils.LogError(errors.New("Unable to check for CLI updates"))
+		utils.LogDebugError(err)
 		return models.VersionCheck{}
 	}
 

--- a/pkg/utils/config.go
+++ b/pkg/utils/config.go
@@ -18,5 +18,8 @@ package utils
 // Debug whether we're running in debug mode
 var Debug = false
 
+// Silent whether we should display Info messages
+var Silent = false
+
 // OutputJSON whether to print OutputJSON
 var OutputJSON = false

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -18,14 +18,16 @@ package utils
 import (
 	"encoding/json"
 	"fmt"
-	"gopkg.in/gookit/color.v1"
 	"os"
 	"runtime/debug"
+
+	"gopkg.in/gookit/color.v1"
 )
 
 // Log info to stdout
 func Log(info string) {
-	if !OutputJSON || Debug {
+	silent := Silent || OutputJSON
+	if Debug || !silent {
 		fmt.Println(info)
 	}
 }

--- a/pkg/utils/log.go
+++ b/pkg/utils/log.go
@@ -32,6 +32,14 @@ func Log(info string) {
 	}
 }
 
+// LogError prints an error message to stderr
+func LogError(e error) {
+	silent := Silent || OutputJSON
+	if Debug || !silent {
+		printError(e)
+	}
+}
+
 // LogDebug prints a debug message to stdout
 func LogDebug(s string) {
 	if Debug {
@@ -39,9 +47,11 @@ func LogDebug(s string) {
 	}
 }
 
-// LogError prints an error message to stderr
-func LogError(e error) {
-	fmt.Fprintln(os.Stderr, color.Red.Render("Doppler Error:"), e)
+// LogDebugError prints an error message to stderr when in debug mode
+func LogDebugError(e error) {
+	if Debug {
+		printError(e)
+	}
 }
 
 // HandleError prints the error and exits with code 1
@@ -58,13 +68,11 @@ func ErrExit(e error, exitCode int, messages ...string) {
 		}
 		fmt.Fprintln(os.Stderr, string(resp))
 	} else {
-		if len(messages) > 0 {
-			for _, message := range messages[0:1] {
-				fmt.Fprintln(os.Stderr, message)
-			}
+		if len(messages) > 0 && messages[0] != "" {
+			fmt.Fprintln(os.Stderr, messages[0])
 		}
 
-		LogError(e)
+		printError(e)
 
 		if len(messages) > 0 {
 			for _, message := range messages[1:] {
@@ -79,4 +87,8 @@ func ErrExit(e error, exitCode int, messages ...string) {
 	}
 
 	os.Exit(exitCode)
+}
+
+func printError(e error) {
+	fmt.Fprintln(os.Stderr, color.Red.Render("Doppler Error:"), e)
 }


### PR DESCRIPTION
More errors are printed by default, and existing printed errors contain more information.