### PR TITLE
Add `doppler update` support for all mac and linux installs

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -21,8 +21,8 @@ import (
 	"time"
 
 	"github.com/DopplerHQ/cli/pkg/configuration"
+	"github.com/DopplerHQ/cli/pkg/controllers"
 	"github.com/DopplerHQ/cli/pkg/http"
-	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/printer"
 	"github.com/DopplerHQ/cli/pkg/utils"
 	"github.com/DopplerHQ/cli/pkg/version"
@@ -82,12 +82,17 @@ func checkVersion(command string) {
 		return
 	}
 
-	versionCheck := http.CheckCLIVersion(prevVersionCheck)
-	if versionCheck == (models.VersionCheck{}) {
+	available, versionCheck, err := controllers.NewVersionAvailable()
+	if err != nil {
+		// retry on next run
 		return
 	}
 
-	if version.ProgramVersion != versionCheck.LatestVersion {
+	if !available {
+		utils.LogDebug("No CLI updates available")
+		// re-use existing version
+		versionCheck.LatestVersion = prevVersionCheck.LatestVersion
+	} else {
 		utils.Log(fmt.Sprintf("Doppler CLI %s is now available\n", versionCheck.LatestVersion))
 	}
 

--- a/pkg/controllers/update.go
+++ b/pkg/controllers/update.go
@@ -1,0 +1,98 @@
+/*
+Copyright © 2020 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"os/exec"
+	"regexp"
+	"strings"
+
+	"github.com/DopplerHQ/cli/pkg/http"
+	"github.com/DopplerHQ/cli/pkg/utils"
+	"github.com/DopplerHQ/cli/pkg/version"
+)
+
+// Error controller errors
+type Error struct {
+	Err     error
+	Message string
+}
+
+// Unwrap get the original error
+func (e *Error) Unwrap() error { return e.Err }
+
+// IsNil whether the error is nil
+func (e *Error) IsNil() bool { return e.Err == nil && e.Message == "" }
+
+// RunInstallScript downloads and executes the CLI install scriptm, returning true if an update was installed
+func RunInstallScript() (bool, string, Error) {
+	// download script
+	script, apiErr := http.GetCLIInstallScript()
+	if !apiErr.IsNil() {
+		return false, "", Error{Err: apiErr.Unwrap(), Message: apiErr.Message}
+	}
+
+	// write script to temp file
+	tmpFile, err := utils.WriteTempFile("install.sh", script, 0555)
+	// clean up temp file once we're done with it
+	defer os.Remove(tmpFile)
+
+	// execute script
+	utils.LogDebug("Executing install script")
+	command := []string{tmpFile, "--debug"}
+	out, err := exec.Command(command[0], command[1:]...).CombinedOutput() // #nosec G204
+	strOut := string(out)
+	// log output before checking error
+	utils.LogDebug(fmt.Sprintf("Executing \"%s\"", strings.Join(command, " ")))
+	if utils.Debug {
+		fmt.Println(strOut)
+	}
+	if err != nil {
+		return false, "", Error{Err: err, Message: "Unable to install the latest Doppler CLI"}
+	}
+
+	// find installed version within script output
+	// Ex: `Installed Doppler CLI v3.7.1`
+	re := regexp.MustCompile(`Installed Doppler CLI v(\d+\.\d+\.\d+)`)
+	matches := re.FindStringSubmatch(strOut)
+	if matches == nil || len(matches) != 2 {
+		return false, "", Error{Err: errors.New("Unable to determine new CLI version")}
+	}
+	// parse latest version string
+	newVersion, err := version.ParseVersion(matches[1])
+	if err != nil {
+		return false, "", Error{Err: err, Message: "Unable to parse new CLI version"}
+	}
+
+	wasUpdated := false
+	// parse current version string
+	currentVersion, currVersionErr := version.ParseVersion(version.ProgramVersion)
+	if currVersionErr != nil {
+		// unexpected error; just consider it an update and continue executing
+		wasUpdated = true
+		utils.LogDebug("Unable to parse current CLI version")
+		utils.LogDebugError(currVersionErr)
+	}
+
+	if !wasUpdated {
+		wasUpdated = version.CompareVersions(currentVersion, newVersion) == 1
+	}
+
+	return wasUpdated, newVersion.String(), Error{}
+}

--- a/pkg/controllers/version.go
+++ b/pkg/controllers/version.go
@@ -1,0 +1,58 @@
+/*
+Copyright © 2020 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"time"
+
+	"github.com/DopplerHQ/cli/pkg/http"
+	"github.com/DopplerHQ/cli/pkg/models"
+	"github.com/DopplerHQ/cli/pkg/utils"
+	"github.com/DopplerHQ/cli/pkg/version"
+)
+
+// NewVersionAvailable checks whether a CLI version is available that's newer than this CLI
+func NewVersionAvailable() (bool, models.VersionCheck, error) {
+	now := time.Now()
+	check, err := http.GetLatestCLIVersion()
+	if err != nil {
+		utils.LogDebug("Unable to fetch latest CLI version")
+		utils.LogDebugError(err)
+		return false, models.VersionCheck{}, err
+	}
+
+	versionCheck := models.VersionCheck{CheckedAt: now, LatestVersion: version.Normalize(check.LatestVersion)}
+	newVersion, err := version.ParseVersion(versionCheck.LatestVersion)
+	if err != nil {
+		utils.LogDebug("Unable to parse new CLI version")
+		return false, models.VersionCheck{}, err
+	}
+
+	currentVersion, err := version.ParseVersion(version.ProgramVersion)
+	if err != nil {
+		// if current version can't be parsed, consider an update available
+		utils.LogDebug("Unable to parse current CLI version")
+		utils.LogDebugError(err)
+		return true, versionCheck, nil
+	}
+
+	compare := version.CompareVersions(currentVersion, newVersion)
+	if compare == 1 {
+		return true, versionCheck, nil
+	}
+
+	return false, versionCheck, nil
+}

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -41,3 +41,27 @@ func WriteFile(filename string, data []byte, perm os.FileMode) error {
 
 	return nil
 }
+
+// WriteTempFile writes data to a unique temp file and returns the file name
+func WriteTempFile(name string, data []byte, perm os.FileMode) (string, error) {
+	tmpFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s.", name))
+	if err != nil {
+		return "", err
+	}
+
+	LogDebug(fmt.Sprintf("Writing to temp file %s", tmpFile.Name()))
+	if _, err := tmpFile.Write(data); err != nil {
+		return "", err
+	}
+
+	tmpFileName := tmpFile.Name()
+	if err := tmpFile.Close(); err != nil {
+		return "", err
+	}
+
+	if err := os.Chmod(tmpFileName, perm); err != nil {
+		return "", err
+	}
+
+	return tmpFileName, nil
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -15,10 +15,98 @@ limitations under the License.
 */
 package version
 
+import (
+	"fmt"
+	"strconv"
+	"strings"
+)
+
 // ProgramVersion the current version of this program
 var ProgramVersion = "master"
+
+// Version semver
+type Version struct {
+	Major int16
+	Minor int16
+	Patch int16
+}
+
+// Unwrap get the original error
+func (v Version) String() string {
+	return fmt.Sprintf("v%d.%d.%d", v.Major, v.Minor, v.Patch)
+}
 
 // IsDevelopment whether the CLI is running in development mode (not a released version)
 func IsDevelopment() bool {
 	return ProgramVersion == "master"
+}
+
+// CompareVersions returns -1 if first is greater, 1 if second is greater, and 0 otherwise
+func CompareVersions(a Version, b Version) int {
+	// major version
+	if a.Major > b.Major {
+		return -1
+	}
+	if b.Major > a.Major {
+		return 1
+	}
+
+	// minor version
+	if a.Minor > b.Minor {
+		return -1
+	}
+	if b.Minor > a.Minor {
+		return 1
+	}
+
+	// patch version
+	if a.Patch > b.Patch {
+		return -1
+	}
+	if b.Patch > a.Patch {
+		return 1
+	}
+
+	return 0
+}
+
+// ParseVersion from a string
+func ParseVersion(s string) (Version, error) {
+	if strings.HasPrefix(s, "v") {
+		s = s[1:]
+	}
+	parts := strings.Split(s, ".")
+	if len(parts) != 3 {
+		return Version{}, fmt.Errorf("Invalid version %s", s)
+	}
+
+	var v Version
+	var major int64
+	var minor int64
+	var patch int64
+	var err error
+	if major, err = strconv.ParseInt(parts[0], 10, 16); err != nil {
+		return Version{}, fmt.Errorf("Invalid version %s", s)
+	}
+	if minor, err = strconv.ParseInt(parts[1], 10, 16); err != nil {
+		return Version{}, fmt.Errorf("Invalid version %s", s)
+	}
+	if patch, err = strconv.ParseInt(parts[2], 10, 16); err != nil {
+		return Version{}, fmt.Errorf("Invalid version %s", s)
+	}
+
+	v.Major = int16(major)
+	v.Minor = int16(minor)
+	v.Patch = int16(patch)
+	return v, nil
+}
+
+// Normalize prepends a 'v' to a version (e.g. 1.0.0 -> v1.0.0)
+func Normalize(version string) string {
+	version = strings.TrimSpace(version)
+	if !strings.HasPrefix(version, "v") {
+		return "v" + version
+	}
+
+	return version
 }

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,7 +5,6 @@ set -e
 DEBUG=0
 INSTALL=1
 CLEAN_EXIT=0
-CWD="$(pwd)"
 tempdir=""
 filename=""
 
@@ -19,17 +18,17 @@ cleanup() {
     fi
   fi
 
-  if [ ! -z "$tempdir" ]; then
+  if [ -n "$tempdir" ]; then
     delete_tempdir
   fi
 
-  exit $exit_code
+  exit "$exit_code"
 }
 trap cleanup EXIT
 
 clean_exit() {
   CLEAN_EXIT=1
-  exit $1
+  exit "$1"
 }
 
 log_debug() {
@@ -139,7 +138,7 @@ if [ -x "$(command -v curl)" ] || [ -x "$(command -v wget)" ]; then
     log_debug "Using $(command -v wget)"
     log_debug "Downloading from $url"
     # when this fails print the exit code
-    headers=$(wget -q -t 3 -S -O $filename "$url" 2>&1 || echo "$?")
+    headers=$(wget -q -t 3 -S -O "$filename" "$url" 2>&1 || echo "$?")
     if expr "$headers" : '[0-9][0-9]*$'>/dev/null; then
       exit_code="$headers"
       echo "ERROR: wget failed with exit code $exit_code"


### PR DESCRIPTION
We currently support `doppler update` on macOS via brew. We now drop support for brew updates and instead use our install.sh script for installing updates.