### PR TITLE
Standardize logging of info messages

### DIFF
--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -191,9 +191,8 @@ Print your secrets to stdout in env format without writing to the filesystem
 $ doppler enclave secrets download --format=env --no-file`,
 	Args: cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
+		// don't log anything extraneous when printing to stdout
 		saveFile := !utils.GetBoolFlag(cmd, "no-file")
-		// don't log anything extraneous when printing secrets to stdout
-		silent := !saveFile || utils.GetBoolFlag(cmd, "silent")
 		jsonFlag := utils.OutputJSON
 		localConfig := configuration.LocalConfig(cmd)
 
@@ -264,9 +263,7 @@ $ doppler enclave secrets download --format=env --no-file`,
 			utils.HandleError(err, "Unable to write the secrets file")
 		}
 
-		if !silent {
-			fmt.Println("Downloaded secrets to " + filePath)
-		}
+		utils.Log(fmt.Sprintf("Downloaded secrets to %s", filePath))
 	},
 }
 

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -50,19 +50,14 @@ var loginCmd = &cobra.Command{
 		code := response["code"].(string)
 		authURL := response["auth_url"].(string)
 
-		if !silent {
-			fmt.Print("Your auth code is ")
-			color.Green.Println(code)
-		}
+		utils.Log(fmt.Sprintf("Your auth code is %s", color.Green.Render(code)))
 
 		if copyAuthCode {
 			utils.CopyToClipboard(code)
 		}
 
-		if !silent {
-			fmt.Println("")
-			fmt.Println("Complete login at", authURL)
-		}
+		utils.Log("")
+		utils.Log(fmt.Sprintf("Complete login at %s", authURL))
 
 		if silent || utils.ConfirmationPrompt("Open this URL in your browser?", true) {
 			err := open.Run(authURL)
@@ -71,9 +66,7 @@ var loginCmd = &cobra.Command{
 			}
 		}
 
-		if !silent {
-			fmt.Println("Waiting...")
-		}
+		utils.Log("Waiting...")
 
 		// auth flow must complete within 5 minutes
 		timeout := 5 * time.Minute
@@ -105,10 +98,8 @@ var loginCmd = &cobra.Command{
 		}
 
 		if err, ok := response["error"]; ok {
-			if !silent {
-				fmt.Println("")
-				fmt.Println(err)
-			}
+			utils.Log("")
+			utils.Log(fmt.Sprint(err))
 
 			os.Exit(1)
 		}
@@ -130,10 +121,8 @@ var loginCmd = &cobra.Command{
 
 		configuration.Set(scope, options)
 
-		if !silent {
-			fmt.Println("")
-			fmt.Println("Welcome, " + name)
-		}
+		utils.Log("")
+		utils.Log(fmt.Sprintf("Welcome, %s", name))
 
 		if prevConfig.Token.Value != "" {
 			prevScope, err1 := filepath.Abs(prevConfig.Token.Scope)
@@ -161,7 +150,6 @@ Your saved configuration will be updated.`,
 	Args: cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		localConfig := configuration.LocalConfig(cmd)
-		silent := utils.GetBoolFlag(cmd, "silent")
 		updateConfig := !utils.GetBoolFlag(cmd, "no-update-config")
 
 		utils.RequireValue("token", localConfig.Token.Value)
@@ -184,9 +172,7 @@ Your saved configuration will be updated.`,
 			}
 		}
 
-		if !silent {
-			fmt.Println("Auth token has been rolled")
-		}
+		utils.Log("Auth token has been rolled")
 	},
 }
 

--- a/pkg/cmd/logout.go
+++ b/pkg/cmd/logout.go
@@ -38,7 +38,6 @@ This is an alias of the "login revoke" command.`,
 
 func revokeToken(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
-	silent := utils.GetBoolFlag(cmd, "silent")
 	updateConfig := !utils.GetBoolFlag(cmd, "no-update-config")
 	verifyTLS := utils.GetBool(localConfig.VerifyTLS.Value, true)
 	yes := utils.GetBoolFlag(cmd, "yes")
@@ -64,9 +63,7 @@ func revokeToken(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	if !silent {
-		fmt.Println("Auth token has been revoked")
-	}
+	utils.Log("Auth token has been revoked")
 }
 
 func init() {

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -79,7 +79,7 @@ func checkVersion(command string, silent bool, print bool) {
 	}
 
 	if version.ProgramVersion != versionCheck.LatestVersion {
-		fmt.Printf("Doppler CLI %s is now available\n", versionCheck.LatestVersion)
+		utils.Log(fmt.Sprintf("Doppler CLI %s is now available\n", versionCheck.LatestVersion))
 	}
 
 	configuration.SetVersionCheck(versionCheck)

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -45,7 +45,7 @@ func installedViaBrew() bool {
 }
 
 func brewUpdate() {
-	fmt.Println("Updating via Homebrew...")
+	utils.Log("Updating via Homebrew...")
 	command := []string{"brew", "upgrade", "--fetch-HEAD", "doppler"}
 	out, err := exec.Command(command[0], command[1:]...).CombinedOutput() // #nosec G204
 	strOut := string(out)
@@ -54,22 +54,22 @@ func brewUpdate() {
 	}
 
 	if err != nil {
-		utils.HandleError(err, "Failed to update the Doppler CLI")
+		utils.HandleError(err, "Unable to update the Doppler CLI")
 	}
 
 	re := regexp.MustCompile(`Upgrading dopplerhq\/doppler\/doppler (\d+\.\d+\.\d+) -> (\d+\.\d+\.\d+)`)
 	if matches := re.FindStringSubmatch(strOut); matches != nil {
 		if len(matches) >= 2 {
-			fmt.Printf("Doppler CLI was upgraded to v%s!\n", matches[2])
+			utils.Log(fmt.Sprintf("Doppler CLI was upgraded to v%s!\n", matches[2]))
 		} else {
-			fmt.Println("Doppler CLI was upgraded!")
+			utils.Log("Doppler CLI was upgraded!")
 		}
 		return
 	}
 
 	re = regexp.MustCompile(`Warning: dopplerhq\/doppler\/doppler \d+\.\d+\.\d+ already installed`)
 	if loc := re.FindStringIndex(strOut); loc != nil {
-		fmt.Println("You are already running the latest version")
+		utils.Log("You are already running the latest version")
 	}
 }
 


### PR DESCRIPTION
`utils.Log` has built-in logic for handling `--silent` `--debug` and `--json` flags.