### PR TITLE
Create all secrets files as read-only

### DIFF
--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -255,7 +255,7 @@ $ doppler enclave secrets download --format=env --no-file`,
 			utils.HandleError(err, "Unable to encrypt your secrets. No file has been written.")
 		}
 
-		if err := utils.WriteFile(filePath, []byte(encryptedBody), 0600); err != nil {
+		if err := utils.WriteFile(filePath, []byte(encryptedBody), 0400); err != nil {
 			utils.HandleError(err, "Unable to write the secrets file")
 		}
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -256,7 +256,7 @@ func getSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbackP
 		}
 
 		utils.LogDebug(fmt.Sprintf("Writing to fallback file %s", fallbackPath))
-		if err := utils.WriteFile(fallbackPath, []byte(encryptedResponse), 0600); err != nil {
+		if err := utils.WriteFile(fallbackPath, []byte(encryptedResponse), 0400); err != nil {
 			utils.Log("Unable to write to fallback file")
 			if exitOnWriteFailure {
 				utils.HandleError(err, "", strings.Join(writeFailureMessage(), "\n"))


### PR DESCRIPTION
All files are written atomically, so existing files are never modified.