### PR TITLE
Add `configure reset` command to reset local config file

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -207,6 +207,26 @@ doppler configure unset key otherkey`,
 	},
 }
 
+var configureResetCmd = &cobra.Command{
+	Use:   "reset",
+	Short: "Reset local CLI configuration to a clean initial state",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		yes := utils.GetBoolFlag(cmd, "yes")
+
+		if !yes {
+			utils.LogWarning("This will delete all local CLI configuration and auth tokens")
+			if !utils.ConfirmationPrompt("Continue?", false) {
+				utils.Log("Aborting")
+				return
+			}
+		}
+
+		configuration.ClearConfig()
+		utils.Log("Configuration has been reset. Please run 'doppler login' to authenticate")
+	},
+}
+
 func init() {
 	configureCmd.AddCommand(configureDebugCmd)
 
@@ -219,6 +239,9 @@ func init() {
 	configureCmd.AddCommand(configureSetCmd)
 
 	configureCmd.AddCommand(configureUnsetCmd)
+
+	configureResetCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
+	configureCmd.AddCommand(configureResetCmd)
 
 	configureCmd.Flags().Bool("all", false, "print all saved options")
 	rootCmd.AddCommand(configureCmd)

--- a/pkg/cmd/logout.go
+++ b/pkg/cmd/logout.go
@@ -47,6 +47,7 @@ func revokeToken(cmd *cobra.Command, args []string) {
 	utils.RequireValue("token", localConfig.Token.Value)
 
 	if !yes && !utils.ConfirmationPrompt(fmt.Sprintf("Revoke auth token scoped to %s?", localConfig.Token.Scope), false) {
+		utils.Log("Aborting")
 		return
 	}
 

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -383,6 +383,22 @@ func Unset(scope string, options []string) {
 	writeConfig(configContents)
 }
 
+// ClearConfig delete all existing config values
+func ClearConfig() {
+	// delete existing tokens from keychain
+	for _, scopedOptions := range configContents.Scoped {
+		if controllers.IsKeyringSecret(scopedOptions.Token) {
+			utils.LogDebug(fmt.Sprintf("Removing %s from keychain", scopedOptions.Token))
+			err := controllers.DeleteKeyring(scopedOptions.Token)
+			if !err.IsNil() {
+				utils.LogDebugError(err.Unwrap())
+			}
+		}
+	}
+
+	writeConfig(models.ConfigFile{})
+}
+
 // Write config to filesystem
 func writeConfig(config models.ConfigFile) {
 	bytes, err := yaml.Marshal(config)


### PR DESCRIPTION
This command is useful in support scenarios where the user has gotten into an unexpected state. It's almost never the "best" solution, but it's by far the easiest.

Closes ENG-2482