### PR TITLE
Disable custom DNS resolver by default

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -44,7 +44,7 @@ type errorResponse struct {
 }
 
 // DNS resolver
-var UseCustomDNSResolver = true
+var UseCustomDNSResolver = false
 var DNSResolverAddress = "1.1.1.1:53"
 var DNSResolverProto = "udp"
 var DNSResolverTimeout = time.Duration(5) * time.Second


### PR DESCRIPTION
When using the OS resolver, DNS resolution fails for a small % of customers. With a custom resolver, a different but similarly sized cohort is affected. It seems disabling the custom resolver is a more sane default, with the ability for users to opt-in to the custom resolver.

Closes ENG-2648