### PR TITLE
Skip creating config dir when installing shell completions

### DIFF
--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -53,6 +53,15 @@ var completionInstallCmd = &cobra.Command{
 	Short:     "Install completions for the current shell",
 	ValidArgs: []string{"bash"},
 	Args:      cobra.MaximumNArgs(1),
+	PersistentPreRun: func(cmd *cobra.Command, args []string) {
+		// This function is used to prevent calling the global PersistentPreRun handler, which is responsible for creating the config directory.
+		// This command is called by our install.sh script, which is often run with `sudo`. If the effective user differs from the real user,
+		// the config directory will be created with the wrong ownership, resulting in an error on all subsequent CLI runs. Thus we opt to skip
+		// creation entirely since this command doesn't rely on any config settings.
+
+		// ensure we still process flags like debug, silent, etc.
+		loadFlags(cmd)
+	},
 	Run: func(cmd *cobra.Command, args []string) {
 		shell := getShell(args)
 


### PR DESCRIPTION
The `completion install` command is called by our install.sh script, which is often run with `sudo`. If the effective user differs from the real user, the config directory will be created with the wrong permissions, resulting in an error on all subsequent CLI runs.

To reproduce:
```sh
$ id
uid=1000(user)
$ sudo id
uid=0(root)
$ ls -ld /Users/user/.doppler
ls: /Users/user/.doppler: No such file or directory
$ sudo ./scripts/install.sh
Installed Doppler CLI v3.23.2
$ ls -ld /Users/user/.doppler
drwx------  3 root  staff  96 Apr 13 18:05 /Users/user/.doppler
# ^ directory is owned by 'root' rather than by 'user'
```

Closes DPLR-2014.