### PR TITLE
Install CLI deb/npm package to /usr/bin

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -191,6 +191,7 @@ nfpms:
     maintainer: Doppler Bot <bot@doppler.com>
     description: "The official Doppler CLI for managing your secrets and config"
     license: Apache-2.0
+    bindir: /usr/bin
     formats:
       - deb
       - rpm


### PR DESCRIPTION
Previous install location was /usr/local/bin/. This may require uninstalling and reinstalling the package.