### PR TITLE
chore: cleanup script resources when killed via SIGINT

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -26,6 +26,7 @@ cleanup() {
   exit "$exit_code"
 }
 trap cleanup EXIT
+trap cleanup INT
 
 clean_exit() {
   CLEAN_EXIT=1

--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -11,6 +11,7 @@ function cleanup {
   rm -rf "$DOCKER_CONFIG"
 }
 trap cleanup EXIT
+trap cleanup INT
 
 echo "Using Docker config $DOCKER_CONFIG"
 


### PR DESCRIPTION
We already cleanup on exit so this was an unhandled edge case.