### PR TITLE
Add install.sh flag for forcing signature verification

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -75,6 +75,44 @@ jobs:
       run: sudo ./scripts/install.sh --debug
     - name: Test CLI
       run: doppler --version
+  ubuntu-force-verify-signature:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/${{ github.repository }}
+    - name: Install CLI
+      run: sudo ./scripts/install.sh --debug --verify-signature
+    - name: Test CLI
+      run: doppler --version
+  ubuntu-force-verify-signature-fail:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/${{ github.repository }}
+    - name: Uninstall gnupg
+      run: |
+        sudo apt-get remove -y gnupg;
+        sudo mv /usr/bin/gpg /usr/bin/gpg.old
+    - name: Verify gnupg has been removed
+      run: |
+        result=$(which gpg) || true;
+        if [ -n "$result" ]; then
+          exit 1;
+        fi;
+    - name: Install CLI
+      continue-on-error: true
+      run: sudo ./scripts/install.sh --debug --verify-signature
+    - name: Verify install failed
+      if: ${{ always() }}
+      run: |
+        result=$(which doppler) || true;
+        if [ -n "$result" ]; then
+          exit 1;
+        fi;
   ubuntu-no-verify-signature:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/post-release.yml
+++ b/.github/workflows/post-release.yml
@@ -1,0 +1,17 @@
+name: Test new release
+
+on: [release]
+
+jobs:
+  verify-gpg-signature:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/${{ github.repository }}
+    - name: Install CLI
+      shell: bash
+      run: curl --tlsv1.2 --proto "=https" -Ls https://cli.doppler.com/install.sh | sudo sh -s -- --debug --verify-signature
+    - name: Test CLI
+      run: doppler --version

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -7,6 +7,7 @@ INSTALL=1
 CLEAN_EXIT=0
 USE_PACKAGE_MANAGER=1
 VERIFY_SIGNATURE=1
+FORCE_VERIFY_SIGNATURE=0
 
 tempdir=""
 filename=""
@@ -90,6 +91,11 @@ for arg; do
     VERIFY_SIGNATURE=0
     echo "Disabling signature verification, this is not recommended"
   fi
+
+  if [ "$arg" = "--verify-signature" ]; then
+    VERIFY_SIGNATURE=1
+    FORCE_VERIFY_SIGNATURE=1
+  fi
 done
 
 # identify OS
@@ -158,11 +164,17 @@ key_url="https://cli.doppler.com/keys/public"
 if [ "$VERIFY_SIGNATURE" -eq 1 ]; then
   log_debug "Checking for gpg binary"
   if [ ! -x "$(command -v gpg)" ]; then
-    log_debug "Unable to find gpg binary, skipping signature verification"
-    VERIFY_SIGNATURE=0
-    echo "WARNING: Skipping signature verification due to no available gpg binary"
-    echo "Signature verification is an additional measure to ensure you're executing code that Doppler produced"
-    echo "You can remove this warning by installing your system's gnupg package, or by specifying --no-verify-signature"
+    if [ "$FORCE_VERIFY_SIGNATURE" -eq 1 ]; then
+      echo "ERROR: Unable to find gpg binary for signature verficiation"
+      echo "You can resolve this error by installing your system's gnupg package"
+      clean_exit 1
+    else
+      log_debug "Unable to find gpg binary, skipping signature verification"
+      VERIFY_SIGNATURE=0
+      echo "WARNING: Skipping signature verification due to no available gpg binary"
+      echo "Signature verification is an additional measure to ensure you're executing code that Doppler produced"
+      echo "You can remove this warning by installing your system's gnupg package, or by specifying --no-verify-signature"
+    fi
   fi
 fi
 


### PR DESCRIPTION
For users that explicitly want to opt-in to signature verification (like Doppler), we now support a `--verify-signature` flag. This flag will eventually be deprecated when we switch signature verification form opt-in to opt-out.