### PR TITLE
Redact token when printed on screen

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -60,7 +60,7 @@ and your config file. Flags have the highest priority; config file has the least
 		utils.Log(fmt.Sprintf("%s %s", color.Green.Render("Configuration file:"), configuration.UserConfigFile))
 
 		config := configuration.LocalConfig(cmd)
-		printer.ScopedConfigSource(config, jsonFlag, true)
+		printer.ScopedConfigSource(config, jsonFlag, true, false)
 	},
 }
 

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -47,7 +47,7 @@ var rootCmd = &cobra.Command{
 		printConfig := utils.GetBoolFlagIfChanged(cmd, "print-config", false)
 		if printConfig {
 			fmt.Println("Active configuration")
-			printer.ScopedConfigSource(configuration.LocalConfig(cmd), false, true)
+			printer.ScopedConfigSource(configuration.LocalConfig(cmd), false, true, true)
 			fmt.Println("")
 		}
 

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -160,7 +160,7 @@ func setup(cmd *cobra.Command, args []string) {
 		conf := configuration.Get(configuration.Scope)
 		valuesToPrint := []string{models.ConfigEnclaveConfig.String(), models.ConfigEnclaveProject.String()}
 		if saveToken {
-			valuesToPrint = append(valuesToPrint, models.ConfigToken.String())
+			valuesToPrint = append(valuesToPrint, utils.RedactAuthToken(models.ConfigToken.String()))
 		}
 		printer.ScopedConfigValues(conf, valuesToPrint, models.ScopedPairs(&conf), utils.OutputJSON, false, false)
 	}

--- a/pkg/printer/config.go
+++ b/pkg/printer/config.go
@@ -27,11 +27,11 @@ import (
 
 // ScopedConfig print scoped config
 func ScopedConfig(conf models.ScopedOptions, jsonFlag bool) {
-	ScopedConfigSource(conf, jsonFlag, false)
+	ScopedConfigSource(conf, jsonFlag, false, true)
 }
 
 // ScopedConfigSource print scoped config with source
-func ScopedConfigSource(conf models.ScopedOptions, jsonFlag bool, source bool) {
+func ScopedConfigSource(conf models.ScopedOptions, jsonFlag bool, source bool, obfuscateToken bool) {
 	pairs := models.ScopedPairs(&conf)
 
 	if jsonFlag {
@@ -45,6 +45,7 @@ func ScopedConfigSource(conf models.ScopedOptions, jsonFlag bool, source bool) {
 				if confMap[scope] == nil {
 					confMap[scope] = map[string]string{}
 				}
+
 				confMap[scope][name] = value
 			}
 		}
@@ -58,7 +59,13 @@ func ScopedConfigSource(conf models.ScopedOptions, jsonFlag bool, source bool) {
 	for name, pair := range pairs {
 		if *pair != (models.ScopedOption{}) {
 			translatedName := configuration.TranslateConfigOption(name)
-			row := []string{translatedName, pair.Value, pair.Scope}
+
+			value := pair.Value
+			if obfuscateToken && name == models.ConfigToken.String() {
+				value = utils.RedactAuthToken(value)
+			}
+
+			row := []string{translatedName, value, pair.Scope}
 			if source {
 				row = append(row, pair.Source)
 			}

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -394,3 +394,13 @@ func UUID() (string, error) {
 
 	return uuid.String(), nil
 }
+
+// RedactAuthToken returns a partially-redacted value that's safe for display
+func RedactAuthToken(token string) string {
+	// ensure there are enough characters or we'll end up giving away the whole token
+	if len(token) > 30 {
+		return fmt.Sprintf("%s…%s", token[0:10], token[len(token)-5:])
+	}
+
+	return "[REDACTED]"
+}


### PR DESCRIPTION
When the token is printed it's generally to let the user know that it has *some* value, rather than needing to expose the exact value. We now display the token in redacted form when it's shown on-screen, with the exception of `doppler configure get token`, `doppler configure debug`, and commands run with the `--json` flag.

Closes DPLR-795.