### PR TITLE
Print error if install.sh fails due to lack of write perms

### DIFF
--- a/pkg/controllers/update.go
+++ b/pkg/controllers/update.go
@@ -65,10 +65,15 @@ func RunInstallScript() (bool, string, Error) {
 		fmt.Println(strOut)
 	}
 	if err != nil {
+		exitCode := 1
+		if exitError, ok := err.(*exec.ExitError); ok {
+			exitCode = exitError.ExitCode()
+		}
+
 		message := "Unable to install the latest Doppler CLI"
-		// check for errors indicating lack of perms
-		if strings.Contains(strOut, "dpkg: error: requested operation requires superuser privilege") {
-			message = "Error: update failed due to improper permissions\nPlease re-run with `sudo` or run as the root user"
+		permissionError := exitCode == 2 || strings.Contains(strOut, "dpkg: error: requested operation requires superuser privilege")
+		if permissionError {
+			message = "Error: update failed due to improper permissions\nPlease re-run with `sudo` or as an admin"
 		}
 
 		return false, "", Error{Err: err, Message: message}


### PR DESCRIPTION
In the event that `install.sh` or `doppler update` fails due to a lack of write perms, we now print a more actionable error.

```sh
$ doppler update
Updating...
Error: update failed due to improper permissions
Please re-run with `sudo` or as an admin
Doppler Error: exit status 2

$ ./scripts/install.sh
Downloading Doppler CLI
Installing...
Unable to write to bin directory; please re-run with `sudo` or as an admin
```

Closes ENG-3292.