### PR TITLE
chore: switch to encoding files with base64

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -308,7 +308,7 @@ func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, enableFall
 	writeFallbackFile := enableFallback && !fallbackReadonly && nameTransformer == nil
 	if writeFallbackFile {
 		utils.LogDebug("Encrypting secrets")
-		encryptedResponse, err := crypto.Encrypt(passphrase, response)
+		encryptedResponse, err := crypto.Encrypt(passphrase, response, "base64")
 		if err != nil {
 			utils.HandleError(err, "Unable to encrypt your secrets. No fallback file has been written.")
 		}
@@ -406,7 +406,13 @@ func readFallbackFile(path string, legacyPath string, passphrase string, silent 
 	}
 
 	utils.LogDebug("Decrypting fallback file")
-	decryptedSecrets, err := crypto.Decrypt(passphrase, response)
+	// default to hex for backwards compatibility b/c we didn't always include a prefix
+	// TODO remove support for optional prefix when releasing CLI v4 (DPLR-435)
+	encoding := "hex"
+	if strings.HasPrefix(string(response), crypto.Base64EncodingPrefix) {
+		encoding = "base64"
+	}
+	decryptedSecrets, err := crypto.Decrypt(passphrase, response, encoding)
 	if err != nil {
 		var msg []string
 		msg = append(msg, "")

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -492,7 +492,7 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 		utils.HandleError(errors.New("invalid passphrase"))
 	}
 
-	encryptedBody, err := crypto.Encrypt(passphrase, body)
+	encryptedBody, err := crypto.Encrypt(passphrase, body, "base64")
 	if err != nil {
 		utils.HandleError(err, "Unable to encrypt your secrets. No file has been written.")
 	}

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/DopplerHQ/cli/pkg/crypto"
 	"github.com/DopplerHQ/cli/pkg/models"
@@ -113,7 +114,13 @@ func SecretsCacheFile(path string, passphrase string) (map[string]string, Error)
 	}
 
 	utils.LogDebug("Decrypting cache file")
-	decryptedSecrets, err := crypto.Decrypt(passphrase, response)
+	// default to hex for backwards compatibility b/c we didn't always include a prefix
+	// TODO remove support for optional prefix when releasing CLI v4 (DPLR-435)
+	encoding := "hex"
+	if strings.HasPrefix(string(response), crypto.Base64EncodingPrefix) {
+		encoding = "base64"
+	}
+	decryptedSecrets, err := crypto.Decrypt(passphrase, response, encoding)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to decrypt cache file"}
 	}

--- a/pkg/crypto/aes_test.go
+++ b/pkg/crypto/aes_test.go
@@ -1,0 +1,76 @@
+/*
+Copyright © 2022 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package crypto
+
+import (
+	"fmt"
+	"testing"
+)
+
+const originalPassphrase = "secret"
+const originalPlaintext = "{\"TEST_SECRET\":\"value\"}"
+
+func TestDecrypt(t *testing.T) {
+	// decode hex w/o prefix
+	ciphertext := "9bc0a6db97dadea4-0d16d53716f505651f894aba-11b04a80eafd8ea700c7755de860aeb0347cff4ae93b626e858681e7e123034b4c11691a412843"
+	plaintext, err := Decrypt(originalPassphrase, []byte(ciphertext), "hex")
+	if err != nil || plaintext != originalPlaintext {
+		t.Error("Invalid plaintext when decrypting non-prefixed hex value")
+	}
+
+	// decode hex w/ prefix
+	ciphertext = fmt.Sprintf("hex:%s", ciphertext)
+	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext), "hex")
+	if err != nil || plaintext != originalPlaintext {
+		t.Error("Invalid plaintext when decrypting hex value")
+	}
+
+	// decode base64 w/o prefix (should error)
+	ciphertext = "qwbkFMWB7FE=-Ew968YdkAXRb6l46-eA4o9Pf9mSIaOofa8YIEP+FqJ6DwScHsYIObAw3dvKvHbe5SDTzB"
+	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext), "base64")
+	if err == nil {
+		t.Error("Expected error when decrypting non-prefixed base64 value")
+	}
+
+	// decode base64 w/ prefix
+	ciphertext = fmt.Sprintf("base64:%s", ciphertext)
+	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext), "base64")
+	if err != nil || plaintext != originalPlaintext {
+		t.Error("Invalid plaintext when decrypting base64 value")
+	}
+}
+
+func TestEncrypt(t *testing.T) {
+	// hex
+	ciphertext, err := Encrypt(originalPassphrase, []byte(originalPlaintext), "hex")
+	if err != nil {
+		t.Error("Invalid ciphertext when encrypting value w/ hex encoding")
+	}
+	plaintext, err := Decrypt(originalPassphrase, []byte(ciphertext), "hex")
+	if err != nil || plaintext != originalPlaintext {
+		t.Error("Invalid plaintext when decrypting hex value")
+	}
+
+	// base64
+	ciphertext, err = Encrypt(originalPassphrase, []byte(originalPlaintext), "base64")
+	if err != nil {
+		t.Error("Invalid ciphertext when encrypting value w/ base64 encoding")
+	}
+	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext), "base64")
+	if err != nil || plaintext != originalPlaintext {
+		t.Error("Invalid plaintext when decrypting base64 value")
+	}
+}


### PR DESCRIPTION
This results in smaller file sizes compared to hex encoding.

Test scenarios (all covered with unit tests):
- [x] Decrypting existing (i.e. legacy) file
- [x] Encrypting new file
- [x] Decrypting new file