### PR TITLE
Use Doppler v3 APIs

### DIFF
--- a/pkg/cmd/configs.go
+++ b/pkg/cmd/configs.go
@@ -17,6 +17,7 @@ package cmd
 
 import (
 	"errors"
+	"fmt"
 	"strings"
 
 	"github.com/DopplerHQ/cli/pkg/configuration"
@@ -160,7 +161,12 @@ func deleteConfigs(cmd *cobra.Command, args []string) {
 	}
 	utils.RequireValue("config", config)
 
-	if yes || utils.ConfirmationPrompt("Delete config "+config, false) {
+	prompt := "Delete config"
+	if config != "" {
+		prompt = fmt.Sprintf("%s %s", prompt, config)
+	}
+
+	if yes || utils.ConfirmationPrompt(prompt, false) {
 		err := http.DeleteConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -216,7 +222,12 @@ func lockConfigs(cmd *cobra.Command, args []string) {
 	}
 	utils.RequireValue("config", config)
 
-	if yes || utils.ConfirmationPrompt("Lock config "+config, false) {
+	prompt := "Lock config"
+	if config != "" {
+		prompt = fmt.Sprintf("%s %s", prompt, config)
+	}
+
+	if yes || utils.ConfirmationPrompt(prompt, false) {
 		configInfo, err := http.LockConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
@@ -242,7 +253,12 @@ func unlockConfigs(cmd *cobra.Command, args []string) {
 	}
 	utils.RequireValue("config", config)
 
-	if yes || utils.ConfirmationPrompt("Unlock config "+config, false) {
+	prompt := "Unlock config"
+	if config != "" {
+		prompt = fmt.Sprintf("%s %s", prompt, config)
+	}
+
+	if yes || utils.ConfirmationPrompt(prompt, false) {
 		configInfo, err := http.UnlockConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)

--- a/pkg/cmd/configs.go
+++ b/pkg/cmd/configs.go
@@ -81,7 +81,6 @@ func configs(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
 
 	configs, err := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value)
 	if !err.IsNil() {
@@ -96,13 +95,11 @@ func getConfigs(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
 
 	config := localConfig.EnclaveConfig.Value
 	if len(args) > 0 {
 		config = args[0]
 	}
-	utils.RequireValue("config", config)
 
 	configInfo, err := http.GetConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config)
 	if !err.IsNil() {
@@ -118,7 +115,6 @@ func createConfigs(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
 
 	name := cmd.Flag("name").Value.String()
 	if len(args) > 0 {
@@ -153,13 +149,11 @@ func deleteConfigs(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
 
 	config := localConfig.EnclaveConfig.Value
 	if len(args) > 0 {
 		config = args[0]
 	}
-	utils.RequireValue("config", config)
 
 	prompt := "Delete config"
 	if config != "" {
@@ -189,14 +183,12 @@ func updateConfigs(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
 	utils.RequireValue("name", name)
 
 	config := localConfig.EnclaveConfig.Value
 	if len(args) > 0 {
 		config = args[0]
 	}
-	utils.RequireValue("config", config)
 
 	info, err := http.UpdateConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config, name)
 	if !err.IsNil() {
@@ -214,13 +206,11 @@ func lockConfigs(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
 
 	config := localConfig.EnclaveConfig.Value
 	if len(args) > 0 {
 		config = args[0]
 	}
-	utils.RequireValue("config", config)
 
 	prompt := "Lock config"
 	if config != "" {
@@ -245,13 +235,11 @@ func unlockConfigs(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
 
 	config := localConfig.EnclaveConfig.Value
 	if len(args) > 0 {
 		config = args[0]
 	}
-	utils.RequireValue("config", config)
 
 	prompt := "Unlock config"
 	if config != "" {

--- a/pkg/cmd/configs_logs.go
+++ b/pkg/cmd/configs_logs.go
@@ -50,8 +50,6 @@ func configsLogs(cmd *cobra.Command, args []string) {
 	// number := utils.GetIntFlag(cmd, "number", 16)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	logs, err := http.GetConfigLogs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 	if !err.IsNil() {
@@ -66,8 +64,6 @@ func getConfigsLogs(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	log := cmd.Flag("log").Value.String()
 	if len(args) > 0 {
@@ -88,8 +84,6 @@ func rollbackConfigsLogs(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	log := cmd.Flag("log").Value.String()
 	if len(args) > 0 {

--- a/pkg/cmd/configs_tokens.go
+++ b/pkg/cmd/configs_tokens.go
@@ -59,8 +59,6 @@ func configsTokens(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	tokens, err := http.GetConfigServiceTokens(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 	if !err.IsNil() {
@@ -75,8 +73,6 @@ func getConfigsTokens(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	slug := cmd.Flag("slug").Value.String()
 	if len(args) > 0 {
@@ -106,8 +102,6 @@ func createConfigsTokens(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	name := cmd.Flag("name").Value.String()
 	if len(args) > 0 {
@@ -128,8 +122,6 @@ func revokeConfigsTokens(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	slug := cmd.Flag("slug").Value.String()
 	if len(args) > 0 {

--- a/pkg/cmd/environments.go
+++ b/pkg/cmd/environments.go
@@ -47,7 +47,6 @@ func environments(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		project = args[0]
 	}
-	utils.RequireValue("project", project)
 
 	info, err := http.GetEnvironments(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, project)
 	if !err.IsNil() {
@@ -63,7 +62,6 @@ func getEnvironments(cmd *cobra.Command, args []string) {
 	environment := args[0]
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
 	utils.RequireValue("environment", environment)
 
 	info, err := http.GetEnvironment(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, environment)

--- a/pkg/cmd/projects.go
+++ b/pkg/cmd/projects.go
@@ -16,6 +16,8 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/DopplerHQ/cli/pkg/configuration"
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/printer"
@@ -129,7 +131,12 @@ func deleteProjects(cmd *cobra.Command, args []string) {
 	}
 	utils.RequireValue("project", project)
 
-	if yes || utils.ConfirmationPrompt("Delete project "+project, false) {
+	prompt := "Delete project"
+	if project != "" {
+		prompt = fmt.Sprintf("%s %s", prompt, project)
+	}
+
+	if yes || utils.ConfirmationPrompt(prompt, false) {
 		err := http.DeleteProject(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, project)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)

--- a/pkg/cmd/projects.go
+++ b/pkg/cmd/projects.go
@@ -84,7 +84,6 @@ func getProjects(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		project = args[0]
 	}
-	utils.RequireValue("project", project)
 
 	info, err := http.GetProject(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, project)
 	if !err.IsNil() {
@@ -129,7 +128,6 @@ func deleteProjects(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		project = args[0]
 	}
-	utils.RequireValue("project", project)
 
 	prompt := "Delete project"
 	if project != "" {
@@ -167,7 +165,6 @@ func updateProjects(cmd *cobra.Command, args []string) {
 	if len(args) > 0 {
 		project = args[0]
 	}
-	utils.RequireValue("project", project)
 
 	info, err := http.UpdateProject(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, project, name, description)
 	if !err.IsNil() {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -73,8 +73,6 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 		localConfig := configuration.LocalConfig(cmd)
 
 		utils.RequireValue("token", localConfig.Token.Value)
-		utils.RequireValue("project", localConfig.EnclaveProject.Value)
-		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 		fallbackPath := ""
 		legacyFallbackPath := ""

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -77,6 +77,7 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 		utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 		fallbackPath := ""
+		legacyFallbackPath := ""
 		if cmd.Flags().Changed("fallback") {
 			var err error
 			fallbackPath, err = utils.GetFilePath(cmd.Flag("fallback").Value.String())
@@ -84,7 +85,12 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 				utils.HandleError(err, "Unable to parse --fallback flag")
 			}
 		} else {
-			fallbackPath = defaultFallbackFile(localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+			fallbackPath = defaultFallbackFile(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+			// TODO remove this when releasing CLI v4 (DPLR-435)
+			if localConfig.EnclaveProject.Value != "" && localConfig.EnclaveConfig.Value != "" {
+				// save to old path to maintain backwards compatibility
+				legacyFallbackPath = legacyFallbackFile(localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+			}
 
 			if enableFallback && !utils.Exists(defaultFallbackDir) {
 				err := os.Mkdir(defaultFallbackDir, 0700)
@@ -93,17 +99,30 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 				}
 			}
 		}
-		absFallbackPath, err := filepath.Abs(fallbackPath)
-		if err == nil {
+
+		if absFallbackPath, err := filepath.Abs(fallbackPath); err == nil {
 			fallbackPath = absFallbackPath
 		}
 
-		passphrase := fmt.Sprintf("%s:%s:%s", localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+		if legacyFallbackPath != "" {
+			if absFallbackPath, err := filepath.Abs(legacyFallbackPath); err == nil {
+				legacyFallbackPath = absFallbackPath
+			}
+		}
+
+		var passphrase string
 		if cmd.Flags().Changed("passphrase") {
 			passphrase = cmd.Flag("passphrase").Value.String()
-			if passphrase == "" {
-				utils.HandleError(errors.New("invalid passphrase"))
+		} else {
+			// using only the token is sufficient for Service Tokens. it's insufficient for CLI tokens, which require a project and config
+			passphrase = fmt.Sprintf("%s", localConfig.Token.Value)
+			if localConfig.EnclaveProject.Value != "" && localConfig.EnclaveConfig.Value != "" {
+				passphrase = fmt.Sprintf("%s:%s:%s", passphrase, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 			}
+		}
+
+		if passphrase == "" {
+			utils.HandleError(errors.New("invalid passphrase"))
 		}
 
 		if !enableFallback {
@@ -115,7 +134,7 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 			}
 		}
 
-		secrets := fetchSecrets(localConfig, enableFallback, fallbackPath, fallbackReadonly, fallbackOnly, exitOnWriteFailure, passphrase)
+		secrets := fetchSecrets(localConfig, enableFallback, fallbackPath, legacyFallbackPath, fallbackReadonly, fallbackOnly, exitOnWriteFailure, passphrase)
 
 		if preserveEnv {
 			utils.LogWarning("Ignoring Doppler secrets already defined in the environment due to --preserve-env flag")
@@ -154,7 +173,7 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 		}
 
 		exitCode := 0
-		err = nil
+		var err error
 
 		if cmd.Flags().Changed("command") {
 			command := cmd.Flag("command").Value.String()
@@ -241,10 +260,10 @@ var runCleanCmd = &cobra.Command{
 	},
 }
 
-func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbackPath string, fallbackReadonly bool, fallbackOnly bool, exitOnWriteFailure bool, passphrase string) map[string]string {
+func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbackPath string, legacyFallbackPath string, fallbackReadonly bool, fallbackOnly bool, exitOnWriteFailure bool, passphrase string) map[string]string {
 	fetchSecrets := !(enableFallback && fallbackOnly)
 	if !fetchSecrets {
-		return readFallbackFile(fallbackPath, localConfig, passphrase)
+		return readFallbackFile(fallbackPath, legacyFallbackPath, passphrase)
 	}
 
 	response, httpErr := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, true)
@@ -252,7 +271,7 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 		if enableFallback {
 			utils.Log("Unable to fetch secrets from the Doppler API")
 			utils.LogError(httpErr.Unwrap())
-			return readFallbackFile(fallbackPath, localConfig, passphrase)
+			return readFallbackFile(fallbackPath, legacyFallbackPath, passphrase)
 		}
 		utils.HandleError(httpErr.Unwrap(), httpErr.Message)
 	}
@@ -263,7 +282,7 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 		if enableFallback {
 			utils.Log("Unable to parse the Doppler API response")
 			utils.LogError(httpErr.Unwrap())
-			return readFallbackFile(fallbackPath, localConfig, passphrase)
+			return readFallbackFile(fallbackPath, legacyFallbackPath, passphrase)
 		}
 		utils.HandleError(err, "Unable to parse API response")
 	}
@@ -283,6 +302,19 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 				utils.HandleError(err, "", strings.Join(writeFailureMessage(), "\n"))
 			} else {
 				utils.LogError(err)
+			}
+		}
+
+		// TODO remove this when releasing CLI v4 (DPLR-435)
+		if localConfig.EnclaveProject.Value != "" && localConfig.EnclaveConfig.Value != "" {
+			utils.LogDebug(fmt.Sprintf("Writing to legacy fallback file %s", legacyFallbackPath))
+			if err := utils.WriteFile(legacyFallbackPath, []byte(encryptedResponse), 0400); err != nil {
+				utils.Log("Unable to write to legacy fallback file")
+				if exitOnWriteFailure {
+					utils.HandleError(err, "", strings.Join(writeFailureMessage(), "\n"))
+				} else {
+					utils.LogError(err)
+				}
 			}
 		}
 	}
@@ -315,12 +347,18 @@ func writeFailureMessage() []string {
 	return msg
 }
 
-func readFallbackFile(path string, localConfig models.ScopedOptions, passphrase string) map[string]string {
+func readFallbackFile(path string, legacyPath string, passphrase string) map[string]string {
 	utils.Log("Reading secrets from fallback file")
 	utils.LogDebug(fmt.Sprintf("Using fallback file %s", path))
 
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
+			// attempt to read from the legacy path, in case the fallback file was created with an older version of the CLI
+			// TODO remove this when releasing CLI v4 (DPLR-435)
+			if legacyPath != "" {
+				return readFallbackFile(legacyPath, "", passphrase)
+			}
+
 			utils.HandleError(errors.New("The fallback file does not exist"))
 		}
 
@@ -368,8 +406,23 @@ func parseSecrets(response []byte) (map[string]string, error) {
 	return secrets, err
 }
 
-func defaultFallbackFile(project string, config string) string {
-	fileName := fmt.Sprintf(".run-%s.json", crypto.Hash(fmt.Sprintf("%s:%s", project, config)))
+// legacyFallbackFile deprecated file path used by early versions of CLI v3
+func legacyFallbackFile(project string, config string) string {
+	name := fmt.Sprintf("%s:%s", project, config)
+	fileName := fmt.Sprintf(".run-%s.json", crypto.Hash(name))
+	return filepath.Join(defaultFallbackDir, fileName)
+}
+
+func defaultFallbackFile(token string, project string, config string) string {
+	var fileName string
+	var name string
+	if project == "" && config == "" {
+		name = fmt.Sprintf("%s", token)
+	} else {
+		name = fmt.Sprintf("%s:%s:%s", token, project, config)
+	}
+
+	fileName = fmt.Sprintf(".secrets-%s.json", crypto.Hash(name))
 	return filepath.Join(defaultFallbackDir, fileName)
 }
 

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -253,12 +253,19 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 	}
 
 	utils.LogDebug("Encrypting secrets")
-	passphrase := fmt.Sprintf("%s:%s:%s", localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+
+	var passphrase string
 	if cmd.Flags().Changed("passphrase") {
 		passphrase = cmd.Flag("passphrase").Value.String()
-		if passphrase == "" {
-			utils.HandleError(errors.New("invalid passphrase"))
+	} else {
+		passphrase = fmt.Sprintf("%s", localConfig.Token.Value)
+		if localConfig.EnclaveProject.Value != "" && localConfig.EnclaveConfig.Value != "" {
+			passphrase = fmt.Sprintf("%s:%s:%s", passphrase, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 		}
+	}
+
+	if passphrase == "" {
+		utils.HandleError(errors.New("invalid passphrase"))
 	}
 
 	encryptedBody, err := crypto.Encrypt(passphrase, body)

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -98,8 +98,6 @@ func secrets(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	response, err := http.GetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 	if !err.IsNil() {
@@ -125,8 +123,6 @@ func getSecrets(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	response, err := http.GetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 	if !err.IsNil() {
@@ -146,8 +142,6 @@ func setSecrets(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	secrets := map[string]interface{}{}
 	var keys []string
@@ -178,8 +172,6 @@ func deleteSecrets(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	if yes || utils.ConfirmationPrompt("Delete secret(s)", false) {
 		secrets := map[string]interface{}{}
@@ -205,8 +197,6 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("project", localConfig.EnclaveProject.Value)
-	utils.RequireValue("config", localConfig.EnclaveConfig.Value)
 
 	format := cmd.Flag("format").Value.String()
 	if jsonFlag {

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -137,6 +137,7 @@ func RevokeAuthToken(host string, verifyTLS bool, token string) (map[string]inte
 func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string, config string, jsonFlag bool) ([]byte, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
 	headers := apiKeyHeader(apiKey)
 	if jsonFlag {
@@ -145,7 +146,7 @@ func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string,
 		headers["Accept"] = "text/plain"
 	}
 
-	statusCode, response, err := GetRequest(host, verifyTLS, headers, "/enclave/v1/configs/"+config+"/secrets/download", params)
+	statusCode, response, err := GetRequest(host, verifyTLS, headers, "/v3/configs/config/secrets/download", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to download secrets", Code: statusCode}
 	}
@@ -157,10 +158,11 @@ func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string,
 func GetSecrets(host string, verifyTLS bool, apiKey string, project string, config string) ([]byte, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
 	headers := apiKeyHeader(apiKey)
 	headers["Accept"] = "application/json"
-	statusCode, response, err := GetRequest(host, verifyTLS, headers, "/enclave/v1/configs/"+config+"/secrets", params)
+	statusCode, response, err := GetRequest(host, verifyTLS, headers, "/v3/configs/config/secrets", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch secrets", Code: statusCode}
 	}
@@ -179,8 +181,9 @@ func SetSecrets(host string, verifyTLS bool, apiKey string, project string, conf
 
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config+"/secrets", params, body)
+	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/secrets", params, body)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to set secrets", Code: statusCode}
 	}
@@ -241,7 +244,7 @@ func SetWorkplaceSettings(host string, verifyTLS bool, apiKey string, values mod
 
 // GetProjects get projects
 func GetProjects(host string, verifyTLS bool, apiKey string) ([]models.ProjectInfo, Error) {
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/projects", []queryParam{})
+	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects", []queryParam{})
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch projects", Code: statusCode}
 	}
@@ -262,7 +265,10 @@ func GetProjects(host string, verifyTLS bool, apiKey string) ([]models.ProjectIn
 
 // GetProject get specified project
 func GetProject(host string, verifyTLS bool, apiKey string, project string) (models.ProjectInfo, Error) {
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/projects/"+project, []queryParam{})
+	var params []queryParam
+	params = append(params, queryParam{Key: "project", Value: project})
+
+	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects/project", params)
 	if err != nil {
 		return models.ProjectInfo{}, Error{Err: err, Message: "Unable to fetch project", Code: statusCode}
 	}
@@ -285,7 +291,7 @@ func CreateProject(host string, verifyTLS bool, apiKey string, name string, desc
 		return models.ProjectInfo{}, Error{Err: err, Message: "Invalid project info"}
 	}
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/projects", []queryParam{}, body)
+	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects", []queryParam{}, body)
 	if err != nil {
 		return models.ProjectInfo{}, Error{Err: err, Message: "Unable to create project", Code: statusCode}
 	}
@@ -308,7 +314,10 @@ func UpdateProject(host string, verifyTLS bool, apiKey string, project string, n
 		return models.ProjectInfo{}, Error{Err: err, Message: "Invalid project info"}
 	}
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/projects/"+project, []queryParam{}, body)
+	var params []queryParam
+	params = append(params, queryParam{Key: "project", Value: project})
+
+	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects/project", params, body)
 	if err != nil {
 		return models.ProjectInfo{}, Error{Err: err, Message: "Unable to update project", Code: statusCode}
 	}
@@ -325,7 +334,10 @@ func UpdateProject(host string, verifyTLS bool, apiKey string, project string, n
 
 // DeleteProject create a project
 func DeleteProject(host string, verifyTLS bool, apiKey string, project string) Error {
-	statusCode, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/projects/"+project, []queryParam{})
+	var params []queryParam
+	params = append(params, queryParam{Key: "project", Value: project})
+
+	statusCode, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects/project", params)
 	if err != nil {
 		return Error{Err: err, Message: "Unable to delete project", Code: statusCode}
 	}
@@ -344,7 +356,7 @@ func GetEnvironments(host string, verifyTLS bool, apiKey string, project string)
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/environments", params)
+	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/environments", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch environments", Code: statusCode}
 	}
@@ -367,8 +379,9 @@ func GetEnvironments(host string, verifyTLS bool, apiKey string, project string)
 func GetEnvironment(host string, verifyTLS bool, apiKey string, project string, environment string) (models.EnvironmentInfo, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "environment", Value: environment})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/environments/"+environment, params)
+	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/environments/environment", params)
 	if err != nil {
 		return models.EnvironmentInfo{}, Error{Err: err, Message: "Unable to fetch environment", Code: statusCode}
 	}
@@ -388,7 +401,7 @@ func GetConfigs(host string, verifyTLS bool, apiKey string, project string) ([]m
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs", params)
+	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch configs", Code: statusCode}
 	}
@@ -411,8 +424,9 @@ func GetConfigs(host string, verifyTLS bool, apiKey string, project string) ([]m
 func GetConfig(host string, verifyTLS bool, apiKey string, project string, config string) (models.ConfigInfo, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config, params)
+	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config", params)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to fetch configs", Code: statusCode}
 	}
@@ -438,7 +452,7 @@ func CreateConfig(host string, verifyTLS bool, apiKey string, project string, na
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs", params, body)
+	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs", params, body)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to create config", Code: statusCode}
 	}
@@ -457,8 +471,9 @@ func CreateConfig(host string, verifyTLS bool, apiKey string, project string, na
 func DeleteConfig(host string, verifyTLS bool, apiKey string, project string, config string) Error {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config, params)
+	statusCode, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config", params)
 	if err != nil {
 		return Error{Err: err, Message: "Unable to delete config", Code: statusCode}
 	}
@@ -476,8 +491,9 @@ func DeleteConfig(host string, verifyTLS bool, apiKey string, project string, co
 func LockConfig(host string, verifyTLS bool, apiKey string, project string, config string) (models.ConfigInfo, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config+"/lock", params, nil)
+	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/lock", params, nil)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to lock config", Code: statusCode}
 	}
@@ -496,8 +512,9 @@ func LockConfig(host string, verifyTLS bool, apiKey string, project string, conf
 func UnlockConfig(host string, verifyTLS bool, apiKey string, project string, config string) (models.ConfigInfo, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config+"/unlock", params, nil)
+	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/unlock", params, nil)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to unlock config", Code: statusCode}
 	}
@@ -522,8 +539,9 @@ func UpdateConfig(host string, verifyTLS bool, apiKey string, project string, co
 
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config, params, body)
+	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config", params, body)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to update config", Code: statusCode}
 	}
@@ -580,8 +598,9 @@ func GetActivityLog(host string, verifyTLS bool, apiKey string, log string) (mod
 func GetConfigLogs(host string, verifyTLS bool, apiKey string, project string, config string) ([]models.ConfigLog, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config+"/logs", params)
+	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/logs", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch config logs", Code: statusCode}
 	}
@@ -604,8 +623,10 @@ func GetConfigLogs(host string, verifyTLS bool, apiKey string, project string, c
 func GetConfigLog(host string, verifyTLS bool, apiKey string, project string, config string, log string) (models.ConfigLog, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
+	params = append(params, queryParam{Key: "log", Value: log})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config+"/logs/"+log, params)
+	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/logs/log", params)
 	if err != nil {
 		return models.ConfigLog{}, Error{Err: err, Message: "Unable to fetch config log", Code: statusCode}
 	}
@@ -624,8 +645,10 @@ func GetConfigLog(host string, verifyTLS bool, apiKey string, project string, co
 func RollbackConfigLog(host string, verifyTLS bool, apiKey string, project string, config string, log string) (models.ConfigLog, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
+	params = append(params, queryParam{Key: "log", Value: log})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config+"/logs/"+log+"/rollback", params, nil)
+	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/logs/log/rollback", params, nil)
 	if err != nil {
 		return models.ConfigLog{}, Error{Err: err, Message: "Unable to rollback config log", Code: statusCode}
 	}
@@ -644,8 +667,9 @@ func RollbackConfigLog(host string, verifyTLS bool, apiKey string, project strin
 func GetConfigServiceTokens(host string, verifyTLS bool, apiKey string, project string, config string) ([]models.ConfigServiceToken, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config+"/tokens", params)
+	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/tokens", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch service tokens", Code: statusCode}
 	}
@@ -674,8 +698,9 @@ func CreateConfigServiceToken(host string, verifyTLS bool, apiKey string, projec
 
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config+"/tokens", params, body)
+	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/tokens", params, body)
 	if err != nil {
 		return models.ConfigServiceToken{}, Error{Err: err, Message: "Unable to create service token", Code: statusCode}
 	}
@@ -694,8 +719,10 @@ func CreateConfigServiceToken(host string, verifyTLS bool, apiKey string, projec
 func DeleteConfigServiceToken(host string, verifyTLS bool, apiKey string, project string, config string, slug string) Error {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
+	params = append(params, queryParam{Key: "slug", Value: slug})
 
-	statusCode, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/enclave/v1/configs/"+config+"/tokens/"+slug, params)
+	statusCode, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/tokens/token", params)
 	if err != nil {
 		return Error{Err: err, Message: "Unable to delete service token", Code: statusCode}
 	}


### PR DESCRIPTION
This PR implements support for the Doppler v3 APIs. This also means that the CLI no longer requires specifying a project or config when using a service token.

The default fallback file path and passphrase have changed in this release. To maintain backwards compatibility, we write both the old file and the new file. Additionally, we support reading from both fallback files (with precedence given to the new file).