### PR TITLE
Add dopplerhq/cli-action example

### DIFF
--- a/.github/workflows/cli-action.yml
+++ b/.github/workflows/cli-action.yml
@@ -1,0 +1,26 @@
+name: Test CLI action
+
+on: [push]
+
+jobs:
+  ubuntu:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Install CLI
+      uses: dopplerhq/cli-action@v1
+    - name: Test CLI
+      run: doppler --version
+  windows:
+    runs-on: windows-latest
+    steps:
+    - name: Install CLI
+      uses: dopplerhq/cli-action@v1
+    - name: Test CLI
+      run: doppler --version
+  macOS:
+    runs-on: macos-latest
+    steps:
+    - name: Install CLI
+      uses: dopplerhq/cli-action@v1
+    - name: Test CLI
+      run: doppler --version

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -99,6 +99,10 @@ We currently publish these Docker tags:
 
 You can find all source Dockerfiles in the `/docker` folder ([here](https://github.com/DopplerHQ/cli/tree/master/docker)).
 
+## GitHub Action
+
+You can install the latest version of the CLI via GitHub Action. See the cli-action [repo](https://github.com/DopplerHQ/cli-action) for more info.
+
 ### Example
 Here's an example Dockerfile for a Node app:
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ The Doppler CLI is the official tool for interacting with your Enclave secrets a
 
 ## Install
 
-The Doppler CLI is available in several popular package managers. It can also be installed via [shell script](https://github.com/DopplerHQ/cli/blob/master/INSTALL.md#shell-script), and downloaded as a [standalone binary](https://github.com/DopplerHQ/cli/releases/latest).
+The Doppler CLI is available in several popular package managers. It can also be installed via [shell script](https://github.com/DopplerHQ/cli/blob/master/INSTALL.md#shell-script), [GitHub Action](https://github.com/DopplerHQ/cli-action), or downloaded as a [standalone binary](https://github.com/DopplerHQ/cli/releases/latest).
 
 For more info, including instructions on verifying binary signatures, see the [Install](INSTALL.md) page.
 
@@ -69,6 +69,10 @@ We currently build these Docker images:
 - `dopplerhq/cli:ruby` based on `ruby:2-alpine`
 
 For more info, see the [Install](INSTALL.md#docker) page.
+
+### GitHub Action
+
+You can install the latest version of the CLI via GitHub Action. See the cli-action [repo](https://github.com/DopplerHQ/cli-action) for more info.
 
 ## Usage
 


### PR DESCRIPTION
This provides a live example of a GitHub Action utilizing dopplerhq/cli-action. It secondarily provides weak evidence that the cli-action is still working (this isn't integrated into the release pipeline, so it definitely isn't a smoke test).