### PR TITLE
Add error handling for missing parent dir when using `--configuration`

### DIFF
--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -65,6 +65,12 @@ func Setup() {
 		}
 	}
 
+	// This may be different from `UserConfigDir` if `--configuration` was provided
+	configDir := filepath.Dir(UserConfigFile)
+	if !utils.Exists(configDir) {
+		utils.HandleError(fmt.Errorf("Configuration file directory does not exist %s", configDir))
+	}
+
 	if !utils.Exists(UserConfigFile) {
 		v1ConfigA := filepath.Join(utils.ConfigDir(), configFileName)
 		v1ConfigB := filepath.Join(utils.HomeDir(), configFileName)


### PR DESCRIPTION
The CLI is designed to create the `UserConfigDir` if it does not already exist. However, when the user specifies `--configuration`, it replaces `UserConfigFile` but not `UserConfigDir` (which is still used in its original form for storing fallback files). To reduce confusion, this change adds a check to make sure that the parent directory of `UserConfigFile` exists and raises a specific error otherwise.