### PR TITLE
Warn user during login if scope already contains a token

### DIFF
--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -43,6 +43,15 @@ var loginCmd = &cobra.Command{
 		copyAuthCode := !utils.GetBoolFlag(cmd, "no-copy")
 		hostname, _ := os.Hostname()
 
+		// warn user if scope already contains a token
+		if prevConfig.Token.Value != "" {
+			prevScope, err1 := filepath.Abs(prevConfig.Token.Scope)
+			newScope, err2 := filepath.Abs(scope)
+			if err1 == nil && err2 == nil && prevScope == newScope {
+				utils.LogWarning("This scope already contains a token and will be overridden.")
+			}
+		}
+
 		response, err := http.GenerateAuthCode(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), hostname, utils.HostOS(), utils.HostArch())
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)


### PR DESCRIPTION
This warning is consistent with how we handle other warnings in the CLI. We show a message with yellow warning text, but otherwise don't get in the user's way.

<img width="623" alt="Screen Shot 2020-07-08 at 3 07 14 PM" src="https://user-images.githubusercontent.com/8296030/87003031-b75bd180-c16f-11ea-97f6-b5f3891d1213.png">
