### PR TITLE
Maintain local config file ownership when modifying config

### DIFF
--- a/pkg/utils/io_nonwindows.go
+++ b/pkg/utils/io_nonwindows.go
@@ -1,0 +1,38 @@
+// +build !windows
+
+/*
+Copyright © 2021 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func FileOwnership(path string) (int, int, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		return -1, -1, err
+	}
+
+	stat, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return -1, -1, errors.New("Unable to stat file")
+	}
+
+	return int(stat.Uid), int(stat.Gid), nil
+}

--- a/pkg/utils/io_windows.go
+++ b/pkg/utils/io_windows.go
@@ -1,0 +1,20 @@
+/*
+Copyright © 2021 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+func FileOwnership(path string) (int, int, error) {
+	return -1, -1, nil
+}


### PR DESCRIPTION
This fixes an issue where running `sudo doppler update` would result in the user's config file being owned by root. I tested an implementation locally that instead modifies the existing file in-place (or creates it if it doesn't exist), but I couldn't find a way to perform the [update or create] operation atomically.

Closes ENG-3389.