### PR TITLE
chore: fix CLI install when using wget

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -153,7 +153,7 @@ wget_download() {
   exit_code=$?
   set -e
 
-  status_code="$(echo "$headers" | sed '1!G;h;$!d' | grep HTTP | head -1 | grep -o -E '[0-9]{3}')"
+  status_code="$(echo "$headers" | sed '1!G;h;$!d' | grep -o -E 'HTTP/[0-9.]+ [0-9]{3}' | head -1 | grep -o -E '[0-9]{3}')"
   # it's possible for this value to be blank, so confirm that it's a valid status code
   valid_status_code=0
   if expr "$status_code" : '[0-9][0-9][0-9]$'>/dev/null; then


### PR DESCRIPTION
When using wget, we parse the response to determine the HTTP status code. Microsoft introduced a new value for one of their `Server` headers in the request chain that was causing a regex to misidentify the status code. The regex has now been made more precise.

New header:
`Server: Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0`