### PR TITLE
chore: Download message now mentions Doppler CLI

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -184,7 +184,7 @@ if [ -x "$(command -v curl)" ] || [ -x "$(command -v wget)" ]; then
   tempdir="$(mktemp -d ~/.tmp.XXXXXXXX)"
   log_debug "Using temp directory $tempdir"
 
-  echo "Downloading latest release"
+  echo "Downloading Doppler CLI"
   file="doppler-download"
   filename="$tempdir/$file"
   sig_filename="$filename.sig"


### PR DESCRIPTION
Seeing `Downloading latest release` in build output (e.g. docker build) does not indicate what it's downloading.

Changing this to `Downloading Doppler CLI` makes this clear.