### PR TITLE
[ENG-2162] Handle '=' in secret values

### DIFF
--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -173,7 +173,7 @@ func setSecrets(cmd *cobra.Command, args []string) {
 	} else {
 		// format: 'doppler secrets set KEY=value'
 		for _, arg := range args {
-			secretArr := strings.Split(arg, "=")
+			secretArr := strings.SplitN(arg, "=", 2)
 			keys = append(keys, secretArr[0])
 			if len(secretArr) < 2 {
 				secrets[secretArr[0]] = ""


### PR DESCRIPTION
Should handle '=' appearing inside secret values.

Noticed another issue that prevents setting two secrets at once: https://linear.app/doppler/issue/ENG-2257/doppler-cli-doesnt-support-setting-two-secrets-at-once