### PR TITLE
Fix: write files on Windows with 0600 file perms

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -292,7 +292,7 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 		}
 
 		utils.LogDebug(fmt.Sprintf("Writing to fallback file %s", fallbackPath))
-		if err := utils.WriteFile(fallbackPath, []byte(encryptedResponse), 0400); err != nil {
+		if err := utils.WriteFile(fallbackPath, []byte(encryptedResponse), utils.RestrictedFilePerms()); err != nil {
 			utils.Log("Unable to write to fallback file")
 			if exitOnWriteFailure {
 				utils.HandleError(err, "", strings.Join(writeFailureMessage(), "\n"))
@@ -304,7 +304,7 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 		// TODO remove this when releasing CLI v4 (DPLR-435)
 		if localConfig.EnclaveProject.Value != "" && localConfig.EnclaveConfig.Value != "" {
 			utils.LogDebug(fmt.Sprintf("Writing to legacy fallback file %s", legacyFallbackPath))
-			if err := utils.WriteFile(legacyFallbackPath, []byte(encryptedResponse), 0400); err != nil {
+			if err := utils.WriteFile(legacyFallbackPath, []byte(encryptedResponse), utils.RestrictedFilePerms()); err != nil {
 				utils.Log("Unable to write to legacy fallback file")
 				if exitOnWriteFailure {
 					utils.HandleError(err, "", strings.Join(writeFailureMessage(), "\n"))

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -263,7 +263,7 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 		utils.HandleError(err, "Unable to encrypt your secrets. No file has been written.")
 	}
 
-	if err := utils.WriteFile(filePath, []byte(encryptedBody), 0400); err != nil {
+	if err := utils.WriteFile(filePath, []byte(encryptedBody), utils.RestrictedFilePerms()); err != nil {
 		utils.HandleError(err, "Unable to write the secrets file")
 	}
 

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -21,6 +21,16 @@ import (
 	"os"
 )
 
+// RestrictedFilePerms perms used for creating restrictied files meant to be accessible only to the user
+func RestrictedFilePerms() os.FileMode {
+	// windows disallows overwriting an existing file with 0400 perms
+	if IsWindows() {
+		return 0600
+	}
+
+	return 0400
+}
+
 // WriteFile atomically writes data to a file named by filename.
 func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	temp := fmt.Sprintf("%s.%s", filename, RandomBase64String(8))


### PR DESCRIPTION
On Windows, we are not able to overwrite a file with 0400 perms without first deleting it, even if we have write perms to the directory. This fixes an issue where `doppler run` failed to create a new fallback file once a fallback file with the same name already existed.