### PR TITLE
Use home dir as temp directory

### DIFF
--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -54,7 +54,8 @@ func WriteFile(filename string, data []byte, perm os.FileMode) error {
 
 // WriteTempFile writes data to a unique temp file and returns the file name
 func WriteTempFile(name string, data []byte, perm os.FileMode) (string, error) {
-	tmpFile, err := ioutil.TempFile(os.TempDir(), fmt.Sprintf("%s.", name))
+	// create hidden file in user's home dir to ensure no other users have write access
+	tmpFile, err := ioutil.TempFile(HomeDir(), fmt.Sprintf(".%s.", name))
 	if err != nil {
 		return "", err
 	}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -112,7 +112,8 @@ url="https://cli.doppler.com/download?os=$os&arch=$arch&format=$format"
 
 # download binary
 if [ -x "$(command -v curl)" ] || [ -x "$(command -v wget)" ]; then
-  tempdir="$(mktemp -d)"
+  # create hidden temp dir in user's home directory to ensure no other users have write perms
+  tempdir="$(mktemp -d ~/.tmp.XXXXXXXX)"
   log_debug "Using temp directory $tempdir"
 
   echo "Downloading latest release"


### PR DESCRIPTION
This prevents temp directories from being created in /tmp/, which is world writable. This fixes a potential race condition where the downloaded CLI install script and CLI binary could be replaced by an attacker before execution.

Tested the new `mktemp` command on macOS, Ubuntu, alpine, RHEL, CentOS, and FreeBSD.

Closes DPLR-502.