### PR TITLE
Add support for generating and installing shell completions

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -379,6 +379,11 @@ func IsWindows() bool {
 	return runtime.GOOS == "windows"
 }
 
+// IsMacOS whether the host os is macOS
+func IsMacOS() bool {
+	return runtime.GOOS == "darwin"
+}
+
 // UUID generates a random UUID
 func UUID() (string, error) {
 	uuid, err := uuid.NewRandom()


### PR DESCRIPTION
This supports generating completions for bash and zsh, and installing completions for bash.

Closes DPLR-585