### PR TITLE
Only display update prompt once per version

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -82,7 +82,7 @@ func checkVersion(command string) {
 		return
 	}
 
-	available, versionCheck, err := controllers.NewVersionAvailable()
+	available, versionCheck, err := controllers.NewVersionAvailable(prevVersionCheck)
 	if err != nil {
 		// retry on next run
 		return

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 
 	"github.com/DopplerHQ/cli/pkg/controllers"
+	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/printer"
 	"github.com/DopplerHQ/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -34,7 +35,7 @@ var updateCmd = &cobra.Command{
 		}
 
 		force := utils.GetBoolFlag(cmd, "force")
-		available, _, err := controllers.NewVersionAvailable()
+		available, _, err := controllers.NewVersionAvailable(models.VersionCheck{})
 		if err != nil {
 			utils.HandleError(err, "Unable to check for CLI updates")
 		}

--- a/pkg/controllers/version.go
+++ b/pkg/controllers/version.go
@@ -25,7 +25,7 @@ import (
 )
 
 // NewVersionAvailable checks whether a CLI version is available that's newer than this CLI
-func NewVersionAvailable() (bool, models.VersionCheck, error) {
+func NewVersionAvailable(prevVersionCheck models.VersionCheck) (bool, models.VersionCheck, error) {
 	now := time.Now()
 	check, err := http.GetLatestCLIVersion()
 	if err != nil {
@@ -35,6 +35,13 @@ func NewVersionAvailable() (bool, models.VersionCheck, error) {
 	}
 
 	versionCheck := models.VersionCheck{CheckedAt: now, LatestVersion: version.Normalize(check.LatestVersion)}
+
+	// skip if available version is unchanged from previous check
+	if versionCheck.LatestVersion == prevVersionCheck.LatestVersion {
+		utils.LogDebug("Previous version check is still latest version")
+		return false, versionCheck, nil
+	}
+
 	newVersion, err := version.ParseVersion(versionCheck.LatestVersion)
 	if err != nil {
 		utils.LogDebug("Unable to parse new CLI version")


### PR DESCRIPTION
After checking for an update, we save the retrieved version to the CLI's config file. If on subsequent checks that same version is still the latest, don't prompt the user.