### PR TITLE
Add support for running additional shells

### DIFF
--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -60,7 +60,9 @@ var loginCmd = &cobra.Command{
 		authURL := response["auth_url"].(string)
 
 		if copyAuthCode {
-			utils.CopyToClipboard(code)
+			if err := utils.CopyToClipboard(code); err != nil {
+				utils.LogWarning("Unable to copy to clipboard")
+			}
 		}
 
 		openBrowser := silent || utils.ConfirmationPrompt("Open the authorization page in your browser?", true)

--- a/pkg/printer/print.go
+++ b/pkg/printer/print.go
@@ -263,7 +263,9 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 			}
 		}
 
-		utils.CopyToClipboard(strings.Join(vals, "\n"))
+		if err := utils.CopyToClipboard(strings.Join(vals, "\n")); err != nil {
+			utils.HandleError(err, "Unable to copy to clipboard")
+		}
 	}
 
 	if jsonFlag {
@@ -421,7 +423,9 @@ func ScopedConfigValues(conf models.ScopedOptions, args []string, values map[str
 
 		print := strings.Join(vals, "\n")
 		if copy {
-			utils.CopyToClipboard(print)
+			if err := utils.CopyToClipboard(print); err != nil {
+				utils.HandleError(err, "Unable to copy to clipboard")
+			}
 		}
 
 		if plain {
@@ -524,7 +528,9 @@ func ConfigServiceTokenInfo(token models.ConfigServiceToken, jsonFlag bool) {
 // ConfigServiceToken print config service token and its info
 func ConfigServiceToken(token models.ConfigServiceToken, jsonFlag bool, plain bool, copy bool) {
 	if copy {
-		utils.CopyToClipboard(token.Token)
+		if err := utils.CopyToClipboard(token.Token); err != nil {
+			utils.HandleError(err, "Unable to copy to clipboard")
+		}
 	}
 
 	if plain {

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -120,6 +120,16 @@ func RunCommandString(command string, env []string, inFile *os.File, outFile *os
 	shell := [2]string{"sh", "-c"}
 	if IsWindows() {
 		shell = [2]string{"cmd", "/C"}
+	} else {
+		// these shells all support the same options we use for sh
+		shells := []string{"/bash", "/dash", "/fish", "/zsh", "/ksh", "/csh", "/tcsh"}
+		envShell := os.Getenv("SHELL")
+		for _, s := range shells {
+			if strings.HasSuffix(envShell, s) {
+				shell[0] = envShell
+				break
+			}
+		}
 	}
 	cmd := exec.Command(shell[0], shell[1], command) // #nosec G204
 	cmd.Env = env

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -306,13 +306,14 @@ func ConfirmationPrompt(message string, defaultValue bool) bool {
 }
 
 // CopyToClipboard copies text to the user's clipboard
-func CopyToClipboard(text string) {
+func CopyToClipboard(text string) error {
 	if !clipboard.Unsupported {
 		err := clipboard.WriteAll(text)
 		if err != nil {
-			HandleError(err, "Unable to copy to clipboard")
+			return err
 		}
 	}
+	return nil
 }
 
 // HostOS the host OS


### PR DESCRIPTION
When using `doppler run` with the `--command` flag we now read the preferred shell out of the SHELL env var. We previously always used `sh`.