### PR TITLE
chore: run Salus scan on daily schedule

### DIFF
--- a/.github/workflows/salus.yaml
+++ b/.github/workflows/salus.yaml
@@ -1,4 +1,7 @@
-on: [push]
+on:
+  push:
+  schedule:
+    - cron: '0 0 * * *'
 
 name: Salus security scan
 


### PR DESCRIPTION
This ensures that Salus is detecting newly vulnerable packages, even if we haven't pushed new code.

Closes ENG-79