### PR TITLE
chore: avoid pulling docker images we no longer use

### DIFF
--- a/scripts/release/release.sh
+++ b/scripts/release/release.sh
@@ -21,8 +21,5 @@ echo "$GOOGLE_CREDS" | docker login -u "$GCR_USER" --password-stdin "$GCR_REGIST
 
 # pull in latest docker images
 docker pull alpine
-docker pull node:lts-alpine
-docker pull python:3-alpine
-docker pull ruby:2-alpine
 
 GOOGLE_APPLICATION_CREDENTIALS=<(echo "$GOOGLE_CREDS") goreleaser release --rm-dist


### PR DESCRIPTION
We no longer use/publish these images.