### PR TITLE
Support setting secrets via stdin

### DIFF
--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -107,6 +107,7 @@ func init() {
 	enclaveSecretsSetCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	enclaveSecretsSetCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
 	enclaveSecretsSetCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
+	enclaveSecretsSetCmd.Flags().Bool("no-interactive", false, "do not allow entering secret value via interactive mode")
 	enclaveSecretsCmd.AddCommand(enclaveSecretsSetCmd)
 
 	enclaveSecretsDeleteCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")

--- a/pkg/cmd/enclave_setup.go
+++ b/pkg/cmd/enclave_setup.go
@@ -16,6 +16,7 @@ limitations under the License.
 package cmd
 
 import (
+	"github.com/DopplerHQ/cli/pkg/utils"
 	"github.com/spf13/cobra"
 )
 
@@ -32,7 +33,17 @@ var enclaveSetupCmd = &cobra.Command{
 func init() {
 	enclaveSetupCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	enclaveSetupCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
-	enclaveSetupCmd.Flags().Bool("no-prompt", false, "do not prompt for information. if the project or config is not specified, an error will be thrown.")
+	enclaveSetupCmd.Flags().Bool("no-interactive", false, "do not prompt for information. if the project or config is not specified, an error will be thrown.")
 	enclaveSetupCmd.Flags().Bool("no-save-token", false, "do not save the token to the config when passed via flag or environment variable.")
+
+	// deprecated
+	enclaveSetupCmd.Flags().Bool("no-prompt", false, "do not prompt for information. if the project or config is not specified, an error will be thrown.")
+	if err := enclaveSetupCmd.Flags().MarkDeprecated("no-prompt", "please use --no-interactive instead"); err != nil {
+		utils.HandleError(err)
+	}
+	if err := enclaveSetupCmd.Flags().MarkHidden("no-prompt"); err != nil {
+		utils.HandleError(err)
+	}
+
 	enclaveCmd.AddCommand(enclaveSetupCmd)
 }

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -54,13 +54,13 @@ var rootCmd = &cobra.Command{
 		}
 
 		plain := utils.GetBoolFlagIfChanged(cmd, "plain", false)
-		canPrompt := !utils.GetBoolFlagIfChanged(cmd, "no-prompt", false)
+		canPrompt := !utils.GetBoolFlagIfChanged(cmd, "no-prompt", false) && !utils.GetBoolFlagIfChanged(cmd, "no-interactive", false)
 		// tty is required to accept user input, otherwise the update can't be accepted/declined
 		isTTY := isatty.IsTerminal(os.Stdout.Fd())
 
 		// only run version check if we can print the results
 		// --plain doesn't normally affect logging output, but due to legacy reasons it does here
-		// also don't want to display updates if user doesn't want to be prompted (--no-prompt)
+		// also don't want to display updates if user doesn't want to be prompted (--no-prompt/--no-interactive)
 		if isTTY && utils.CanLogInfo() && !plain && canPrompt {
 			checkVersion(cmd.CommandPath())
 		}


### PR DESCRIPTION
This PR adds support for setting secrets via stdin. It has two different modes:

Piping in data
```
$ echo -e 'my\nsecret\nvalue' | doppler secrets set A
┌──────┬────────┐
│ NAME │ VALUE  │
├──────┼────────┤
│ A    │ my     │
│      │ secret │
│      │ value  │
└──────┴────────┘
```

Interactive mode
```
$ doppler secrets set A
Enter your secret value
When finished, type a newline followed by a period
Run 'doppler secrets set --help' for more information
———————————————————— START INPUT ————————————————————
my
secret
value

.
————————————————————— END INPUT —————————————————————
┌──────┬────────┐
│ NAME │ VALUE  │
├──────┼────────┤
│ A    │ my     │
│      │ secret │
│      │ value  │
└──────┴────────┘
```

Updated help text
```
$ doppler secrets set --help
Set the value of one or more secrets.

There are several methods for setting secrets:

1) stdin (recommended)
$ echo -e 'multiline\nvalue' | doppler secrets set CERT

2) interactive stdin (recommended)
$ doppler secrets set CERT
multiline
value

.

3) one secret
$ doppler secrets set API_KEY '123'

4) multiple secrets
$ doppler secrets set API_KEY='123' DATABASE_URL='postgres:random@127.0.0.1:5432'

Usage:
  doppler secrets set [secrets] [flags]

Flags:
  -c, --config string    config (e.g. dev)
  -h, --help             help for set
      --no-prompt        do not allow entering secret value via interactive mode
  -p, --project string   project (e.g. backend)
      --raw              print the raw secret value without processing variables

Global Flags:
      --api-host string                 The host address for the Doppler API (default "https://api.doppler.com")
      --configuration string            config file (default "/Users/doppler/.doppler/.doppler.yaml")
      --dashboard-host string           The host address for the Doppler Dashboard (default "https://dashboard.doppler.com")
      --debug                           output additional information
      --dns-resolver-address string     address to use for DNS resolution (default "1.1.1.1:53")
      --dns-resolver-proto string       protocol to use for DNS resolution (default "udp")
      --dns-resolver-timeout duration   max dns lookup duration (default 5s)
      --enable-dns-resolver             bypass the OS's default DNS resolver
      --json                            output json
      --no-check-version                disable checking for Doppler CLI updates
      --no-read-env                     do not read config from the environment
      --no-timeout                      disable http timeout
      --no-verify-tls                   do not verify the validity of TLS certificates on HTTP requests (not recommended)
      --print-config                    output active configuration
      --scope string                    the directory to scope your config to (default ".")
      --silent                          disable output of info messages
      --timeout duration                max http request duration (default 10s)
  -t, --token string                    doppler token
```

Closes ENG-2351.