### PR TITLE
Auto-select sole project/config during 'enclave setup'

### DIFF
--- a/pkg/cmd/enclave_setup.go
+++ b/pkg/cmd/enclave_setup.go
@@ -42,21 +42,17 @@ var setupCmd = &cobra.Command{
 
 		utils.RequireValue("token", localConfig.Token.Value)
 
-		flagsFromEnvironment := []string{}
 
-		originalProject := localConfig.EnclaveProject.Value
+		currentProject := localConfig.EnclaveProject.Value
 		selectedProject := ""
+
 		switch localConfig.EnclaveProject.Source {
 		case models.FlagSource.String():
 			selectedProject = localConfig.EnclaveProject.Value
 		case models.EnvironmentSource.String():
-			flagsFromEnvironment = append(flagsFromEnvironment, "ENCLAVE_PROJECT")
+			utils.Log(valueFromEnvironmentNotice("ENCLAVE_PROJECT"))
 			selectedProject = localConfig.EnclaveProject.Value
 		default:
-			if !promptUser {
-				utils.HandleError(errors.New("project must be specified via --project flag or ENCLAVE_PROJECT environment variable when using --no-prompt"))
-			}
-
 			projects, httpErr := http.GetProjects(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value)
 			if !httpErr.IsNil() {
 				utils.HandleError(httpErr.Unwrap(), httpErr.Message)
@@ -65,51 +61,22 @@ var setupCmd = &cobra.Command{
 				utils.HandleError(errors.New("you do not have access to any projects"))
 			}
 
-			var options []string
-			var defaultOption string
-			for _, val := range projects {
-				option := val.Name + " (" + val.ID + ")"
-				options = append(options, option)
-
-				// reselect previously-configured value
-				if val.ID == scopedConfig.EnclaveProject.Value {
-					defaultOption = option
-				}
-			}
-
-			prompt := &survey.Select{
-				Message: "Select a project:",
-				Options: options,
-			}
-			if defaultOption != "" {
-				prompt.Default = defaultOption
-			}
-			err := survey.AskOne(prompt, &selectedProject)
-			if err != nil {
-				utils.HandleError(err)
-			}
-
-			for _, val := range projects {
-				if strings.HasSuffix(selectedProject, "("+val.ID+")") {
-					selectedProject = val.ID
-					break
-				}
+			selectedProject = selectProject(projects, scopedConfig.EnclaveProject.Value, promptUser)
+			if selectedProject == "" {
+				utils.HandleError(errors.New("Invalid project"))
 			}
 		}
 
+		selectedConfiguredProject := selectedProject == currentProject
 		selectedConfig := ""
+
 		switch localConfig.EnclaveConfig.Source {
 		case models.FlagSource.String():
 			selectedConfig = localConfig.EnclaveConfig.Value
 		case models.EnvironmentSource.String():
-			flagsFromEnvironment = append(flagsFromEnvironment, "ENCLAVE_CONFIG")
+			utils.Log(valueFromEnvironmentNotice("ENCLAVE_CONFIG"))
 			selectedConfig = localConfig.EnclaveConfig.Value
 		default:
-			if !promptUser {
-				utils.HandleError(errors.New("config must be specified via --config flag or ENCLAVE_CONFIG environment variable when using --no-prompt"))
-			}
-
-			// Get Configs
 			configs, apiError := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, selectedProject)
 			if !apiError.IsNil() {
 				utils.HandleError(apiError.Unwrap(), apiError.Message)
@@ -118,46 +85,102 @@ var setupCmd = &cobra.Command{
 				utils.HandleError(errors.New("your project does not have any configs"))
 			}
 
-			var options []string
-			var defaultOption string
-			for _, val := range configs {
-				option := val.Name
-				options = append(options, option)
-				// reselect previously-configured value
-				if selectedProject == originalProject && val.Name == scopedConfig.EnclaveConfig.Value {
-					defaultOption = val.Name
-				}
-			}
-
-			prompt := &survey.Select{
-				Message: "Select a config:",
-				Options: options,
-			}
-			if defaultOption != "" {
-				prompt.Default = defaultOption
-			}
-			err := survey.AskOne(prompt, &selectedConfig)
-			if err != nil {
-				utils.HandleError(err)
+			selectedConfig = selectConfig(configs, selectedConfiguredProject, scopedConfig.EnclaveConfig.Value, promptUser)
+			if selectedConfig == "" {
+				utils.HandleError(errors.New("Invalid config"))
 			}
 		}
 
-		configuration.Set(scope, map[string]string{
+		configToSave := map[string]string{
 			models.ConfigEnclaveProject.String(): selectedProject,
 			models.ConfigEnclaveConfig.String():  selectedConfig,
-		})
+		}
+		configuration.Set(scope, configToSave)
 
 		if !silent {
-			if len(flagsFromEnvironment) > 0 {
-				fmt.Println("Using " + strings.Join(flagsFromEnvironment, " and ") + " from the environment. To disable this, use --no-read-env.")
-			}
-
 			// do not fetch the LocalConfig since we do not care about env variables or cmd flags
 			conf := configuration.Get(scope)
 			valuesToPrint := []string{models.ConfigEnclaveConfig.String(), models.ConfigEnclaveProject.String()}
 			printer.ScopedConfigValues(conf, valuesToPrint, models.ScopedPairs(&conf), utils.OutputJSON, false, false)
 		}
 	},
+}
+
+func selectProject(projects []models.ProjectInfo, prevConfiguredProject string, promptUser bool) string {
+	var options []string
+	var defaultOption string
+	for _, val := range projects {
+		option := val.Name + " (" + val.ID + ")"
+		options = append(options, option)
+
+		if val.ID == prevConfiguredProject {
+			defaultOption = option
+		}
+	}
+
+	if !promptUser {
+		utils.HandleError(errors.New("project must be specified via --project flag or ENCLAVE_PROJECT environment variable when using --no-prompt"))
+	}
+
+	prompt := &survey.Select{
+		Message: "Select a project:",
+		Options: options,
+	}
+	if defaultOption != "" {
+		prompt.Default = defaultOption
+	}
+
+	selectedProject := ""
+	err := survey.AskOne(prompt, &selectedProject)
+	if err != nil {
+		utils.HandleError(err)
+	}
+
+	for _, val := range projects {
+		if strings.HasSuffix(selectedProject, "("+val.ID+")") {
+			return val.ID
+		}
+	}
+
+	return ""
+}
+
+func selectConfig(configs []models.ConfigInfo, selectedConfiguredProject bool, prevConfiguredConfig string, promptUser bool) string {
+	var options []string
+	var defaultOption string
+	for _, val := range configs {
+		option := val.Name
+		options = append(options, option)
+
+		// make previously selected config the default when re-using the previously selected project
+		if selectedConfiguredProject && val.Name == prevConfiguredConfig {
+			defaultOption = val.Name
+		}
+	}
+
+	if !promptUser {
+		utils.HandleError(errors.New("config must be specified via --config flag or ENCLAVE_CONFIG environment variable when using --no-prompt"))
+	}
+
+	prompt := &survey.Select{
+		Message: "Select a config:",
+		Options: options,
+	}
+	if defaultOption != "" {
+		prompt.Default = defaultOption
+	}
+
+	selectedConfig := ""
+	err := survey.AskOne(prompt, &selectedConfig)
+	if err != nil {
+		utils.HandleError(err)
+	}
+
+	return selectedConfig
+}
+
+func valueFromEnvironmentNotice(name string) string {
+	return fmt.Sprintf("Using %s from the environment. To disable this, use --no-read-env.", name)
 }
 
 func init() {

--- a/pkg/cmd/enclave_setup.go
+++ b/pkg/cmd/enclave_setup.go
@@ -27,6 +27,7 @@ import (
 	"github.com/DopplerHQ/cli/pkg/printer"
 	"github.com/DopplerHQ/cli/pkg/utils"
 	"github.com/spf13/cobra"
+	"gopkg.in/gookit/color.v1"
 )
 
 var setupCmd = &cobra.Command{
@@ -118,6 +119,14 @@ func selectProject(projects []models.ProjectInfo, prevConfiguredProject string, 
 		}
 	}
 
+	if len(projects) == 1 {
+		// the user is expecting to a prompt, so print a message instead
+		if promptUser {
+			utils.Log(fmt.Sprintf("%s %s", color.Bold.Render("Selected only available project:"), options[0]))
+		}
+		return projects[0].ID
+	}
+
 	if !promptUser {
 		utils.HandleError(errors.New("project must be specified via --project flag or ENCLAVE_PROJECT environment variable when using --no-prompt"))
 	}
@@ -156,6 +165,15 @@ func selectConfig(configs []models.ConfigInfo, selectedConfiguredProject bool, p
 		if selectedConfiguredProject && val.Name == prevConfiguredConfig {
 			defaultOption = val.Name
 		}
+	}
+
+	if len(configs) == 1 {
+		config := configs[0].Name
+		// the user is expecting to a prompt, so print a message instead
+		if promptUser {
+			utils.Log(fmt.Sprintf("%s %s", color.Bold.Render("Selected only available config:"), config))
+		}
+		return config
 	}
 
 	if !promptUser {


### PR DESCRIPTION
- Auto-select sole project/config during 'enclave setup'
- Save token during 'enclave setup` when passed via flag/env

With these two changes, it is now sufficient to run `doppler enclave setup --token=$TOKEN --no-prompt` to fully configure a service token. The project and config are no longer required, and neither is the call to `doppler configure`.