### PR TITLE
Switch default login scope from "*" to "/"

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -80,6 +80,7 @@ changelog:
     exclude:
     - '^docs:'
     - '^test:'
+    - '^chore:'
     - Merge pull request
     - Merge branch
 

--- a/README.md
+++ b/README.md
@@ -86,7 +86,6 @@ $ doppler enclave setup             # select your project and config
 $ doppler configure --all           # view local configuration
 ```
 
-By default, `doppler login` scopes the auth token globally (`--scope=*`). This means that the token will be accessible to projects using the Doppler CLI from any local directory. To limit this, specify the `scope` flag during login: `doppler login --scope=./` or `doppler login --scope ~/projects/backend`.
+By default, `doppler login` scopes the auth token to the root directory (`--scope=/`). This means that the token will be accessible to projects using the Doppler CLI in any subdirectory. To limit this, specify the `scope` flag during login: `doppler login --scope=./` or `doppler login --scope ~/projects/backend`.
 
 Enclave setup (i.e. `doppler enclave setup`) scopes the enclave project and config to the current directory (`--scope=./`). You can also modify this scope with the `scope` flag. Run `doppler help` for more information.
-

--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -142,7 +142,6 @@ doppler configure set key=123 otherkey=456`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		silent := utils.GetBoolFlag(cmd, "silent")
 		jsonFlag := utils.OutputJSON
 
 		if !strings.Contains(args[0], "=") {
@@ -156,7 +155,7 @@ doppler configure set key=123 otherkey=456`,
 			configuration.Set(configuration.Scope, options)
 		}
 
-		if !silent {
+		if !utils.Silent {
 			printer.ScopedConfig(configuration.Get(configuration.Scope), jsonFlag)
 		}
 	},
@@ -183,12 +182,11 @@ doppler configure unset key otherkey`,
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		silent := utils.GetBoolFlag(cmd, "silent")
 		jsonFlag := utils.OutputJSON
 
 		configuration.Unset(configuration.Scope, args)
 
-		if !silent {
+		if !utils.Silent {
 			printer.ScopedConfig(configuration.Get(configuration.Scope), jsonFlag)
 		}
 	},

--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -42,8 +42,7 @@ var configureCmd = &cobra.Command{
 			return
 		}
 
-		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
-		config := configuration.Get(scope)
+		config := configuration.Get(configuration.Scope)
 		printer.ScopedConfig(config, jsonFlag)
 	},
 }
@@ -104,8 +103,7 @@ doppler configure get key otherkey`,
 		plain := utils.GetBoolFlag(cmd, "plain")
 		copy := utils.GetBoolFlag(cmd, "copy")
 
-		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
-		conf := configuration.Get(scope)
+		conf := configuration.Get(configuration.Scope)
 
 		printer.ScopedConfigValues(conf, args, models.ScopedPairs(&conf), jsonFlag, plain, copy)
 	},
@@ -145,22 +143,21 @@ doppler configure set key=123 otherkey=456`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		silent := utils.GetBoolFlag(cmd, "silent")
-		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
 		jsonFlag := utils.OutputJSON
 
 		if !strings.Contains(args[0], "=") {
-			configuration.Set(scope, map[string]string{args[0]: args[1]})
+			configuration.Set(configuration.Scope, map[string]string{args[0]: args[1]})
 		} else {
 			options := map[string]string{}
 			for _, option := range args {
 				arr := strings.Split(option, "=")
 				options[arr[0]] = arr[1]
 			}
-			configuration.Set(scope, options)
+			configuration.Set(configuration.Scope, options)
 		}
 
 		if !silent {
-			printer.ScopedConfig(configuration.Get(scope), jsonFlag)
+			printer.ScopedConfig(configuration.Get(configuration.Scope), jsonFlag)
 		}
 	},
 }
@@ -189,11 +186,10 @@ doppler configure unset key otherkey`,
 		silent := utils.GetBoolFlag(cmd, "silent")
 		jsonFlag := utils.OutputJSON
 
-		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
-		configuration.Unset(scope, args)
+		configuration.Unset(configuration.Scope, args)
 
 		if !silent {
-			printer.ScopedConfig(configuration.Get(scope), jsonFlag)
+			printer.ScopedConfig(configuration.Get(configuration.Scope), jsonFlag)
 		}
 	},
 }

--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -42,7 +42,7 @@ var configureCmd = &cobra.Command{
 			return
 		}
 
-		scope := cmd.Flag("scope").Value.String()
+		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
 		config := configuration.Get(scope)
 		printer.ScopedConfig(config, jsonFlag)
 	},
@@ -104,7 +104,7 @@ doppler configure get key otherkey`,
 		plain := utils.GetBoolFlag(cmd, "plain")
 		copy := utils.GetBoolFlag(cmd, "copy")
 
-		scope := cmd.Flag("scope").Value.String()
+		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
 		conf := configuration.Get(scope)
 
 		printer.ScopedConfigValues(conf, args, models.ScopedPairs(&conf), jsonFlag, plain, copy)
@@ -145,7 +145,7 @@ doppler configure set key=123 otherkey=456`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		silent := utils.GetBoolFlag(cmd, "silent")
-		scope := cmd.Flag("scope").Value.String()
+		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
 		jsonFlag := utils.OutputJSON
 
 		if !strings.Contains(args[0], "=") {
@@ -189,7 +189,7 @@ doppler configure unset key otherkey`,
 		silent := utils.GetBoolFlag(cmd, "silent")
 		jsonFlag := utils.OutputJSON
 
-		scope := cmd.Flag("scope").Value.String()
+		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
 		configuration.Unset(scope, args)
 
 		if !silent {

--- a/pkg/cmd/enclave_configs.go
+++ b/pkg/cmd/enclave_configs.go
@@ -78,7 +78,6 @@ var configsCreateCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		environment := cmd.Flag("environment").Value.String()
 		localConfig := configuration.LocalConfig(cmd)
 
@@ -107,7 +106,7 @@ var configsCreateCmd = &cobra.Command{
 			utils.HandleError(err.Unwrap(), err.Message)
 		}
 
-		if !silent {
+		if !utils.Silent {
 			printer.ConfigInfo(info, jsonFlag)
 		}
 	},
@@ -119,7 +118,6 @@ var configsDeleteCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
 		localConfig := configuration.LocalConfig(cmd)
 
@@ -138,7 +136,7 @@ var configsDeleteCmd = &cobra.Command{
 				utils.HandleError(err.Unwrap(), err.Message)
 			}
 
-			if !silent {
+			if !utils.Silent {
 				configs, err := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value)
 				if !err.IsNil() {
 					utils.HandleError(err.Unwrap(), err.Message)
@@ -156,7 +154,6 @@ var configsUpdateCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		name := cmd.Flag("name").Value.String()
 		localConfig := configuration.LocalConfig(cmd)
 
@@ -175,7 +172,7 @@ var configsUpdateCmd = &cobra.Command{
 			utils.HandleError(err.Unwrap(), err.Message)
 		}
 
-		if !silent {
+		if !utils.Silent {
 			printer.ConfigInfo(info, jsonFlag)
 		}
 	},
@@ -187,7 +184,6 @@ var configsLockCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
 		localConfig := configuration.LocalConfig(cmd)
 
@@ -206,7 +202,7 @@ var configsLockCmd = &cobra.Command{
 				utils.HandleError(err.Unwrap(), err.Message)
 			}
 
-			if !silent {
+			if !utils.Silent {
 				printer.ConfigInfo(configInfo, jsonFlag)
 			}
 		}
@@ -219,7 +215,6 @@ var configsUnlockCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
 		localConfig := configuration.LocalConfig(cmd)
 
@@ -238,7 +233,7 @@ var configsUnlockCmd = &cobra.Command{
 				utils.HandleError(err.Unwrap(), err.Message)
 			}
 
-			if !silent {
+			if !utils.Silent {
 				printer.ConfigInfo(configInfo, jsonFlag)
 			}
 		}

--- a/pkg/cmd/enclave_configs.go
+++ b/pkg/cmd/enclave_configs.go
@@ -267,17 +267,17 @@ func init() {
 
 	configsDeleteCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	configsDeleteCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
-	configsDeleteCmd.Flags().Bool("yes", false, "proceed without confirmation")
+	configsDeleteCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	configsCmd.AddCommand(configsDeleteCmd)
 
 	configsLockCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	configsLockCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
-	configsLockCmd.Flags().Bool("yes", false, "proceed without confirmation")
+	configsLockCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	configsCmd.AddCommand(configsLockCmd)
 
 	configsUnlockCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	configsUnlockCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
-	configsUnlockCmd.Flags().Bool("yes", false, "proceed without confirmation")
+	configsUnlockCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	configsCmd.AddCommand(configsUnlockCmd)
 
 	enclaveCmd.AddCommand(configsCmd)

--- a/pkg/cmd/enclave_configs_logs.go
+++ b/pkg/cmd/enclave_configs_logs.go
@@ -78,7 +78,6 @@ var configsLogsRollbackCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		localConfig := configuration.LocalConfig(cmd)
 
 		utils.RequireValue("token", localConfig.Token.Value)
@@ -96,7 +95,7 @@ var configsLogsRollbackCmd = &cobra.Command{
 			utils.HandleError(err.Unwrap(), err.Message)
 		}
 
-		if !silent {
+		if !utils.Silent {
 			printer.ConfigLog(configLog, jsonFlag, true)
 		}
 	},

--- a/pkg/cmd/enclave_configs_tokens.go
+++ b/pkg/cmd/enclave_configs_tokens.go
@@ -116,7 +116,6 @@ var configsTokensRevokeCmd = &cobra.Command{
 	Args:    cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		localConfig := configuration.LocalConfig(cmd)
 
 		utils.RequireValue("token", localConfig.Token.Value)
@@ -134,7 +133,7 @@ var configsTokensRevokeCmd = &cobra.Command{
 			utils.HandleError(err.Unwrap(), err.Message)
 		}
 
-		if !silent {
+		if !utils.Silent {
 			tokens, err := http.GetConfigServiceTokens(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 			if !err.IsNil() {
 				utils.HandleError(err.Unwrap(), err.Message)

--- a/pkg/cmd/enclave_projects.go
+++ b/pkg/cmd/enclave_projects.go
@@ -73,7 +73,6 @@ var projectsCreateCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		description := cmd.Flag("description").Value.String()
 		localConfig := configuration.LocalConfig(cmd)
 
@@ -91,7 +90,7 @@ var projectsCreateCmd = &cobra.Command{
 			utils.HandleError(err.Unwrap(), err.Message)
 		}
 
-		if !silent {
+		if !utils.Silent {
 			printer.ProjectInfo(info, jsonFlag)
 		}
 	},
@@ -103,7 +102,6 @@ var projectsDeleteCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
 		localConfig := configuration.LocalConfig(cmd)
 
@@ -121,7 +119,7 @@ var projectsDeleteCmd = &cobra.Command{
 				utils.HandleError(err.Unwrap(), err.Message)
 			}
 
-			if !silent {
+			if !utils.Silent {
 				info, err := http.GetProjects(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value)
 				if !err.IsNil() {
 					utils.HandleError(err.Unwrap(), err.Message)
@@ -139,7 +137,6 @@ var projectsUpdateCmd = &cobra.Command{
 	Args:  cobra.MaximumNArgs(1),
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
-		silent := utils.GetBoolFlag(cmd, "silent")
 		name := cmd.Flag("name").Value.String()
 		description := cmd.Flag("description").Value.String()
 		localConfig := configuration.LocalConfig(cmd)
@@ -159,7 +156,7 @@ var projectsUpdateCmd = &cobra.Command{
 			utils.HandleError(err.Unwrap(), err.Message)
 		}
 
-		if !silent {
+		if !utils.Silent {
 			printer.ProjectInfo(info, jsonFlag)
 		}
 	},

--- a/pkg/cmd/enclave_projects.go
+++ b/pkg/cmd/enclave_projects.go
@@ -173,7 +173,7 @@ func init() {
 	projectsCreateCmd.Flags().String("description", "", "project description")
 	projectsCmd.AddCommand(projectsCreateCmd)
 
-	projectsDeleteCmd.Flags().Bool("yes", false, "proceed without confirmation")
+	projectsDeleteCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	projectsDeleteCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	projectsCmd.AddCommand(projectsDeleteCmd)
 

--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -109,7 +109,6 @@ doppler enclave secrets set API_KEY=123 CRYPTO_KEY=456`,
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
 		raw := utils.GetBoolFlag(cmd, "raw")
-		silent := utils.GetBoolFlag(cmd, "silent")
 		localConfig := configuration.LocalConfig(cmd)
 
 		utils.RequireValue("token", localConfig.Token.Value)
@@ -133,7 +132,7 @@ doppler enclave secrets set API_KEY=123 CRYPTO_KEY=456`,
 			utils.HandleError(err.Unwrap(), err.Message)
 		}
 
-		if !silent {
+		if !utils.Silent {
 			printer.Secrets(response, keys, jsonFlag, false, raw, false)
 		}
 	},
@@ -150,7 +149,6 @@ doppler enclave secrets delete API_KEY CRYPTO_KEY`,
 	Run: func(cmd *cobra.Command, args []string) {
 		jsonFlag := utils.OutputJSON
 		raw := utils.GetBoolFlag(cmd, "raw")
-		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
 		localConfig := configuration.LocalConfig(cmd)
 
@@ -169,7 +167,7 @@ doppler enclave secrets delete API_KEY CRYPTO_KEY`,
 				utils.HandleError(err.Unwrap(), err.Message)
 			}
 
-			if !silent {
+			if !utils.Silent {
 				printer.Secrets(response, []string{}, jsonFlag, false, raw, false)
 			}
 		}

--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -286,7 +286,7 @@ func init() {
 	secretsDeleteCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	secretsDeleteCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
 	secretsDeleteCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
-	secretsDeleteCmd.Flags().Bool("yes", false, "proceed without confirmation")
+	secretsDeleteCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	secretsCmd.AddCommand(secretsDeleteCmd)
 
 	secretsDownloadCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")

--- a/pkg/cmd/enclave_setup.go
+++ b/pkg/cmd/enclave_setup.go
@@ -20,7 +20,6 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/AlecAivazis/survey/v2"
 	"github.com/DopplerHQ/cli/pkg/configuration"
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/models"
@@ -153,20 +152,7 @@ func selectProject(projects []models.ProjectInfo, prevConfiguredProject string, 
 		utils.HandleError(errors.New("project must be specified via --project flag or ENCLAVE_PROJECT environment variable when using --no-prompt"))
 	}
 
-	prompt := &survey.Select{
-		Message: "Select a project:",
-		Options: options,
-	}
-	if defaultOption != "" {
-		prompt.Default = defaultOption
-	}
-
-	selectedProject := ""
-	err := survey.AskOne(prompt, &selectedProject)
-	if err != nil {
-		utils.HandleError(err)
-	}
-
+	selectedProject := utils.SelectPrompt("Select a project:", options, defaultOption)
 	for _, val := range projects {
 		if selectedProject == val.ID || strings.HasSuffix(selectedProject, "("+val.ID+")") {
 			return val.ID
@@ -202,20 +188,7 @@ func selectConfig(configs []models.ConfigInfo, selectedConfiguredProject bool, p
 		utils.HandleError(errors.New("config must be specified via --config flag or ENCLAVE_CONFIG environment variable when using --no-prompt"))
 	}
 
-	prompt := &survey.Select{
-		Message: "Select a config:",
-		Options: options,
-	}
-	if defaultOption != "" {
-		prompt.Default = defaultOption
-	}
-
-	selectedConfig := ""
-	err := survey.AskOne(prompt, &selectedConfig)
-	if err != nil {
-		utils.HandleError(err)
-	}
-
+	selectedConfig := utils.SelectPrompt("Select a config:", options, defaultOption)
 	return selectedConfig
 }
 

--- a/pkg/cmd/enclave_setup.go
+++ b/pkg/cmd/enclave_setup.go
@@ -37,9 +37,8 @@ var setupCmd = &cobra.Command{
 		silent := utils.GetBoolFlag(cmd, "silent")
 		promptUser := !utils.GetBoolFlag(cmd, "no-prompt")
 		canSaveToken := !utils.GetBoolFlag(cmd, "no-save-token")
-		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
 		localConfig := configuration.LocalConfig(cmd)
-		scopedConfig := configuration.Get(scope)
+		scopedConfig := configuration.Get(configuration.Scope)
 
 		utils.RequireValue("token", localConfig.Token.Value)
 
@@ -111,11 +110,11 @@ var setupCmd = &cobra.Command{
 		if saveToken {
 			configToSave[models.ConfigToken.String()] = localConfig.Token.Value
 		}
-		configuration.Set(scope, configToSave)
+		configuration.Set(configuration.Scope, configToSave)
 
 		if !silent {
 			// do not fetch the LocalConfig since we do not care about env variables or cmd flags
-			conf := configuration.Get(scope)
+			conf := configuration.Get(configuration.Scope)
 			valuesToPrint := []string{models.ConfigEnclaveConfig.String(), models.ConfigEnclaveProject.String()}
 			if saveToken {
 				valuesToPrint = append(valuesToPrint, models.ConfigToken.String())

--- a/pkg/cmd/enclave_setup.go
+++ b/pkg/cmd/enclave_setup.go
@@ -37,7 +37,7 @@ var setupCmd = &cobra.Command{
 		silent := utils.GetBoolFlag(cmd, "silent")
 		promptUser := !utils.GetBoolFlag(cmd, "no-prompt")
 		canSaveToken := !utils.GetBoolFlag(cmd, "no-save-token")
-		scope := cmd.Flag("scope").Value.String()
+		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
 		localConfig := configuration.LocalConfig(cmd)
 		scopedConfig := configuration.Get(scope)
 

--- a/pkg/cmd/enclave_setup.go
+++ b/pkg/cmd/enclave_setup.go
@@ -34,7 +34,6 @@ var setupCmd = &cobra.Command{
 	Short: "Setup the Doppler CLI for Enclave",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		silent := utils.GetBoolFlag(cmd, "silent")
 		promptUser := !utils.GetBoolFlag(cmd, "no-prompt")
 		canSaveToken := !utils.GetBoolFlag(cmd, "no-save-token")
 		localConfig := configuration.LocalConfig(cmd)
@@ -112,7 +111,7 @@ var setupCmd = &cobra.Command{
 		}
 		configuration.Set(configuration.Scope, configToSave)
 
-		if !silent {
+		if !utils.Silent {
 			// do not fetch the LocalConfig since we do not care about env variables or cmd flags
 			conf := configuration.Get(configuration.Scope)
 			valuesToPrint := []string{models.ConfigEnclaveConfig.String(), models.ConfigEnclaveProject.String()}

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -208,7 +208,7 @@ This is an alias of the "logout" command.`,
 func init() {
 	loginCmd.Flags().Bool("no-copy", false, "do not copy the auth code to the clipboard")
 	loginCmd.Flags().String("scope", "/", "the directory to scope your token to")
-	loginCmd.Flags().Bool("yes", false, "open browser without confirmation")
+	loginCmd.Flags().BoolP("yes", "y", false, "open browser without confirmation")
 
 	loginRollCmd.Flags().String("scope", "/", "the directory to scope your token to")
 	loginRollCmd.Flags().Bool("no-update-config", false, "do not update the rolled token in the config file")
@@ -217,7 +217,7 @@ func init() {
 	loginRevokeCmd.Flags().String("scope", "/", "the directory to scope your token to")
 	loginRevokeCmd.Flags().Bool("no-update-config", false, "do not remove the revoked token and Enclave configuration from the config file")
 	loginRevokeCmd.Flags().Bool("no-update-enclave-config", false, "do not remove the Enclave configuration from the config file")
-	loginRevokeCmd.Flags().Bool("yes", false, "proceed without confirmation")
+	loginRevokeCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	loginCmd.AddCommand(loginRevokeCmd)
 
 	rootCmd.AddCommand(loginCmd)

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -37,8 +37,7 @@ var loginCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		localConfig := configuration.LocalConfig(cmd)
-		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
-		prevConfig := configuration.Get(scope)
+		prevConfig := configuration.Get(configuration.Scope)
 		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
 		copyAuthCode := !utils.GetBoolFlag(cmd, "no-copy")
@@ -47,7 +46,7 @@ var loginCmd = &cobra.Command{
 		// warn user if scope already contains a token
 		if prevConfig.Token.Value != "" {
 			prevScope, err1 := filepath.Abs(prevConfig.Token.Scope)
-			newScope, err2 := filepath.Abs(scope)
+			newScope, err2 := filepath.Abs(configuration.Scope)
 			if err1 == nil && err2 == nil && prevScope == newScope {
 				utils.LogWarning("This scope already contains a token and will be overridden.")
 			}
@@ -137,14 +136,14 @@ var loginCmd = &cobra.Command{
 			options[models.ConfigVerifyTLS.String()] = localConfig.VerifyTLS.Value
 		}
 
-		configuration.Set(scope, options)
+		configuration.Set(configuration.Scope, options)
 
 		utils.Log("")
 		utils.Log(fmt.Sprintf("Welcome, %s", name))
 
 		if prevConfig.Token.Value != "" {
 			prevScope, err1 := filepath.Abs(prevConfig.Token.Scope)
-			newScope, err2 := filepath.Abs(scope)
+			newScope, err2 := filepath.Abs(configuration.Scope)
 			if err1 == nil && err2 == nil && prevScope == newScope {
 				utils.LogDebug("Revoking previous token")
 				_, err := http.RevokeAuthToken(prevConfig.APIHost.Value, utils.GetBool(prevConfig.VerifyTLS.Value, verifyTLS), prevConfig.Token.Value)

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -38,7 +38,6 @@ var loginCmd = &cobra.Command{
 	Run: func(cmd *cobra.Command, args []string) {
 		localConfig := configuration.LocalConfig(cmd)
 		prevConfig := configuration.Get(configuration.Scope)
-		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
 		copyAuthCode := !utils.GetBoolFlag(cmd, "no-copy")
 		hostname, _ := os.Hostname()
@@ -65,11 +64,11 @@ var loginCmd = &cobra.Command{
 			}
 		}
 
-		openBrowser := yes || silent || utils.ConfirmationPrompt("Open the authorization page in your browser?", true)
+		openBrowser := yes || utils.Silent || utils.ConfirmationPrompt("Open the authorization page in your browser?", true)
 		printURL := !openBrowser
 		if openBrowser {
 			if err := open.Run(authURL); err != nil {
-				if silent {
+				if utils.Silent {
 					utils.HandleError(err, "Unable to launch a browser")
 				}
 

--- a/pkg/cmd/login.go
+++ b/pkg/cmd/login.go
@@ -37,7 +37,7 @@ var loginCmd = &cobra.Command{
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		localConfig := configuration.LocalConfig(cmd)
-		scope := cmd.Flag("scope").Value.String()
+		scope := configuration.NormalizeScope(cmd.Flag("scope").Value.String())
 		prevConfig := configuration.Get(scope)
 		silent := utils.GetBoolFlag(cmd, "silent")
 		yes := utils.GetBoolFlag(cmd, "yes")
@@ -207,14 +207,14 @@ This is an alias of the "logout" command.`,
 
 func init() {
 	loginCmd.Flags().Bool("no-copy", false, "do not copy the auth code to the clipboard")
-	loginCmd.Flags().String("scope", "*", "the directory to scope your token to")
+	loginCmd.Flags().String("scope", "/", "the directory to scope your token to")
 	loginCmd.Flags().Bool("yes", false, "open browser without confirmation")
 
-	loginRollCmd.Flags().String("scope", "*", "the directory to scope your token to")
+	loginRollCmd.Flags().String("scope", "/", "the directory to scope your token to")
 	loginRollCmd.Flags().Bool("no-update-config", false, "do not update the rolled token in the config file")
 	loginCmd.AddCommand(loginRollCmd)
 
-	loginRevokeCmd.Flags().String("scope", "*", "the directory to scope your token to")
+	loginRevokeCmd.Flags().String("scope", "/", "the directory to scope your token to")
 	loginRevokeCmd.Flags().Bool("no-update-config", false, "do not remove the revoked token and Enclave configuration from the config file")
 	loginRevokeCmd.Flags().Bool("no-update-enclave-config", false, "do not remove the Enclave configuration from the config file")
 	loginRevokeCmd.Flags().Bool("yes", false, "proceed without confirmation")

--- a/pkg/cmd/logout.go
+++ b/pkg/cmd/logout.go
@@ -82,6 +82,6 @@ func init() {
 	logoutCmd.Flags().String("scope", "/", "the directory to scope your token to")
 	logoutCmd.Flags().Bool("no-update-config", false, "do not remove the revoked token and Enclave configuration from the config file")
 	logoutCmd.Flags().Bool("no-update-enclave-config", false, "do not remove the Enclave configuration from the config file")
-	logoutCmd.Flags().Bool("yes", false, "proceed without confirmation")
+	logoutCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	rootCmd.AddCommand(logoutCmd)
 }

--- a/pkg/cmd/logout.go
+++ b/pkg/cmd/logout.go
@@ -79,7 +79,7 @@ func revokeToken(cmd *cobra.Command, args []string) {
 }
 
 func init() {
-	logoutCmd.Flags().String("scope", "*", "the directory to scope your token to")
+	logoutCmd.Flags().String("scope", "/", "the directory to scope your token to")
 	logoutCmd.Flags().Bool("no-update-config", false, "do not remove the revoked token and Enclave configuration from the config file")
 	logoutCmd.Flags().Bool("no-update-enclave-config", false, "do not remove the Enclave configuration from the config file")
 	logoutCmd.Flags().Bool("yes", false, "proceed without confirmation")

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -39,11 +39,8 @@ var rootCmd = &cobra.Command{
 		configuration.Setup()
 		configuration.LoadConfig()
 
-		if utils.Debug {
-			silent := utils.GetBoolFlagIfChanged(cmd, "silent", false)
-			if silent {
-				utils.LogWarning("--silent has no effect when used with --debug")
-			}
+		if utils.Debug && utils.Silent {
+			utils.LogWarning("--silent has no effect when used with --debug")
 		}
 
 		// this output does not honor --silent

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -98,6 +98,11 @@ func checkVersion(command string) {
 }
 
 func loadFlags(cmd *cobra.Command) {
+	var err error
+	if configuration.Scope, err = configuration.NormalizeScope(cmd.Flag("scope").Value.String()); err != nil {
+		utils.HandleError(err, "Invalid scope")
+	}
+
 	configuration.UserConfigFile = utils.GetPathFlagIfChanged(cmd, "configuration", configuration.UserConfigFile)
 	http.TimeoutDuration = utils.GetDurationFlagIfChanged(cmd, "timeout", http.TimeoutDuration)
 	http.UseTimeout = !utils.GetBoolFlagIfChanged(cmd, "no-timeout", !http.UseTimeout)
@@ -139,7 +144,7 @@ func init() {
 	rootCmd.PersistentFlags().Duration("timeout", http.TimeoutDuration, "max http request duration")
 
 	rootCmd.PersistentFlags().Bool("no-read-env", false, "do not read enclave config from the environment")
-	rootCmd.PersistentFlags().String("scope", ".", "the directory to scope your config to")
+	rootCmd.PersistentFlags().String("scope", configuration.Scope, "the directory to scope your config to")
 	rootCmd.PersistentFlags().String("configuration", configuration.UserConfigFile, "config file")
 	rootCmd.PersistentFlags().Bool("json", utils.OutputJSON, "output json")
 	rootCmd.PersistentFlags().Bool("debug", utils.Debug, "output additional information")

--- a/pkg/cmd/settings.go
+++ b/pkg/cmd/settings.go
@@ -64,7 +64,6 @@ var settingsUpdateCmd = &cobra.Command{
 		return nil
 	},
 	Run: func(cmd *cobra.Command, args []string) {
-		silent := utils.GetBoolFlag(cmd, "silent")
 		name := cmd.Flag("name").Value.String()
 		email := cmd.Flag("email").Value.String()
 		jsonFlag := utils.OutputJSON
@@ -79,7 +78,7 @@ var settingsUpdateCmd = &cobra.Command{
 			utils.HandleError(err.Unwrap(), err.Message)
 		}
 
-		if !silent {
+		if !utils.Silent {
 			printer.Settings(info, jsonFlag)
 		}
 	},

--- a/pkg/configuration/migration.go
+++ b/pkg/configuration/migration.go
@@ -47,6 +47,7 @@ func convertOldConfig(oldConfig map[string]oldConfig) models.ConfigFile {
 	config := map[string]models.FileScopedOptions{}
 
 	for key, val := range oldConfig {
+		key = NormalizeScope(key)
 		config[key] = models.FileScopedOptions{EnclaveProject: val.Pipeline, EnclaveConfig: val.Environment, Token: val.Key}
 	}
 

--- a/pkg/configuration/migration.go
+++ b/pkg/configuration/migration.go
@@ -47,8 +47,11 @@ func convertOldConfig(oldConfig map[string]oldConfig) models.ConfigFile {
 	config := map[string]models.FileScopedOptions{}
 
 	for key, val := range oldConfig {
-		key = NormalizeScope(key)
-		config[key] = models.FileScopedOptions{EnclaveProject: val.Pipeline, EnclaveConfig: val.Environment, Token: val.Key}
+		var err error
+		// skip items that fail to parse
+		if key, err = NormalizeScope(key); err == nil {
+			config[key] = models.FileScopedOptions{EnclaveProject: val.Pipeline, EnclaveConfig: val.Environment, Token: val.Key}
+		}
 	}
 
 	return models.ConfigFile{Scoped: config}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -315,6 +315,26 @@ func ConfirmationPrompt(message string, defaultValue bool) bool {
 	return confirm
 }
 
+// SelectPrompt prompt user to select from a list of options
+func SelectPrompt(message string, options []string, defaultOption string) string {
+	prompt := &survey.Select{
+		Message:  message,
+		Options:  options,
+		PageSize: 25,
+	}
+	if defaultOption != "" {
+		prompt.Default = defaultOption
+	}
+
+	selectedProject := ""
+	err := survey.AskOne(prompt, &selectedProject)
+	if err != nil {
+		HandleError(err)
+	}
+
+	return selectedProject
+}
+
 // CopyToClipboard copies text to the user's clipboard
 func CopyToClipboard(text string) error {
 	if !clipboard.Unsupported {


### PR DESCRIPTION
With this switch we can now more strictly enforce that the provided scope is a path. This change is completely backwards compatible. Any config containing "*" will be rewritten to use "/", which all old CLI versions already support.