### PR TITLE
Add env to cli-action

### DIFF
--- a/.github/workflows/cli-action.yml
+++ b/.github/workflows/cli-action.yml
@@ -10,6 +10,8 @@ jobs:
       uses: dopplerhq/cli-action@v1
     - name: Test CLI
       run: doppler --version
+      env:
+        DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
   windows:
     runs-on: windows-latest
     steps:
@@ -17,6 +19,8 @@ jobs:
       uses: dopplerhq/cli-action@v1
     - name: Test CLI
       run: doppler --version
+      env:
+        DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}
   macOS:
     runs-on: macos-latest
     steps:
@@ -24,3 +28,5 @@ jobs:
       uses: dopplerhq/cli-action@v1
     - name: Test CLI
       run: doppler --version
+      env:
+        DOPPLER_TOKEN: ${{ secrets.DOPPLER_TOKEN }}


### PR DESCRIPTION
If you installed the doppler cli in github actions, then more often than not you will need a DOPPLER_TOKEN in the environment