### PR TITLE
Disable HTTP keep-alives for client requests

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -125,10 +125,7 @@ func performRequest(req *http.Request, verifyTLS bool, params []queryParam) (int
 		client.Timeout = TimeoutDuration
 	}
 
-	// try to prevent "connect: cannot assign requested address" errors
-	// https://github.com/golang/go/issues/16012
-	transport := &http.Transport{MaxIdleConnsPerHost: 250, MaxConnsPerHost: 250, MaxIdleConns: 250}
-
+	transport := &http.Transport{}
 	// set TLS config
 	// #nosec G402
 	if !verifyTLS {

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -125,7 +125,11 @@ func performRequest(req *http.Request, verifyTLS bool, params []queryParam) (int
 		client.Timeout = TimeoutDuration
 	}
 
-	transport := &http.Transport{}
+	transport := &http.Transport{
+		// disable keep alives to prevent multiple CLI instances from exhausting the
+		// OS's available network sockets. this adds a negligible performance penalty
+		DisableKeepAlives: true,
+	}
 	// set TLS config
 	// #nosec G402
 	if !verifyTLS {


### PR DESCRIPTION
This is to prevent multiple CLI instances from exhausting the OS's available sockets.

