### PR TITLE
Add support for mounting secrets to file path

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -53,11 +53,13 @@ type fallbackOptions struct {
 var runCmd = &cobra.Command{
 	Use:   "run [command]",
 	Short: "Run a command with secrets injected into the environment",
-	Long: `Run a command with secrets injected into the environment
+	Long: `Run a command with secrets injected into the environment.
+Secrets can also be mounted to an ephemeral file using the --mount flag.
 
 To view the CLI's active configuration, run ` + "`doppler configure debug`",
 	Example: `doppler run -- YOUR_COMMAND --YOUR-FLAG
-doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
+doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"
+doppler run --mount secrets.json -- cat secrets.json`,
 	Args: func(cmd *cobra.Command, args []string) error {
 		// The --command flag and args are mututally exclusive
 		usingCommandFlag := cmd.Flags().Changed("command")
@@ -131,52 +133,105 @@ doppler run --command "YOUR_COMMAND && YOUR_OTHER_COMMAND"`,
 			exitOnWriteFailure: exitOnWriteFailure,
 			passphrase:         passphrase,
 		}
-		secrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL)
+		// retrieve secrets
+		dopplerSecrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL)
+
+		mountPath := cmd.Flag("mount").Value.String()
+		mountFormat := cmd.Flag("mount-format").Value.String()
+		maxReads := utils.GetIntFlag(cmd, "mount-max-reads", 32)
+		// only auto-detect the format if it hasn't been explicitly specified
+		shouldAutoDetectFormat := !cmd.Flags().Changed("mount-format")
+		shouldMountFile := mountPath != ""
 
 		if preserveEnv {
-			utils.LogWarning("Ignoring Doppler secrets already defined in the environment due to --preserve-env flag")
+			if shouldMountFile {
+				utils.LogWarning("--preserve-env has no effect when used with --mount")
+			} else {
+				utils.LogWarning("Ignoring Doppler secrets already defined in the environment due to --preserve-env flag")
+			}
 		}
 
-		env := os.Environ()
+		originalEnv := os.Environ()
 		existingEnvKeys := map[string]bool{}
-		for _, envVar := range env {
+		for _, envVar := range originalEnv {
 			// key=value format
 			parts := strings.SplitN(envVar, "=", 2)
 			key := parts[0]
 			existingEnvKeys[key] = true
 		}
 
+		secrets := map[string]string{}
 		excludedKeys := []string{"PATH", "PS1", "HOME"}
-		for name, value := range secrets {
+		for name, value := range dopplerSecrets {
 			useSecret := true
-			for _, excludedKey := range excludedKeys {
-				if excludedKey == name {
-					useSecret = false
-					break
+			if !shouldMountFile {
+				// ignore secrets that might conflict with the environment
+				for _, excludedKey := range excludedKeys {
+					if excludedKey == name {
+						utils.LogDebug(fmt.Sprintf("Ignoring restricted secret %s", name))
+						useSecret = false
+						break
+					}
 				}
-			}
 
-			if useSecret && preserveEnv {
 				// skip secret if environment already contains variable w/ same name
-				if existingEnvKeys[name] == true {
+				if preserveEnv && existingEnvKeys[name] == true {
 					utils.LogDebug(fmt.Sprintf("Ignoring Doppler secret %s", name))
 					useSecret = false
 				}
 			}
 
-			if useSecret {
-				env = append(env, fmt.Sprintf("%s=%s", name, value))
+			if !useSecret {
+				continue
+			}
+
+			secrets[name] = value
+		}
+
+		var env []string
+		var onExit func()
+		if shouldMountFile {
+			if shouldAutoDetectFormat {
+				if strings.HasSuffix(mountPath, ".env") {
+					mountFormat = "env"
+					utils.LogDebug(fmt.Sprintf("Detected %s format", mountFormat))
+				} else if strings.HasSuffix(mountPath, ".json") {
+					mountFormat = "json"
+					utils.LogDebug(fmt.Sprintf("Detected %s format", mountFormat))
+				} else {
+					parts := strings.Split(mountPath, ".")
+					detectedFormat := parts[len(parts)-1]
+					utils.LogWarning(fmt.Sprintf("Detected \"%s\" file format, which is not supported. Using default JSON format for mounted secrets", detectedFormat))
+				}
+			}
+
+			absMountPath, handler, err := controllers.MountSecrets(secrets, mountFormat, mountPath, maxReads)
+			if !err.IsNil() {
+				utils.HandleError(err.Unwrap(), err.Message)
+			}
+			mountPath = absMountPath
+			onExit = handler
+
+			// export path to mounted file
+			env = append(env, fmt.Sprintf("%s=%s", "DOPPLER_CLI_SECRETS_PATH", mountPath))
+		} else {
+			// export doppler secrets
+			for _, envVar := range controllers.MapToEnvFormat(secrets, false) {
+				env = append(env, envVar)
 			}
 		}
+
+		// include original environment variables
+		env = append(env, originalEnv...)
 
 		exitCode := 0
 		var err error
 
 		if cmd.Flags().Changed("command") {
 			command := cmd.Flag("command").Value.String()
-			exitCode, err = utils.RunCommandString(command, env, os.Stdin, os.Stdout, os.Stderr, forwardSignals)
+			exitCode, err = utils.RunCommandString(command, env, os.Stdin, os.Stdout, os.Stderr, forwardSignals, onExit)
 		} else {
-			exitCode, err = utils.RunCommand(args, env, os.Stdin, os.Stdout, os.Stderr, forwardSignals)
+			exitCode, err = utils.RunCommand(args, env, os.Stdin, os.Stdout, os.Stderr, forwardSignals, onExit)
 		}
 
 		if err != nil {
@@ -269,7 +324,7 @@ var runCleanCmd = &cobra.Command{
 	},
 }
 
-// fetchSecrets fetches secrets, including all reading and writing of fallback files
+// fetchSecrets from Doppler and handle fallback file
 func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOpts fallbackOptions, metadataPath string, nameTransformer *models.SecretsNameTransformer, dynamicSecretsTTL time.Duration) map[string]string {
 	if fallbackOpts.exclusive {
 		if !fallbackOpts.enable {
@@ -591,6 +646,10 @@ func init() {
 	runCmd.Flags().Bool("fallback-only", false, "read all secrets directly from the fallback file, without contacting Doppler. secrets will not be updated. (implies --fallback-readonly)")
 	runCmd.Flags().Bool("no-exit-on-write-failure", false, "do not exit if unable to write the fallback file")
 	runCmd.Flags().Bool("forward-signals", forwardSignals, "forward signals to the child process (defaults to false when STDOUT is a TTY)")
+	// secrets mount flags
+	runCmd.Flags().String("mount", "", "write secrets to an ephemeral file, accessible at DOPPLER_CLI_SECRETS_PATH. when enabled, secrets are NOT injected into the environment")
+	runCmd.Flags().String("mount-format", "json", "file format to use. if not specified, will be auto-detected from mount name. one of [json, env]")
+	runCmd.Flags().Int("mount-max-reads", 0, "maximum number of times the mounted secrets file can be read (0 for unlimited)")
 
 	// deprecated
 	runCmd.Flags().Bool("silent-exit", false, "disable error output if the supplied command exits non-zero")

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -449,7 +449,17 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 		if enableCache {
 			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
 		}
-		secrets := fetchSecrets(localConfig, enableCache, enableFallback, fallbackPath, legacyFallbackPath, metadataPath, fallbackReadonly, fallbackOnly, exitOnWriteFailure, fallbackPassphrase, nameTransformer, dynamicSecretsTTL)
+
+		fallbackOpts := fallbackOptions{
+			enable:             enableFallback,
+			path:               fallbackPath,
+			legacyPath:         legacyFallbackPath,
+			readonly:           fallbackReadonly,
+			exclusive:          fallbackOnly,
+			exitOnWriteFailure: exitOnWriteFailure,
+			passphrase:         fallbackPassphrase,
+		}
+		secrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL)
 
 		var err error
 		body, err = json.Marshal(secrets)

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -16,7 +16,14 @@ limitations under the License.
 package controllers
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sort"
+	"strings"
+	"time"
 
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/models"
@@ -43,4 +50,112 @@ func GetSecretNames(config models.ScopedOptions) ([]string, Error) {
 	sort.Strings(secretsNames)
 
 	return secretsNames, Error{}
+}
+
+func MapToEnvFormat(secrets map[string]string, wrapInQuotes bool) []string {
+	var env []string
+	for k, v := range secrets {
+		if wrapInQuotes {
+			v = strings.ReplaceAll(v, "\\", "\\\\")
+			v = strings.ReplaceAll(v, "\"", "\\\"")
+			env = append(env, fmt.Sprintf("%s=\"%s\"", k, v))
+		} else {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	// sort keys alphabetically for deterministic order
+	sort.Slice(env, func(a, b int) bool {
+		return env[a] < env[b]
+	})
+
+	return env
+}
+
+func MountSecrets(secrets map[string]string, format string, mountPath string, maxReads int) (string, func(), Error) {
+	if !utils.SupportsNamedPipes {
+		return "", nil, Error{Err: errors.New("This OS does not support mounting a secrets file")}
+	}
+
+	if mountPath == "" {
+		return "", nil, Error{Err: errors.New("Mount path cannot be blank")}
+	}
+
+	var mountData []byte
+	if format == "env" {
+		mountData = []byte(strings.Join(MapToEnvFormat(secrets, true), "\n"))
+	} else if format == "json" {
+		envStr, err := json.Marshal(secrets)
+		if err != nil {
+			return "", nil, Error{Err: err, Message: "Unable to marshall secrets to json"}
+		}
+		mountData = envStr
+	} else {
+		return "", nil, Error{Err: fmt.Errorf("Invalid mount format: %s", format)}
+	}
+
+	// convert mount path to absolute path
+	var err error
+	mountPath, err = filepath.Abs(mountPath)
+	if err != nil {
+		return "", nil, Error{Err: err, Message: "Unable to resolve mount path"}
+	}
+
+	if utils.Exists(mountPath) {
+		return "", nil, Error{Err: errors.New("The mount path already exists")}
+	}
+
+	if err := utils.CreateNamedPipe(mountPath, 0600); err != nil {
+		return "", nil, Error{Err: err, Message: "Unable to mount secrets file"}
+	}
+
+	// cleanup named pipe on exit
+	cleanupFIFO := func() {
+		if utils.Exists(mountPath) {
+			utils.LogDebug(fmt.Sprintf("Deleting secrets mount %s", mountPath))
+			if err := os.Remove(mountPath); err != nil {
+				utils.LogDebug("Unable to delete secrets mount")
+				utils.LogError(err)
+			}
+		}
+	}
+
+	// prevent this from blocking later operations
+	go func() {
+		message := "Unable to mount secrets file"
+		enableReadsLimit := maxReads > 0
+		numReads := 0
+
+		utils.LogDebug(fmt.Sprintf("Mounting secrets in %s format to %s", format, mountPath))
+
+		for {
+			if enableReadsLimit && numReads >= maxReads {
+				utils.LogDebug(fmt.Sprintf("Secrets mount has reached its limit of %d read(s)", maxReads))
+				break
+			}
+
+			numReads++
+
+			// this operation blocks until the FIFO is opened for reads
+			f, err := os.OpenFile(mountPath, os.O_WRONLY, os.ModeNamedPipe) // #nosec G304
+			if err != nil {
+				utils.HandleError(err, message)
+			}
+
+			if _, err := f.Write(mountData); err != nil {
+				utils.HandleError(err, message)
+			}
+
+			if err := f.Close(); err != nil {
+				utils.HandleError(err, message)
+			}
+
+			// delay before re-opening file so reader can detect an EOF
+			time.Sleep(time.Millisecond * 10)
+		}
+
+		cleanupFIFO()
+	}()
+
+	return mountPath, cleanupFIFO, Error{}
 }

--- a/pkg/utils/io_nonwindows.go
+++ b/pkg/utils/io_nonwindows.go
@@ -23,6 +23,8 @@ import (
 	"syscall"
 )
 
+const SupportsNamedPipes = true
+
 func FileOwnership(path string) (int, int, error) {
 	info, err := os.Stat(path)
 	if err != nil {
@@ -35,4 +37,10 @@ func FileOwnership(path string) (int, int, error) {
 	}
 
 	return int(stat.Uid), int(stat.Gid), nil
+}
+
+func CreateNamedPipe(path string, mode uint32) error {
+	// this path must be cleaned up manually, but the pipe's contents are
+	// only available while the writer (i.e. this program) is alive
+	return syscall.Mkfifo(path, mode)
 }

--- a/pkg/utils/io_windows.go
+++ b/pkg/utils/io_windows.go
@@ -15,6 +15,14 @@ limitations under the License.
 */
 package utils
 
+import "errors"
+
+const SupportsNamedPipes = false
+
 func FileOwnership(path string) (int, int, error) {
 	return -1, -1, nil
+}
+
+func CreateNamedPipe(path string, mode uint32) error {
+	return errors.New("This platform does not support named pipes")
 }

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -12,6 +12,7 @@ export DOPPLER_CONFIG="prd_e2e_tests"
 # Run tests
 "$DIR/e2e/secrets-download-fallback.sh"
 "$DIR/e2e/run-fallback.sh"
+"$DIR/e2e/run-mount.sh"
 "$DIR/e2e/configure.sh"
 "$DIR/e2e/install-sh-install-path.sh"
 "$DIR/e2e/install-sh-update-in-place.sh"

--- a/tests/e2e/run-mount.sh
+++ b/tests/e2e/run-mount.sh
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_NAME="run-mount"
+
+cleanup() {
+  exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    echo "ERROR: '$TEST_NAME' tests failed during execution"
+    afterAll || echo "ERROR: Cleanup failed"
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+beforeAll() {
+  echo "INFO: Executing '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+beforeEach() {
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+  rm -f ./secrets.json ./secrets.env
+}
+
+afterAll() {
+  echo "INFO: Completed '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+  rm -f ./secrets.json ./secrets.env
+}
+
+beforeAll
+
+beforeEach
+
+# verify content of mounted secrets file
+EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli"}'
+actual="$("$DOPPLER_BINARY" run --mount secrets.json --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
+if [ "$actual" != "$EXPECTED_SECRETS" ]; then
+ echo "ERROR: mounted secrets file has invalid contents"
+ exit 1
+fi
+
+beforeEach
+
+# verify secrets aren't injected into environment
+# this will succeed
+"$DOPPLER_BINARY" run --command "printenv DOPPLER_ENVIRONMENT" && \
+  # this should fail
+  "$DOPPLER_BINARY" run --mount secrets.json --command "printenv DOPPLER_ENVIRONMENT" && \
+  (echo "ERROR: secrets injected into environment despite using mounted secrets file" && exit 1)
+
+beforeEach
+
+# verify specified mount path is used and converted to absolute path
+expected="$(pwd)/secrets.json"
+actual="$("$DOPPLER_BINARY" run --mount secrets.json --command "echo \$DOPPLER_CLI_SECRETS_PATH")"
+if [ "$actual" != "$expected" ]; then
+ echo "ERROR: secrets are not mounted to specified path"
+ exit 1
+fi
+
+beforeEach
+
+# verify format is auto detected
+EXPECTED_SECRETS='DOPPLER_CONFIG="prd_e2e_tests"\nDOPPLER_ENCLAVE_CONFIG="prd_e2e_tests"\nDOPPLER_ENCLAVE_ENVIRONMENT="prd"\nDOPPLER_ENCLAVE_PROJECT="cli"\nDOPPLER_ENVIRONMENT="prd"\nDOPPLER_PROJECT="cli"'
+actual="$("$DOPPLER_BINARY" run --mount secrets.env --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
+if [[ "$actual" != "$(echo -e "$EXPECTED_SECRETS")" ]]; then
+ echo "ERROR: mounted secrets file with auto-detected env format has invalid contents"
+ exit 1
+fi
+
+beforeEach
+
+# verify specified format is used
+EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli"}'
+actual="$("$DOPPLER_BINARY" run --mount secrets.env --mount-format json --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
+if [[ "$actual" != "$(echo -e "$EXPECTED_SECRETS")" ]]; then
+ echo "ERROR: mounted secrets file with json format has invalid contents"
+ exit 1
+fi
+
+beforeEach
+
+# verify specified name transformer is used
+EXPECTED_SECRETS='{"TF_VAR_doppler_config":"prd_e2e_tests","TF_VAR_doppler_enclave_config":"prd_e2e_tests","TF_VAR_doppler_enclave_environment":"prd","TF_VAR_doppler_enclave_project":"cli","TF_VAR_doppler_environment":"prd","TF_VAR_doppler_project":"cli"}'
+actual="$("$DOPPLER_BINARY" run --mount secrets.json --name-transformer tf-var --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
+if [[ "$actual" != "$EXPECTED_SECRETS" ]]; then
+ echo "ERROR: mounted secrets file with name transformer has invalid contents"
+ exit 1
+fi
+
+beforeEach
+
+# verify existing env value is ignored even when --preserve-env is specified
+EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli"}'
+actual="$(DOPPLER_CONFIG="test" "$DOPPLER_BINARY" run --preserve-env --config prd_e2e_tests --mount secrets.json --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
+if [ "$actual" != "$EXPECTED_SECRETS" ]; then
+ echo "ERROR: mounted secrets file with --preserve-env has invalid contents"
+ exit 1
+fi
+
+afterAll


### PR DESCRIPTION
Currently, `doppler run` always inject secrets as environment variables. With this PR, secrets can now instead be mounted to an ephemeral file. The file exists for the lifetime of the application and can be read by libraries like dotenv. The path to the file is made available in the `DOPPLER_CLI_SECRETS_PATH` environment variable.

This feature supports custom name transformers.

Example:
```sh
$ doppler run --mount secrets.json -- sh
# new shell
$ echo $DOPPLER_CLI_SECRETS_PATH
/Users/doppler/.doppler/secrets.json
$ cat $DOPPLER_CLI_SECRETS_PATH
'{"TEST_SECRET":"hello"}'
```
Example w/ Node:
```node
$ doppler run --mount secrets.json -- node
> fs.readFileSync(process.env.DOPPLER_CLI_SECRETS_PATH).toString()
'{"TEST_SECRET":"hello"}'
$ doppler run --mount .env -- node
> process.env
{
  DOPPLER_CLI_SECRETS_PATH: '/usr/src/app/.env'
}
> require('dotenv').config()
> process.env
{
  DOPPLER_CLI_SECRETS_PATH: '/usr/src/app/.env',
  TEST_SECRET: 'hello'
}
```

New flags for `doppler run`:
| Flag        | Default           | Description  |
| ------------- |-------------| -----|
|`mount` | (off) | path to mount secrets file to, accessible via DOPPLER_CLI_SECRETS_PATH env var |
| `mount-format` | json | file format to use. one of [json, env] |
| `mount-max-reads` | 0 | maximum number of times the mounted secrets file can be read (0 for unlimited) |

## More info

Technically, the mounted secrets file is a named pipe. This allows us to ensure that the pipe's contents (i.e. the secrets) are only accessible while the CLI is connected to it. Once the CLI exits, the pipe is useless.

Potential gotchas:
- Next.js appears to [disallow reading from FIFOs](https://github.com/vercel/next.js/blob/636d3aeda753301657cf9f2e9faa8e947392bfe2/packages/next-env/index.ts#L99-L102), other libraries might too
- After writing the secrets to the FIFO, we close the FIFO to signal to the reader that we're finished. We then wait 10 ms before re-opening the FIFO for further reads. This delay seems arbitrary but, in testing, is required for the reader to be able to detect the EOF. Of  course the 10ms number itself is arbitrary and may need to be adjusted at some point.

Closes ENG-3665