### PR TITLE
Require confirmation before renaming project/config

### DIFF
--- a/pkg/cmd/enclave_configs.go
+++ b/pkg/cmd/enclave_configs.go
@@ -108,6 +108,7 @@ func init() {
 	if err := enclaveConfigsUpdateCmd.MarkFlagRequired("name"); err != nil {
 		utils.HandleError(err)
 	}
+	enclaveConfigsUpdateCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	enclaveConfigsCmd.AddCommand(enclaveConfigsUpdateCmd)
 
 	enclaveConfigsDeleteCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")

--- a/pkg/cmd/enclave_projects.go
+++ b/pkg/cmd/enclave_projects.go
@@ -84,13 +84,10 @@ func init() {
 
 	enclaveProjectsUpdateCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	enclaveProjectsUpdateCmd.Flags().String("name", "", "project name")
-	enclaveProjectsUpdateCmd.Flags().String("description", "", "project description")
 	if err := enclaveProjectsUpdateCmd.MarkFlagRequired("name"); err != nil {
 		utils.HandleError(err)
 	}
-	if err := enclaveProjectsUpdateCmd.MarkFlagRequired("description"); err != nil {
-		utils.HandleError(err)
-	}
+	enclaveProjectsUpdateCmd.Flags().String("description", "", "project description")
 	enclaveProjectsCmd.AddCommand(enclaveProjectsUpdateCmd)
 
 	enclaveCmd.AddCommand(enclaveProjectsCmd)

--- a/pkg/cmd/enclave_projects.go
+++ b/pkg/cmd/enclave_projects.go
@@ -88,6 +88,7 @@ func init() {
 		utils.HandleError(err)
 	}
 	enclaveProjectsUpdateCmd.Flags().String("description", "", "project description")
+	enclaveProjectsUpdateCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	enclaveProjectsCmd.AddCommand(enclaveProjectsUpdateCmd)
 
 	enclaveCmd.AddCommand(enclaveProjectsCmd)

--- a/pkg/cmd/projects.go
+++ b/pkg/cmd/projects.go
@@ -159,6 +159,7 @@ func updateProjects(cmd *cobra.Command, args []string) {
 	jsonFlag := utils.OutputJSON
 	name := cmd.Flag("name").Value.String()
 	description := cmd.Flag("description").Value.String()
+	yes := utils.GetBoolFlag(cmd, "yes")
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
@@ -167,6 +168,14 @@ func updateProjects(cmd *cobra.Command, args []string) {
 	project := localConfig.EnclaveProject.Value
 	if len(args) > 0 {
 		project = args[0]
+	}
+
+	if !yes {
+		utils.LogWarning("Renaming this project may break your current deploys.")
+		if !utils.ConfirmationPrompt("Continue?", false) {
+			utils.Log("Aborting")
+			return
+		}
 	}
 
 	var info models.ProjectInfo
@@ -214,6 +223,7 @@ func init() {
 	if err := projectsUpdateCmd.MarkFlagRequired("name"); err != nil {
 		utils.HandleError(err)
 	}
+	projectsUpdateCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	projectsCmd.AddCommand(projectsUpdateCmd)
 
 	rootCmd.AddCommand(projectsCmd)


### PR DESCRIPTION
These are potentially sensitive actions and should require user confirmation.