### PR TITLE
Support downloading secrets in docker-specific format

### DIFF
--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -139,9 +139,9 @@ func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string,
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
+	params = append(params, queryParam{Key: "format", Value: format.String()})
 
 	headers := apiKeyHeader(apiKey)
-	headers["Accept"] = format.MimeType()
 	if etag != "" {
 		headers["If-None-Match"] = etag
 	}

--- a/pkg/models/secrets_format.go
+++ b/pkg/models/secrets_format.go
@@ -23,15 +23,16 @@ const (
 	JSON SecretsFormat = iota
 	ENV
 	YAML
+	DOCKER
 )
 
 func (s SecretsFormat) String() string {
-	return [...]string{"json", "env", "yaml"}[s]
+	return [...]string{"json", "env", "yaml", "docker"}[s]
 }
 
 // OutputFile the default secrets file name
 func (s SecretsFormat) OutputFile() string {
-	return [...]string{"doppler.json", "doppler.env", "secrets.yaml"}[s]
+	return [...]string{"doppler.json", "doppler.env", "secrets.yaml", "doppler.env"}[s]
 }
 
 // SecretsFormatList list of supported secrets formats
@@ -41,4 +42,5 @@ func init() {
 	SecretsFormatList = append(SecretsFormatList, JSON)
 	SecretsFormatList = append(SecretsFormatList, ENV)
 	SecretsFormatList = append(SecretsFormatList, YAML)
+	SecretsFormatList = append(SecretsFormatList, DOCKER)
 }

--- a/pkg/models/secrets_format.go
+++ b/pkg/models/secrets_format.go
@@ -34,11 +34,6 @@ func (s SecretsFormat) OutputFile() string {
 	return [...]string{"doppler.json", "doppler.env", "secrets.yaml"}[s]
 }
 
-// MimeType the mime type of a given format
-func (s SecretsFormat) MimeType() string {
-	return [...]string{"application/json", "text/plain", "text/yaml"}[s]
-}
-
 // SecretsFormatList list of supported secrets formats
 var SecretsFormatList []SecretsFormat
 


### PR DESCRIPTION
This produces a format that can be injected via `docker run --env-file`.

Closes DPLR-1009.