### PR TITLE
Add additional checking for required parameters

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -159,7 +159,7 @@ dockers:
 
 brews:
   - name: doppler
-    github:
+    tap:
       owner: DopplerHQ
       name: homebrew-doppler
     commit_author:

--- a/pkg/cmd/enclave_configs_logs.go
+++ b/pkg/cmd/enclave_configs_logs.go
@@ -61,6 +61,7 @@ var configsLogsGetCmd = &cobra.Command{
 		if len(args) > 0 {
 			log = args[0]
 		}
+		utils.RequireValue("log", log)
 
 		configLog, err := http.GetConfigLog(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, log)
 		if !err.IsNil() {
@@ -88,6 +89,7 @@ var configsLogsRollbackCmd = &cobra.Command{
 		if len(args) > 0 {
 			log = args[0]
 		}
+		utils.RequireValue("log", log)
 
 		configLog, err := http.RollbackConfigLog(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, log)
 		if !err.IsNil() {

--- a/pkg/cmd/enclave_configs_tokens.go
+++ b/pkg/cmd/enclave_configs_tokens.go
@@ -62,6 +62,7 @@ var configsTokensGetCmd = &cobra.Command{
 		if len(args) > 0 {
 			slug = args[0]
 		}
+		utils.RequireValue("slug", slug)
 
 		tokens, err := http.GetConfigServiceTokens(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 		if !err.IsNil() {
@@ -97,6 +98,7 @@ var configsTokensCreateCmd = &cobra.Command{
 		if len(args) > 0 {
 			name = args[0]
 		}
+		utils.RequireValue("name", name)
 
 		configToken, err := http.CreateConfigServiceToken(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, name)
 		if !err.IsNil() {
@@ -125,6 +127,7 @@ var configsTokensRevokeCmd = &cobra.Command{
 		if len(args) > 0 {
 			slug = args[0]
 		}
+		utils.RequireValue("slug", slug)
 
 		err := http.DeleteConfigServiceToken(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, slug)
 		if !err.IsNil() {


### PR DESCRIPTION
This allows us to quickly show an error instead of trying the request (and failing).