### PR TITLE
Reap zombie processes in Docker using tini

### DIFF
--- a/docker/alpine
+++ b/docker/alpine
@@ -1,3 +1,4 @@
 FROM alpine
+RUN apk add --no-cache tini
 COPY doppler /bin/doppler
-ENTRYPOINT ["/bin/doppler"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/doppler"]

--- a/docker/node:alpine
+++ b/docker/node:alpine
@@ -1,3 +1,4 @@
 FROM node:lts-alpine
+RUN apk add --no-cache tini
 COPY doppler /bin/doppler
-ENTRYPOINT ["/bin/doppler"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/doppler"]

--- a/docker/python:alpine
+++ b/docker/python:alpine
@@ -1,3 +1,4 @@
 FROM python:3-alpine
+RUN apk add --no-cache tini
 COPY doppler /bin/doppler
-ENTRYPOINT ["/bin/doppler"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/doppler"]

--- a/docker/ruby:alpine
+++ b/docker/ruby:alpine
@@ -1,3 +1,4 @@
 FROM ruby:2-alpine
+RUN apk add --no-cache tini
 COPY doppler /bin/doppler
-ENTRYPOINT ["/bin/doppler"]
+ENTRYPOINT ["/sbin/tini", "--", "/bin/doppler"]


### PR DESCRIPTION
This prevents the Docker zombie reaping problem[0] that's caused by pid 1 (in this case the CLI) not sufficiently cleaning up zombie processes. Without adding an init process to the entrypoint, another solution is using the `--init` flag on `docker run`.

[0] https://blog.phusion.nl/2015/01/20/docker-and-the-pid-1-zombie-reaping-problem/