### PR TITLE
Support using fallback file as secrets cache

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -26,6 +26,7 @@ import (
 	"time"
 
 	"github.com/DopplerHQ/cli/pkg/configuration"
+	"github.com/DopplerHQ/cli/pkg/controllers"
 	"github.com/DopplerHQ/cli/pkg/crypto"
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/models"
@@ -65,6 +66,7 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 	},
 	Run: func(cmd *cobra.Command, args []string) {
 		enableFallback := !utils.GetBoolFlag(cmd, "no-fallback")
+		enableCache := enableFallback && !utils.GetBoolFlag(cmd, "no-cache")
 		fallbackReadonly := utils.GetBoolFlag(cmd, "fallback-readonly")
 		fallbackOnly := utils.GetBoolFlag(cmd, "fallback-only")
 		exitOnWriteFailure := !utils.GetBoolFlag(cmd, "no-exit-on-write-failure")
@@ -75,8 +77,12 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 
 		fallbackPath := ""
 		legacyFallbackPath := ""
+		metadataPath := ""
 		if enableFallback {
 			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, exitOnWriteFailure)
+		}
+		if enableCache {
+			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 		}
 
 		passphrase := getPassphrase(cmd, "passphrase", localConfig)
@@ -93,7 +99,7 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 			}
 		}
 
-		secrets := fetchSecrets(localConfig, enableFallback, fallbackPath, legacyFallbackPath, fallbackReadonly, fallbackOnly, exitOnWriteFailure, passphrase)
+		secrets := fetchSecrets(localConfig, enableCache, enableFallback, fallbackPath, legacyFallbackPath, metadataPath, fallbackReadonly, fallbackOnly, exitOnWriteFailure, passphrase)
 
 		if preserveEnv {
 			utils.LogWarning("Ignoring Doppler secrets already defined in the environment due to --preserve-env flag")
@@ -219,7 +225,7 @@ var runCleanCmd = &cobra.Command{
 }
 
 // fetchSecrets fetches secrets, including all reading and writing of fallback files
-func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbackPath string, legacyFallbackPath string, fallbackReadonly bool, fallbackOnly bool, exitOnWriteFailure bool, passphrase string) map[string]string {
+func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, enableFallback bool, fallbackPath string, legacyFallbackPath string, metadataPath string, fallbackReadonly bool, fallbackOnly bool, exitOnWriteFailure bool, passphrase string) map[string]string {
 	if fallbackOnly {
 		if !enableFallback {
 			utils.HandleError(errors.New("Conflict: unable to specify --no-fallback with --fallback-only"))
@@ -227,14 +233,38 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 		return readFallbackFile(fallbackPath, legacyFallbackPath, passphrase)
 	}
 
-	response, httpErr := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, true)
-	if httpErr != (http.Error{}) {
+	// this scenario likely isn't possible, but just to be safe, disable using cache when there's no metadata file
+	enableCache = enableCache && metadataPath != ""
+	etag := ""
+	if enableCache {
+		metadata, err := controllers.MetadataFile(metadataPath)
+		if !err.IsNil() {
+			utils.LogDebugError(err.Unwrap())
+			utils.LogDebug(err.Message)
+		} else {
+			etag = metadata.ETag
+		}
+	}
+
+	statusCode, respHeaders, response, httpErr := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, true, etag)
+	if !httpErr.IsNil() {
 		if enableFallback {
 			utils.Log("Unable to fetch secrets from the Doppler API")
 			utils.LogError(httpErr.Unwrap())
 			return readFallbackFile(fallbackPath, legacyFallbackPath, passphrase)
 		}
 		utils.HandleError(httpErr.Unwrap(), httpErr.Message)
+	}
+
+	if enableCache && statusCode == 304 {
+		utils.LogDebug("Using cached secrets from fallback file")
+		cache, err := controllers.SecretsCacheFile(fallbackPath, passphrase)
+		if !err.IsNil() {
+			utils.LogDebugError(err.Unwrap())
+			utils.LogDebug(err.Message)
+		} else {
+			return cache
+		}
 	}
 
 	// ensure the response can be parsed before proceeding
@@ -276,6 +306,17 @@ func fetchSecrets(localConfig models.ScopedOptions, enableFallback bool, fallbac
 				} else {
 					utils.LogDebugError(err)
 				}
+			}
+		}
+
+		if enableCache {
+			if etag := respHeaders.Get("etag"); etag != "" {
+				if err := controllers.WriteMetadataFile(metadataPath, etag); !err.IsNil() {
+					utils.LogDebugError(err.Unwrap())
+					utils.LogDebug(err.Message)
+				}
+			} else {
+				utils.LogDebug("API response does not contain ETag")
 			}
 		}
 	}
@@ -443,6 +484,7 @@ func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, exitOnWrit
 
 func init() {
 	defaultFallbackDir = filepath.Join(configuration.UserConfigDir, "fallback")
+	controllers.DefaultMetadataDir = defaultFallbackDir
 
 	runCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")
 	runCmd.Flags().StringP("config", "c", "", "config (e.g. dev)")
@@ -452,7 +494,8 @@ func init() {
 	runCmd.Flags().String("fallback", "", "path to the fallback file. encrypted secrets are written to this file after each successful fetch. secrets will be read from this file if subsequent connections are unsuccessful.")
 	// TODO rename this to 'fallback-passphrase' in CLI v4 (DPLR-435)
 	runCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the fallback file. the default passphrase is computed using your current configuration.")
-	runCmd.Flags().Bool("no-fallback", false, "disable reading and writing the fallback file")
+	runCmd.Flags().Bool("no-cache", false, "disable using the fallback file to speed up fetches. the fallback file is only used when the API indicates that it's still current.")
+	runCmd.Flags().Bool("no-fallback", false, "disable reading and writing the fallback file (implies --no-cache)")
 	runCmd.Flags().Bool("fallback-readonly", false, "disable modifying the fallback file. secrets can still be read from the file.")
 	runCmd.Flags().Bool("fallback-only", false, "read all secrets directly from the fallback file, without contacting Doppler. secrets will not be updated. (implies --fallback-readonly)")
 	runCmd.Flags().Bool("no-exit-on-write-failure", false, "do not exit if unable to write the fallback file")

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -1,0 +1,127 @@
+/*
+Copyright © 2020 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+
+	"github.com/DopplerHQ/cli/pkg/crypto"
+	"github.com/DopplerHQ/cli/pkg/models"
+	"github.com/DopplerHQ/cli/pkg/utils"
+	"gopkg.in/yaml.v3"
+)
+
+// DefaultMetadataDir the directory containing metadata files
+var DefaultMetadataDir string
+
+// MetadataFilePath calculates the name of the metadata file
+func MetadataFilePath(token string, project string, config string) string {
+	var name string
+	if project == "" && config == "" {
+		name = fmt.Sprintf("%s", token)
+	} else {
+		name = fmt.Sprintf("%s:%s:%s", token, project, config)
+	}
+
+	fileName := fmt.Sprintf(".metadata-%s.json", crypto.Hash(name))
+	path := filepath.Join(DefaultMetadataDir, fileName)
+	if absPath, err := filepath.Abs(path); err == nil {
+		return absPath
+	}
+	return path
+}
+
+// MetadataFile reads the contents of the metadata file
+func MetadataFile(path string) (models.SecretsFileMetadata, Error) {
+	utils.LogDebug(fmt.Sprintf("Using metadata file %s", path))
+
+	if _, err := os.Stat(path); err != nil {
+		var e Error
+		e.Err = err
+		if os.IsNotExist(err) {
+			e.Message = "Metadata file does not exist"
+		} else {
+			e.Message = "Unable to read metadata file"
+		}
+		return models.SecretsFileMetadata{}, e
+	}
+
+	utils.LogDebug(fmt.Sprintf("Reading metadata file %s", path))
+	response, err := ioutil.ReadFile(path) // #nosec G304
+	if err != nil {
+		return models.SecretsFileMetadata{}, Error{Err: err, Message: "Unable to read metadata file"}
+	}
+
+	var metadata models.SecretsFileMetadata
+	if err := yaml.Unmarshal(response, &metadata); err != nil {
+		return models.SecretsFileMetadata{}, Error{Err: err, Message: "Unable to parse metadata file"}
+	}
+
+	return metadata, Error{}
+}
+
+// WriteMetadataFile writes the contents of the metadata file
+func WriteMetadataFile(path string, etag string) Error {
+	utils.LogDebug(fmt.Sprintf("Writing ETag to metadata file %s", path))
+
+	metadata := models.SecretsFileMetadata{
+		Version: "1",
+		ETag:    etag,
+	}
+
+	metadataBytes, err := yaml.Marshal(metadata)
+	if err != nil {
+		return Error{Err: err, Message: "Unable to marshal metadata to YAML"}
+	}
+
+	if err := utils.WriteFile(path, []byte(metadataBytes), utils.RestrictedFilePerms()); err != nil {
+		return Error{Err: err, Message: "Unable to write metadata file"}
+	}
+
+	return Error{}
+}
+
+// SecretsCacheFile reads the contents of the cache file
+func SecretsCacheFile(path string, passphrase string) (map[string]string, Error) {
+	utils.LogDebug(fmt.Sprintf("Using fallback file for cache %s", path))
+
+	if _, err := os.Stat(path); err != nil {
+		return nil, Error{Err: err, Message: "Unable to stat fallback file"}
+	}
+
+	response, err := ioutil.ReadFile(path) // #nosec G304
+	if err != nil {
+		return nil, Error{Err: err, Message: "Unable to read fallback file"}
+	}
+
+	utils.LogDebug("Decrypting fallback file")
+	decryptedSecrets, err := crypto.Decrypt(passphrase, response)
+	if err != nil {
+		return nil, Error{Err: err, Message: "Unable to decrypt fallback file"}
+	}
+
+	secrets := map[string]string{}
+	err = json.Unmarshal([]byte(decryptedSecrets), &secrets)
+	if err != nil {
+		return nil, Error{Err: err, Message: "Unable to parse fallback file"}
+	}
+
+	return secrets, Error{}
+}

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -50,7 +50,7 @@ func GenerateAuthCode(host string, verifyTLS bool, hostname string, os string, a
 	params = append(params, queryParam{Key: "os", Value: os})
 	params = append(params, queryParam{Key: "arch", Value: arch})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, nil, "/auth/v1/cli/generate", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, nil, "/auth/v1/cli/generate", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch auth code", Code: statusCode}
 	}
@@ -73,7 +73,7 @@ func GetAuthToken(host string, verifyTLS bool, code string) (map[string]interfac
 		return nil, Error{Err: err, Message: "Invalid auth code"}
 	}
 
-	statusCode, response, err := PostRequest(host, verifyTLS, nil, "/auth/v1/cli/authorize", []queryParam{}, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, nil, "/auth/v1/cli/authorize", []queryParam{}, body)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch auth token", Code: statusCode}
 	}
@@ -96,7 +96,7 @@ func RollAuthToken(host string, verifyTLS bool, token string) (map[string]interf
 		return nil, Error{Err: err, Message: "Invalid auth token"}
 	}
 
-	statusCode, response, err := PostRequest(host, verifyTLS, nil, "/auth/v1/cli/roll", []queryParam{}, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, nil, "/auth/v1/cli/roll", []queryParam{}, body)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to roll auth token", Code: statusCode}
 	}
@@ -119,7 +119,7 @@ func RevokeAuthToken(host string, verifyTLS bool, token string) (map[string]inte
 		return nil, Error{Err: err, Message: "Invalid auth token"}
 	}
 
-	statusCode, response, err := PostRequest(host, verifyTLS, nil, "/auth/v1/cli/revoke", []queryParam{}, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, nil, "/auth/v1/cli/revoke", []queryParam{}, body)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to revoke auth token", Code: statusCode}
 	}
@@ -146,7 +146,7 @@ func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string,
 		headers["Accept"] = "text/plain"
 	}
 
-	statusCode, response, err := GetRequest(host, verifyTLS, headers, "/v3/configs/config/secrets/download", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, headers, "/v3/configs/config/secrets/download", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to download secrets", Code: statusCode}
 	}
@@ -162,7 +162,7 @@ func GetSecrets(host string, verifyTLS bool, apiKey string, project string, conf
 
 	headers := apiKeyHeader(apiKey)
 	headers["Accept"] = "application/json"
-	statusCode, response, err := GetRequest(host, verifyTLS, headers, "/v3/configs/config/secrets", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, headers, "/v3/configs/config/secrets", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch secrets", Code: statusCode}
 	}
@@ -183,7 +183,7 @@ func SetSecrets(host string, verifyTLS bool, apiKey string, project string, conf
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/secrets", params, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/secrets", params, body)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to set secrets", Code: statusCode}
 	}
@@ -205,7 +205,7 @@ func SetSecrets(host string, verifyTLS bool, apiKey string, project string, conf
 
 // GetWorkplaceSettings get specified workplace settings
 func GetWorkplaceSettings(host string, verifyTLS bool, apiKey string) (models.WorkplaceSettings, Error) {
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/workplace/v1", []queryParam{})
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/workplace/v1", []queryParam{})
 	if err != nil {
 		return models.WorkplaceSettings{}, Error{Err: err, Message: "Unable to fetch workplace settings", Code: statusCode}
 	}
@@ -227,7 +227,7 @@ func SetWorkplaceSettings(host string, verifyTLS bool, apiKey string, values mod
 		return models.WorkplaceSettings{}, Error{Err: err, Message: "Invalid workplace settings"}
 	}
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/workplace/v1", []queryParam{}, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/workplace/v1", []queryParam{}, body)
 	if err != nil {
 		return models.WorkplaceSettings{}, Error{Err: err, Message: "Unable to update workplace settings", Code: statusCode}
 	}
@@ -244,7 +244,7 @@ func SetWorkplaceSettings(host string, verifyTLS bool, apiKey string, values mod
 
 // GetProjects get projects
 func GetProjects(host string, verifyTLS bool, apiKey string) ([]models.ProjectInfo, Error) {
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects", []queryParam{})
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects", []queryParam{})
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch projects", Code: statusCode}
 	}
@@ -268,7 +268,7 @@ func GetProject(host string, verifyTLS bool, apiKey string, project string) (mod
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects/project", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects/project", params)
 	if err != nil {
 		return models.ProjectInfo{}, Error{Err: err, Message: "Unable to fetch project", Code: statusCode}
 	}
@@ -291,7 +291,7 @@ func CreateProject(host string, verifyTLS bool, apiKey string, name string, desc
 		return models.ProjectInfo{}, Error{Err: err, Message: "Invalid project info"}
 	}
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects", []queryParam{}, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects", []queryParam{}, body)
 	if err != nil {
 		return models.ProjectInfo{}, Error{Err: err, Message: "Unable to create project", Code: statusCode}
 	}
@@ -322,7 +322,7 @@ func UpdateProject(host string, verifyTLS bool, apiKey string, project string, n
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects/project", params, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects/project", params, body)
 	if err != nil {
 		return models.ProjectInfo{}, Error{Err: err, Message: "Unable to update project", Code: statusCode}
 	}
@@ -342,7 +342,7 @@ func DeleteProject(host string, verifyTLS bool, apiKey string, project string) E
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 
-	statusCode, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects/project", params)
+	statusCode, _, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/projects/project", params)
 	if err != nil {
 		return Error{Err: err, Message: "Unable to delete project", Code: statusCode}
 	}
@@ -361,7 +361,7 @@ func GetEnvironments(host string, verifyTLS bool, apiKey string, project string)
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/environments", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/environments", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch environments", Code: statusCode}
 	}
@@ -386,7 +386,7 @@ func GetEnvironment(host string, verifyTLS bool, apiKey string, project string, 
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "environment", Value: environment})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/environments/environment", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/environments/environment", params)
 	if err != nil {
 		return models.EnvironmentInfo{}, Error{Err: err, Message: "Unable to fetch environment", Code: statusCode}
 	}
@@ -406,7 +406,7 @@ func GetConfigs(host string, verifyTLS bool, apiKey string, project string) ([]m
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch configs", Code: statusCode}
 	}
@@ -431,7 +431,7 @@ func GetConfig(host string, verifyTLS bool, apiKey string, project string, confi
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config", params)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to fetch configs", Code: statusCode}
 	}
@@ -457,7 +457,7 @@ func CreateConfig(host string, verifyTLS bool, apiKey string, project string, na
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs", params, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs", params, body)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to create config", Code: statusCode}
 	}
@@ -478,7 +478,7 @@ func DeleteConfig(host string, verifyTLS bool, apiKey string, project string, co
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config", params)
+	statusCode, _, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config", params)
 	if err != nil {
 		return Error{Err: err, Message: "Unable to delete config", Code: statusCode}
 	}
@@ -498,7 +498,7 @@ func LockConfig(host string, verifyTLS bool, apiKey string, project string, conf
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/lock", params, nil)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/lock", params, nil)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to lock config", Code: statusCode}
 	}
@@ -519,7 +519,7 @@ func UnlockConfig(host string, verifyTLS bool, apiKey string, project string, co
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/unlock", params, nil)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/unlock", params, nil)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to unlock config", Code: statusCode}
 	}
@@ -546,7 +546,7 @@ func UpdateConfig(host string, verifyTLS bool, apiKey string, project string, co
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config", params, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config", params, body)
 	if err != nil {
 		return models.ConfigInfo{}, Error{Err: err, Message: "Unable to update config", Code: statusCode}
 	}
@@ -563,7 +563,7 @@ func UpdateConfig(host string, verifyTLS bool, apiKey string, project string, co
 
 // GetActivityLogs get activity logs
 func GetActivityLogs(host string, verifyTLS bool, apiKey string) ([]models.ActivityLog, Error) {
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/logs/v1", []queryParam{})
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/logs/v1", []queryParam{})
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch activity logs", Code: statusCode}
 	}
@@ -584,7 +584,7 @@ func GetActivityLogs(host string, verifyTLS bool, apiKey string) ([]models.Activ
 
 // GetActivityLog get specified activity log
 func GetActivityLog(host string, verifyTLS bool, apiKey string, log string) (models.ActivityLog, Error) {
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/logs/v1/"+log, []queryParam{})
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/logs/v1/"+log, []queryParam{})
 	if err != nil {
 		return models.ActivityLog{}, Error{Err: err, Message: "Unable to fetch activity log", Code: statusCode}
 	}
@@ -605,7 +605,7 @@ func GetConfigLogs(host string, verifyTLS bool, apiKey string, project string, c
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/logs", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/logs", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch config logs", Code: statusCode}
 	}
@@ -631,7 +631,7 @@ func GetConfigLog(host string, verifyTLS bool, apiKey string, project string, co
 	params = append(params, queryParam{Key: "config", Value: config})
 	params = append(params, queryParam{Key: "log", Value: log})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/logs/log", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/logs/log", params)
 	if err != nil {
 		return models.ConfigLog{}, Error{Err: err, Message: "Unable to fetch config log", Code: statusCode}
 	}
@@ -653,7 +653,7 @@ func RollbackConfigLog(host string, verifyTLS bool, apiKey string, project strin
 	params = append(params, queryParam{Key: "config", Value: config})
 	params = append(params, queryParam{Key: "log", Value: log})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/logs/log/rollback", params, nil)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/logs/log/rollback", params, nil)
 	if err != nil {
 		return models.ConfigLog{}, Error{Err: err, Message: "Unable to rollback config log", Code: statusCode}
 	}
@@ -674,7 +674,7 @@ func GetConfigServiceTokens(host string, verifyTLS bool, apiKey string, project 
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/tokens", params)
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/tokens", params)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to fetch service tokens", Code: statusCode}
 	}
@@ -705,7 +705,7 @@ func CreateConfigServiceToken(host string, verifyTLS bool, apiKey string, projec
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 
-	statusCode, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/tokens", params, body)
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/tokens", params, body)
 	if err != nil {
 		return models.ConfigServiceToken{}, Error{Err: err, Message: "Unable to create service token", Code: statusCode}
 	}
@@ -727,7 +727,7 @@ func DeleteConfigServiceToken(host string, verifyTLS bool, apiKey string, projec
 	params = append(params, queryParam{Key: "config", Value: config})
 	params = append(params, queryParam{Key: "slug", Value: slug})
 
-	statusCode, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/tokens/token", params)
+	statusCode, _, response, err := DeleteRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/tokens/token", params)
 	if err != nil {
 		return Error{Err: err, Message: "Unable to delete service token", Code: statusCode}
 	}

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -19,6 +19,7 @@ import (
 	"encoding/base64"
 	"encoding/json"
 	"fmt"
+	"net/http"
 
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/version"
@@ -134,7 +135,7 @@ func RevokeAuthToken(host string, verifyTLS bool, token string) (map[string]inte
 }
 
 // DownloadSecrets for specified project and config
-func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string, config string, jsonFlag bool) ([]byte, Error) {
+func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string, config string, jsonFlag bool, etag string) (int, http.Header, []byte, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
@@ -145,13 +146,16 @@ func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string,
 	} else {
 		headers["Accept"] = "text/plain"
 	}
-
-	statusCode, _, response, err := GetRequest(host, verifyTLS, headers, "/v3/configs/config/secrets/download", params)
-	if err != nil {
-		return nil, Error{Err: err, Message: "Unable to download secrets", Code: statusCode}
+	if etag != "" {
+		headers["If-None-Match"] = etag
 	}
 
-	return response, Error{}
+	statusCode, respHeaders, response, err := GetRequest(host, verifyTLS, headers, "/v3/configs/config/secrets/download", params)
+	if err != nil {
+		return statusCode, respHeaders, nil, Error{Err: err, Message: "Unable to download secrets", Code: statusCode}
+	}
+
+	return statusCode, respHeaders, response, Error{}
 }
 
 // GetSecrets for specified project and config

--- a/pkg/http/github.go
+++ b/pkg/http/github.go
@@ -28,7 +28,7 @@ import (
 func getLatestVersion() (string, error) {
 	origTimeout := TimeoutDuration
 	TimeoutDuration = 2 * time.Second
-	_, resp, err := GetRequest("https://api.github.com", true, nil, "/repos/DopplerHQ/cli/releases/latest", nil)
+	_, _, resp, err := GetRequest("https://api.github.com", true, nil, "/repos/DopplerHQ/cli/releases/latest", nil)
 	TimeoutDuration = origTimeout
 	if err != nil {
 		return "", err
@@ -63,7 +63,7 @@ func GetLatestCLIVersion() (models.VersionCheck, error) {
 
 // GetCLIInstallScript from cli.doppler.com
 func GetCLIInstallScript() ([]byte, Error) {
-	_, resp, err := GetRequest("https://cli.doppler.com", true, nil, "/install.sh", nil)
+	_, _, resp, err := GetRequest("https://cli.doppler.com", true, nil, "/install.sh", nil)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to download CLI install script"}
 	}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -221,7 +221,7 @@ func performRequest(req *http.Request, verifyTLS bool, params []queryParam) (int
 }
 
 func isSuccess(statusCode int) bool {
-	return statusCode >= 200 && statusCode <= 299
+	return (statusCode >= 200 && statusCode <= 299) || (statusCode >= 300 && statusCode <= 399)
 }
 
 func isRetry(statusCode int) bool {

--- a/pkg/models/files.go
+++ b/pkg/models/files.go
@@ -1,0 +1,36 @@
+/*
+Copyright © 2020 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package models
+
+// SecretsFileMetadata contains metadata about a secrets file
+type SecretsFileMetadata struct {
+	Version string `json:"version,omitempty" yaml:"version,omitempty"`
+	ETag    string `json:"etag,omitempty" yaml:"etag,omitempty"`
+}
+
+// ParseSecretsFileMetadata parse secrets file metadata
+func ParseSecretsFileMetadata(data map[string]interface{}) SecretsFileMetadata {
+	var parsedMetadata SecretsFileMetadata
+
+	if data["version"] != nil {
+		parsedMetadata.Version = data["version"].(string)
+	}
+	if data["etag"] != nil {
+		parsedMetadata.ETag = data["etag"].(string)
+	}
+
+	return parsedMetadata
+}


### PR DESCRIPTION
Currently, on successful secrets fetch, the CLI encrypts the response and saves it as a fallback file. With this PR, we now additionally save the response ETag to a separate metadata file.

On subsequent fetches, we read the ETag from the metadata file and send it in the request's `If-None-Match` header. If the server confirms that this is still the latest hash, it sends back a 304. The CLI responds to this 304 by reading the fallback file. This results in a speed improvement due to the API performing a fast hash lookup, rather than a slower token reveal. 