### PR TITLE
Add fallback file support to the 'secrets download' command

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,11 +15,7 @@ jobs:
       with:
         path: ./src/github.com/${{ github.repository }}
     - name: Build
-      run: go build
-      env:
-        GOPATH: ${{ runner.workspace }}
-    - name: Test
-      run: make test
+      run: make build
       env:
         GOPATH: ${{ runner.workspace }}
     - name: GoReleaser Check

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,24 @@
+name: Run tests
+
+on: [push]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.15'
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/${{ github.repository }}
+    - name: Build
+      run: make build
+      env:
+        GOPATH: ${{ runner.workspace }}
+    - name: E2E Tests
+      run: make test-e2e
+      env:
+        DOPPLER_TOKEN: ${{ secrets.E2E_TEST_DOPPLER_TOKEN }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -22,3 +22,22 @@ jobs:
       run: make test-e2e
       env:
         DOPPLER_TOKEN: ${{ secrets.E2E_TEST_DOPPLER_TOKEN }}
+  unit:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v1
+      with:
+        go-version: '1.15'
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/${{ github.repository }}
+    - name: Build
+      run: make build
+      env:
+        GOPATH: ${{ runner.workspace }}
+    - name: Unit Tests
+      run: make test
+      env:
+        GOPATH: ${{ runner.workspace }}

--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,9 @@ release:
 test:
 	go test ./pkg/... -v
 
+test-e2e:
+	./tests.sh
+
 test-release:
 	goreleaser release --snapshot --skip-publish --skip-sign --rm-dist
 

--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -117,7 +117,7 @@ func init() {
 	enclaveSecretsDownloadCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	enclaveSecretsDownloadCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
 	enclaveSecretsDownloadCmd.Flags().String("format", "json", "output format. one of [json, env]")
-	enclaveSecretsDownloadCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the secrets file. the default passphrase is `$token:$project:$config`.")
+	enclaveSecretsDownloadCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the secrets file. the default passphrase is computed using your current configuration.")
 	enclaveSecretsDownloadCmd.Flags().Bool("no-file", false, "print the response to stdout")
 	enclaveSecretsCmd.AddCommand(enclaveSecretsDownloadCmd)
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -111,6 +111,8 @@ func loadFlags(cmd *cobra.Command) {
 	http.UseTimeout = !utils.GetBoolFlagIfChanged(cmd, "no-timeout", !http.UseTimeout)
 	utils.Debug = utils.GetBoolFlagIfChanged(cmd, "debug", utils.Debug)
 	utils.Silent = utils.GetBoolFlagIfChanged(cmd, "silent", utils.Silent)
+	// no-file is used by the 'secrets download' command to output secrets to stdout
+	utils.Silent = utils.GetBoolFlagIfChanged(cmd, "no-file", utils.Silent)
 	utils.OutputJSON = utils.GetBoolFlagIfChanged(cmd, "json", utils.OutputJSON)
 	version.PerformVersionCheck = !utils.GetBoolFlagIfChanged(cmd, "no-check-version", !version.PerformVersionCheck)
 }

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -218,6 +218,7 @@ var runCleanCmd = &cobra.Command{
 	},
 }
 
+// fetchSecrets fetches secrets, including all reading and writing of fallback files
 func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbackPath string, legacyFallbackPath string, fallbackReadonly bool, fallbackOnly bool, exitOnWriteFailure bool, passphrase string) map[string]string {
 	if fallbackOnly {
 		if !enableFallback {
@@ -445,10 +446,12 @@ func init() {
 
 	runCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")
 	runCmd.Flags().StringP("config", "c", "", "config (e.g. dev)")
-	runCmd.Flags().String("fallback", "", "path to the fallback file.write secrets to this file after connecting to Doppler. secrets will be read from this file if subsequent connections are unsuccessful.")
-	runCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the fallback file. the default passphrase is computed using your current configuration.")
 	runCmd.Flags().String("command", "", "command to execute (e.g. \"echo hi\")")
 	runCmd.Flags().Bool("preserve-env", false, "ignore any Doppler secrets that are already defined in the environment. this has potential security implications, use at your own risk.")
+	// fallback flags
+	runCmd.Flags().String("fallback", "", "path to the fallback file. encrypted secrets are written to this file after each successful fetch. secrets will be read from this file if subsequent connections are unsuccessful.")
+	// TODO rename this to 'fallback-passphrase' in CLI v4 (DPLR-435)
+	runCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the fallback file. the default passphrase is computed using your current configuration.")
 	runCmd.Flags().Bool("no-fallback", false, "disable reading and writing the fallback file")
 	runCmd.Flags().Bool("fallback-readonly", false, "disable modifying the fallback file. secrets can still be read from the file.")
 	runCmd.Flags().Bool("fallback-only", false, "read all secrets directly from the fallback file, without contacting Doppler. secrets will not be updated. (implies --fallback-readonly)")

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -262,7 +262,7 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 			if exitOnWriteFailure {
 				utils.HandleError(err, "", strings.Join(writeFailureMessage(), "\n"))
 			} else {
-				utils.LogError(err)
+				utils.LogDebugError(err)
 			}
 		}
 
@@ -274,7 +274,7 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 				if exitOnWriteFailure {
 					utils.HandleError(err, "", strings.Join(writeFailureMessage(), "\n"))
 				} else {
-					utils.LogError(err)
+					utils.LogDebugError(err)
 				}
 			}
 		}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -266,7 +266,7 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 		}
 
 		// TODO remove this when releasing CLI v4 (DPLR-435)
-		if localConfig.EnclaveProject.Value != "" && localConfig.EnclaveConfig.Value != "" {
+		if legacyFallbackPath != "" && localConfig.EnclaveProject.Value != "" && localConfig.EnclaveConfig.Value != "" {
 			utils.LogDebug(fmt.Sprintf("Writing to legacy fallback file %s", legacyFallbackPath))
 			if err := utils.WriteFile(legacyFallbackPath, []byte(encryptedResponse), utils.RestrictedFilePerms()); err != nil {
 				utils.Log("Unable to write to legacy fallback file")

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -257,8 +257,10 @@ var runCleanCmd = &cobra.Command{
 }
 
 func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbackPath string, legacyFallbackPath string, fallbackReadonly bool, fallbackOnly bool, exitOnWriteFailure bool, passphrase string) map[string]string {
-	fetchSecrets := !(enableFallback && fallbackOnly)
-	if !fetchSecrets {
+	if fallbackOnly {
+		if !enableFallback {
+			utils.HandleError(errors.New("Conflict: unable to specify --no-fallback with --fallback-only"))
+		}
 		return readFallbackFile(fallbackPath, legacyFallbackPath, passphrase)
 	}
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -443,7 +443,7 @@ func init() {
 	runCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")
 	runCmd.Flags().StringP("config", "c", "", "config (e.g. dev)")
 	runCmd.Flags().String("fallback", "", "path to the fallback file.write secrets to this file after connecting to Doppler. secrets will be read from this file if subsequent connections are unsuccessful.")
-	runCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the fallback file. by default the passphrase is computed using your current configuration.")
+	runCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the fallback file. the default passphrase is computed using your current configuration.")
 	runCmd.Flags().String("command", "", "command to execute (e.g. \"echo hi\")")
 	runCmd.Flags().Bool("preserve-env", false, "ignore any Doppler secrets that are already defined in the environment. this has potential security implications, use at your own risk.")
 	runCmd.Flags().Bool("no-fallback", false, "disable reading and writing the fallback file")

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -191,7 +191,6 @@ func deleteSecrets(cmd *cobra.Command, args []string) {
 }
 
 func downloadSecrets(cmd *cobra.Command, args []string) {
-	// don't log anything extraneous when printing to stdout
 	saveFile := !utils.GetBoolFlag(cmd, "no-file")
 	jsonFlag := utils.OutputJSON
 	localConfig := configuration.LocalConfig(cmd)

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -297,7 +297,7 @@ func init() {
 	secretsDownloadCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")
 	secretsDownloadCmd.Flags().StringP("config", "c", "", "config (e.g. dev)")
 	secretsDownloadCmd.Flags().String("format", "json", "output format. one of [json, env]")
-	secretsDownloadCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the secrets file. the default passphrase is `$token:$project:$config`.")
+	secretsDownloadCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the secrets file. the default passphrase is computed using your current configuration.")
 	secretsDownloadCmd.Flags().Bool("no-file", false, "print the response to stdout")
 	secretsCmd.AddCommand(secretsDownloadCmd)
 

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"encoding/json"
 	"errors"
 	"fmt"
 	"path/filepath"
@@ -195,6 +196,11 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 	jsonFlag := utils.OutputJSON
 	localConfig := configuration.LocalConfig(cmd)
 
+	enableFallback := !utils.GetBoolFlag(cmd, "no-fallback")
+	fallbackReadonly := utils.GetBoolFlag(cmd, "fallback-readonly")
+	fallbackOnly := utils.GetBoolFlag(cmd, "fallback-only")
+	exitOnWriteFailure := !utils.GetBoolFlag(cmd, "no-exit-on-write-failure")
+
 	utils.RequireValue("token", localConfig.Token.Value)
 
 	format := cmd.Flag("format").Value.String()
@@ -218,9 +224,40 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	body, apiError := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format == "json")
-	if !apiError.IsNil() {
-		utils.HandleError(apiError.Unwrap(), apiError.Message)
+	fallbackPassphrase := getPassphrase(cmd, "fallback-passphrase", localConfig)
+	if fallbackPassphrase == "" {
+		utils.HandleError(errors.New("invalid fallback file passphrase"))
+	}
+
+	var body []byte
+	if format == "json" {
+		fallbackPath := ""
+		legacyFallbackPath := ""
+		if enableFallback {
+			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, exitOnWriteFailure)
+		}
+		secrets := fetchSecrets(localConfig, enableFallback, fallbackPath, legacyFallbackPath, fallbackReadonly, fallbackOnly, exitOnWriteFailure, fallbackPassphrase)
+
+		var err error
+		body, err = json.Marshal(secrets)
+		if err != nil {
+			utils.HandleError(err, "Unable to parse JSON secrets")
+		}
+	} else {
+		// fallback file is not supported when fetching .env format
+		enableFallback = false
+		flags := []string{"fallback", "fallback-only", "fallback-readonly", "no-exit-on-write-failure"}
+		for _, flag := range flags {
+			if cmd.Flags().Changed(flag) {
+				utils.LogWarning(fmt.Sprintf("--%s has no effect when format is %s", flag, format))
+			}
+		}
+
+		var apiError http.Error
+		body, apiError = http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, false)
+		if !apiError.IsNil() {
+			utils.HandleError(apiError.Unwrap(), apiError.Message)
+		}
 	}
 
 	if !saveFile {
@@ -289,6 +326,13 @@ func init() {
 	secretsDownloadCmd.Flags().String("format", "json", "output format. one of [json, env]")
 	secretsDownloadCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the secrets file. the default passphrase is computed using your current configuration.")
 	secretsDownloadCmd.Flags().Bool("no-file", false, "print the response to stdout")
+	// fallback flags
+	secretsDownloadCmd.Flags().String("fallback", "", "path to the fallback file. encrypted secrets are written to this file after each successful fetch. secrets will be read from this file if subsequent connections are unsuccessful.")
+	secretsDownloadCmd.Flags().Bool("no-fallback", false, "disable reading and writing the fallback file")
+	secretsDownloadCmd.Flags().String("fallback-passphrase", "", "passphrase to use for encrypting the fallback file. by default the passphrase is computed using your current configuration.")
+	secretsDownloadCmd.Flags().Bool("fallback-readonly", false, "disable modifying the fallback file. secrets can still be read from the file.")
+	secretsDownloadCmd.Flags().Bool("fallback-only", false, "read all secrets directly from the fallback file, without contacting Doppler. secrets will not be updated. (implies --fallback-readonly)")
+	secretsDownloadCmd.Flags().Bool("no-exit-on-write-failure", false, "do not exit if unable to write the fallback file")
 	secretsCmd.AddCommand(secretsDownloadCmd)
 
 	rootCmd.AddCommand(secretsCmd)

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -243,16 +243,7 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 
 	utils.LogDebug("Encrypting secrets")
 
-	var passphrase string
-	if cmd.Flags().Changed("passphrase") {
-		passphrase = cmd.Flag("passphrase").Value.String()
-	} else {
-		passphrase = fmt.Sprintf("%s", localConfig.Token.Value)
-		if localConfig.EnclaveProject.Value != "" && localConfig.EnclaveConfig.Value != "" {
-			passphrase = fmt.Sprintf("%s:%s:%s", passphrase, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
-		}
-	}
-
+	passphrase := getPassphrase(cmd, "passphrase", localConfig)
 	if passphrase == "" {
 		utils.HandleError(errors.New("invalid passphrase"))
 	}

--- a/tests.sh
+++ b/tests.sh
@@ -10,6 +10,7 @@ export DOPPLER_CONFIG="prd_e2e_tests"
 
 # Run tests
 "$DIR/tests/secrets-download-fallback.sh"
+"$DIR/tests/run-fallback.sh"
 
 echo -e "\nAll tests completed successfully!"
 exit 0

--- a/tests.sh
+++ b/tests.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+set -euo pipefail
+
+DIR="$(dirname "$0")"
+
+export DOPPLER_BINARY="$DIR/doppler"
+export DOPPLER_PROJECT="cli"
+export DOPPLER_CONFIG="prd_e2e_tests"
+
+# Run tests
+"$DIR/tests/secrets-download-fallback.sh"
+
+echo -e "\nAll tests completed successfully!"
+exit 0

--- a/tests/run-fallback.sh
+++ b/tests/run-fallback.sh
@@ -1,0 +1,78 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_NAME="run-fallback"
+
+cleanup() {
+  exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    echo "ERROR: '$TEST_NAME' tests failed during execution"
+    afterAll || echo "ERROR: Cleanup failed"
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+beforeAll() {
+  echo "INFO: Executing '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+beforeEach() {
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+  rm -f fallback.json
+  rm -rf ./temp-fallback
+}
+
+afterAll() {
+  echo "INFO: Completed '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+  rm -f fallback.json
+  rm -rf ./temp-fallback
+}
+
+beforeAll
+
+beforeEach
+
+# test fallback-only fails when no fallback files exist
+"$DOPPLER_BINARY" run --fallback-only -- echo -n > /dev/null 2>&1 && (echo ERROR: "--fallback-only flag is not respected" && exit 1)
+
+beforeEach
+
+# test fallback-readonly doesn't write a fallback file
+"$DOPPLER_BINARY" run --fallback-readonly -- echo -n > /dev/null
+"$DOPPLER_BINARY" run --fallback-only -- echo -n > /dev/null 2>&1 && (echo ERROR: "--fallback-readonly flag is not respected" && exit 1)
+
+beforeEach
+
+# test 'run' respects custom fallback file location
+"$DOPPLER_BINARY" run --fallback ./fallback.json -- echo -n > /dev/null
+# should fail due to non-existence of default fallback file
+"$DOPPLER_BINARY" run --fallback-only -- echo -n > /dev/null 2>&1 && (echo ERROR: "--fallback flag is not respected" && exit 1)
+"$DOPPLER_BINARY" run --fallback ./fallback.json --fallback-only -- echo -n > /dev/null 2>&1 || (echo ERROR: "--fallback flag is not respected" && exit 1)
+rm -f fallback.json
+
+beforeEach
+
+# test 'run' respects custom passphrase
+"$DOPPLER_BINARY" run --passphrase=123456 -- echo -n > /dev/null
+# ensure default passphrase fails
+"$DOPPLER_BINARY" run --fallback-only -- echo -n > /dev/null 2>&1 && (echo ERROR: "--passphrase flag is not respected" && exit 1)
+# test decryption with custom passphrase
+"$DOPPLER_BINARY" run --fallback-only --passphrase=123456 -- echo -n > /dev/null || (echo ERROR: "--passphrase2 flag is not respected" && exit 1)
+
+beforeEach
+
+# test 'run' respects --no-exit-on-write-failure
+mkdir ./temp-fallback
+chmod 500 ./temp-fallback
+# this should fail
+"$DOPPLER_BINARY" run --fallback=./temp-fallback -- echo -n > /dev/null 2>&1 && (echo ERROR: "--no-exit-on-write-failure flag is not respected" && exit 1)
+# this should succeed
+"$DOPPLER_BINARY" run --fallback=./temp-fallback --no-exit-on-write-failure -- echo -n > /dev/null || (echo ERROR: "--no-exit-on-write-failure flag is not respected" && exit 1)
+rm -rf ./temp-fallback
+
+afterAll

--- a/tests/secrets-download-fallback.sh
+++ b/tests/secrets-download-fallback.sh
@@ -1,0 +1,136 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_NAME="secrets-download-fallback"
+
+cleanup() {
+  exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    echo "ERROR: '$TEST_NAME' tests failed during execution"
+    afterAll || echo "ERROR: Cleanup failed"
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+beforeAll() {
+  echo "INFO: Executing '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+beforeEach() {
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+  rm -f fallback.json
+  rm -rf ./temp-fallback
+}
+
+afterAll() {
+  echo "INFO: Completed '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+  rm -f fallback.json
+  rm -rf ./temp-fallback
+}
+
+beforeAll
+
+beforeEach
+
+# test fallback-only fails when no fallback files exist
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only > /dev/null 2>&1 && (echo ERROR: "--fallback-only flag is not respected" && exit 1)
+
+beforeEach
+
+# test fallback-readonly doesn't write a fallback file
+"$DOPPLER_BINARY" secrets download --no-file --fallback-readonly > /dev/null
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only > /dev/null 2>&1 && (echo ERROR: "--fallback-readonly flag is not respected" && exit 1)
+
+beforeEach
+
+# test 'secrets download' respects custom fallback file location
+"$DOPPLER_BINARY" secrets download --no-file --fallback ./fallback.json > /dev/null
+# should fail due to non-existence of default fallback file
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only > /dev/null 2>&1 && (echo ERROR: "--fallback flag is not respected" && exit 1)
+"$DOPPLER_BINARY" secrets download --no-file --fallback ./fallback.json --fallback-only > /dev/null 2>&1 || (echo ERROR: "--fallback flag is not respected" && exit 1)
+rm -f fallback.json
+
+beforeEach
+
+# test 'secrets download' respects custom passphrase
+"$DOPPLER_BINARY" secrets download --no-file --fallback-passphrase=123456 > /dev/null
+# ensure default passphrase fails
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only > /dev/null 2>&1 && (echo ERROR: "--passphrase flag is not respected" && exit 1)
+# test decryption with custom passphrase
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only --fallback-passphrase=123456 > /dev/null || (echo ERROR: "--passphrase flag is not respected" && exit 1)
+
+beforeEach
+
+# test 'secrets download' respects --no-exit-on-write-failure
+mkdir ./temp-fallback
+chmod 500 ./temp-fallback
+# this should fail
+"$DOPPLER_BINARY" secrets download --no-file --fallback=./temp-fallback > /dev/null 2>&1 && (echo ERROR: "--no-exit-on-write-failure flag is not respected" && exit 1)
+# this should succeed
+"$DOPPLER_BINARY" secrets download --no-file --fallback=./temp-fallback --no-exit-on-write-failure > /dev/null || (echo ERROR: "--no-exit-on-write-failure flag is not respected" && exit 1)
+rm -rf ./temp-fallback
+
+beforeEach
+
+# test fallback file contents matches api response
+a="$("$DOPPLER_BINARY" secrets download --no-file)"
+b="$("$DOPPLER_BINARY" secrets download --no-file --fallback-only)"
+[[ "$a" == "$b" ]] || (echo "ERROR: fallback file contents do not match" && exit 1)
+
+beforeEach
+
+# test 'run' fallback file contents matches 'secrets download' api response
+# generate fallback file
+"$DOPPLER_BINARY" run -- echo -n
+# print fallback file
+a="$("$DOPPLER_BINARY" secrets download --no-file --fallback-only)"
+# fetch from api
+b="$("$DOPPLER_BINARY" secrets download --no-file --no-fallback)"
+[[ "$a" == "$b" ]] || (echo "ERROR: 'run' fallback file contents do not match 'secrets download'" && exit 1)
+
+beforeEach
+
+# test 'secrets download' fallback file can be used with 'run'
+# generate fallback file
+"$DOPPLER_BINARY" secrets download --no-file > /dev/null
+"$DOPPLER_BINARY" run --fallback-only -- echo -n > /dev/null || (echo "ERROR: 'secrets download' fallback file is not used by 'run'" && exit 1)
+
+beforeEach
+
+# test 'secrets download' file can be used as fallback file for 'run'
+"$DOPPLER_BINARY" secrets download --no-fallback ./fallback.json  > /dev/null
+"$DOPPLER_BINARY" run --fallback ./fallback.json --fallback-only > /dev/null -- echo -n || (echo "ERROR: 'secrets download' file failed to be used as fallback file for 'run'" && exit 1)
+rm -f fallback.json
+
+beforeEach
+
+# test 'secrets download' file can be used as fallback file for 'secrets download'
+"$DOPPLER_BINARY" secrets download --no-file --fallback ./fallback.json > /dev/null
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only --fallback ./fallback.json > /dev/null || (echo "ERROR: 'secrets download' file failed to be used as fallback file for 'secrets download'" && exit 1)
+rm -f fallback.json
+
+beforeEach
+
+# test contents of 'secrets download' file when used as fallback file for 'secrets download'
+a="$("$DOPPLER_BINARY" secrets download --no-file --fallback ./fallback.json)"
+b="$("$DOPPLER_BINARY" secrets download --no-file --fallback-only --fallback ./fallback.json)"
+rm -f fallback.json
+[[ "$a" == "$b" ]] || (echo "ERROR: 'secrets download' file contents do not match when used as fallback file for 'secrets download'" && exit 1)
+
+beforeEach
+
+# test 'secrets download' doesn't write fallback when using env format
+"$DOPPLER_BINARY" secrets download --no-file --format=env > /dev/null
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only > /dev/null 2>&1 && (echo ERROR: "'secrets download' should not write fallback file when format is env" && exit 1)
+
+beforeEach
+
+# test 'secrets download' ignores fallback flags when format is env
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only --fallback=./nonexistent-file --format=env > /dev/null
+
+afterAll


### PR DESCRIPTION
Fallback files only work when used with the default JSON format (.env is not supported).