### PR TITLE
chore: add branch name and commit sha to dev build version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 .PHONY: build release test
 
 build:
-	go build -o doppler main.go
+	go build -o doppler -ldflags="-X github.com/DopplerHQ/cli/pkg/version.ProgramVersion=dev-$(shell git rev-parse --abbrev-ref HEAD)-$(shell git rev-parse --short HEAD)" main.go
 
 release:
 	./scripts/release/pre-release.sh $(v)


### PR DESCRIPTION
For this branch, the local build version is `dev-tom_dev_version-06818e6`. It was previously `master`.

Closes DPLR-717.