### PR TITLE
Verify hash of cache file before using

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -267,9 +267,12 @@ func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, enableFall
 		if !err.IsNil() {
 			utils.LogDebugError(err.Unwrap())
 			utils.LogDebug(err.Message)
-		} else {
-			return cache
+
+			// we have to exit here as we don't have any secrets to parse
+			utils.HandleError(err.Unwrap(), err.Message)
 		}
+
+		return cache
 	}
 
 	// ensure the response can be parsed before proceeding

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -278,6 +278,8 @@ func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, enableFall
 	// ensure the response can be parsed before proceeding
 	secrets, err := parseSecrets(response)
 	if err != nil {
+		utils.LogDebugError(err)
+
 		if enableFallback {
 			utils.Log("Unable to parse the Doppler API response")
 			utils.LogError(httpErr.Unwrap())

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -78,12 +78,13 @@ func MetadataFile(path string) (models.SecretsFileMetadata, Error) {
 }
 
 // WriteMetadataFile writes the contents of the metadata file
-func WriteMetadataFile(path string, etag string) Error {
+func WriteMetadataFile(path string, etag string, hash string) Error {
 	utils.LogDebug(fmt.Sprintf("Writing ETag to metadata file %s", path))
 
 	metadata := models.SecretsFileMetadata{
 		Version: "1",
 		ETag:    etag,
+		Hash:    hash,
 	}
 
 	metadataBytes, err := yaml.Marshal(metadata)

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -104,24 +104,24 @@ func SecretsCacheFile(path string, passphrase string) (map[string]string, Error)
 	utils.LogDebug(fmt.Sprintf("Using fallback file for cache %s", path))
 
 	if _, err := os.Stat(path); err != nil {
-		return nil, Error{Err: err, Message: "Unable to stat fallback file"}
+		return nil, Error{Err: err, Message: "Unable to stat cache file"}
 	}
 
 	response, err := ioutil.ReadFile(path) // #nosec G304
 	if err != nil {
-		return nil, Error{Err: err, Message: "Unable to read fallback file"}
+		return nil, Error{Err: err, Message: "Unable to read cache file"}
 	}
 
-	utils.LogDebug("Decrypting fallback file")
+	utils.LogDebug("Decrypting cache file")
 	decryptedSecrets, err := crypto.Decrypt(passphrase, response)
 	if err != nil {
-		return nil, Error{Err: err, Message: "Unable to decrypt fallback file"}
+		return nil, Error{Err: err, Message: "Unable to decrypt cache file"}
 	}
 
 	secrets := map[string]string{}
 	err = json.Unmarshal([]byte(decryptedSecrets), &secrets)
 	if err != nil {
-		return nil, Error{Err: err, Message: "Unable to parse fallback file"}
+		return nil, Error{Err: err, Message: "Unable to parse cache file"}
 	}
 
 	return secrets, Error{}

--- a/pkg/models/files.go
+++ b/pkg/models/files.go
@@ -19,6 +19,7 @@ package models
 type SecretsFileMetadata struct {
 	Version string `json:"version,omitempty" yaml:"version,omitempty"`
 	ETag    string `json:"etag,omitempty" yaml:"etag,omitempty"`
+	Hash    string `json:"hash,omitempty" yaml:"hash,omitempty"`
 }
 
 // ParseSecretsFileMetadata parse secrets file metadata
@@ -30,6 +31,9 @@ func ParseSecretsFileMetadata(data map[string]interface{}) SecretsFileMetadata {
 	}
 	if data["etag"] != nil {
 		parsedMetadata.ETag = data["etag"].(string)
+	}
+	if data["hash"] != nil {
+		parsedMetadata.Hash = data["hash"].(string)
 	}
 
 	return parsedMetadata

--- a/tests/run-fallback.sh
+++ b/tests/run-fallback.sh
@@ -22,14 +22,14 @@ beforeAll() {
 
 beforeEach() {
   "$DOPPLER_BINARY" run clean --max-age=0s --silent
-  rm -f fallback.json
+  rm -f fallback.json nonexistent-fallback.json
   rm -rf ./temp-fallback
 }
 
 afterAll() {
   echo "INFO: Completed '$TEST_NAME' tests"
   "$DOPPLER_BINARY" run clean --max-age=0s --silent
-  rm -f fallback.json
+  rm -f fallback.json nonexistent-fallback.json
   rm -rf ./temp-fallback
 }
 
@@ -74,5 +74,27 @@ chmod 500 ./temp-fallback
 # this should succeed
 "$DOPPLER_BINARY" run --fallback=./temp-fallback --no-exit-on-write-failure -- echo -n > /dev/null || (echo "ERROR: --no-exit-on-write-failure flag is not respected" && exit 1)
 rm -rf ./temp-fallback
+
+beforeEach
+
+# test 'run' w/ no cache and invalid fallback file
+"$DOPPLER_BINARY" run --fallback ./fallback.json -- echo -n > /dev/null
+rm -f fallback.json
+
+beforeEach
+
+# test 'run' w/ valid cache and invalid fallback file
+"$DOPPLER_BINARY" run --fallback ./fallback.json -- echo -n > /dev/null
+rm -f fallback.json
+echo "foo" > ./fallback.json
+"$DOPPLER_BINARY" run --fallback ./fallback.json -- echo -n > /dev/null || (echo "ERROR: run w/ valid cache is not ignoring invalid fallback file" && exit 1)
+rm -f fallback.json
+
+beforeEach
+
+# test 'run' w/ valid cache and non-existent fallback file
+"$DOPPLER_BINARY" run --fallback ./fallback.json -- echo -n > /dev/null
+"$DOPPLER_BINARY" run --fallback ./nonexistent-fallback.json -- echo -n > /dev/null || (echo "ERROR: run w/ valid cache is not ignoring nonexistent fallback file" && exit 1)
+rm -f fallback.json nonexistent-fallback.json
 
 afterAll

--- a/tests/secrets-download-fallback.sh
+++ b/tests/secrets-download-fallback.sh
@@ -158,4 +158,26 @@ beforeEach
 # test 'secrets download' ignores fallback flags when format is yaml
 "$DOPPLER_BINARY" secrets download --no-file --fallback-only --fallback=./nonexistent-file --format=yaml > /dev/null
 
+beforeEach
+
+# test 'secrets download' w/ no cache and invalid fallback file
+"$DOPPLER_BINARY" secrets download --no-file --fallback ./fallback.json > /dev/null
+rm -f fallback.json
+
+beforeEach
+
+# test 'secrets download' w/ valid cache and invalid fallback file
+"$DOPPLER_BINARY" secrets download --no-file --fallback ./fallback.json > /dev/null
+rm -f fallback.json
+echo "foo" > ./fallback.json
+"$DOPPLER_BINARY" secrets download --no-file --fallback ./fallback.json > /dev/null || (echo "ERROR: run w/ valid cache is not ignoring invalid fallback file" && exit 1)
+rm -f fallback.json
+
+beforeEach
+
+# test 'secrets download' w/ valid cache and non-existent fallback file
+"$DOPPLER_BINARY" secrets download --no-file --fallback ./fallback.json > /dev/null
+"$DOPPLER_BINARY" secrets download --no-file --fallback ./nonexistent-fallback.json > /dev/null || (echo "ERROR: run w/ valid cache is not ignoring nonexistent fallback file" && exit 1)
+rm -f fallback.json
+
 afterAll


### PR DESCRIPTION
This handles a previously unconsidered edge case where a valid etag has been cached, but the fallback file points to a different file than what was saved. The fallback file would fail to decrypt and cause the command to exit.

To reproduce locally:
1. Generate metadata file and fallback file: `doppler run --fallback ./fallback.json`
2. Modify fallback file contents: `rm -f ./fallback.json && echo foo > ./fallback.json`
3. Execute again: `doppler run --fallback ./fallback.json`

Closes DPLR-900.