### PR TITLE
Print 'run' error on exit if command not found

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -151,6 +151,9 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 		}
 
 		if err != nil {
+			if strings.HasPrefix(err.Error(), "exec") || strings.HasPrefix(err.Error(), "fork/exec") {
+				utils.LogError(err)
+			}
 			utils.LogDebugError(err)
 		}
 


### PR DESCRIPTION
This is to address https://community.doppler.com/t/doppler-masks-underlying-boot-errors/234. We [previously](https://github.com/DopplerHQ/cli/commit/58e530bd79bea6b621e126d59f29c34b4d1b170d) moved away from always displaying the exit error, and we now only do so when it has a high likelihood of being useful. 