### PR TITLE
Add support for dynamic secrets in standard secret commands

### DIFF
--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -104,6 +104,7 @@ func init() {
 	enclaveSecretsGetCmd.Flags().Bool("plain", false, "print values without formatting")
 	enclaveSecretsGetCmd.Flags().Bool("copy", false, "copy the value(s) to your clipboard")
 	enclaveSecretsGetCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
+	enclaveSecretsGetCmd.Flags().Bool("no-exit-on-missing-secret", false, "do not exit if unable to find a requested secret")
 	enclaveSecretsCmd.AddCommand(enclaveSecretsGetCmd)
 
 	enclaveSecretsSetCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")

--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -125,6 +125,7 @@ func init() {
 	enclaveSecretsDownloadCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the secrets file. the default passphrase is computed using your current configuration.")
 	enclaveSecretsDownloadCmd.Flags().Bool("no-file", false, "print the response to stdout")
 	enclaveSecretsDownloadCmd.Flags().String("name-transformer", "", fmt.Sprintf("(BETA) output name transformer. one of %v", validNameTransformersList))
+	enclaveSecretsDownloadCmd.Flags().Duration("expire-dynamics", 0, "(BETA) dynamic secrets will expire after specified duration, (e.g. '3h', '15m')")
 	// fallback flags
 	enclaveSecretsDownloadCmd.Flags().String("fallback", "", "path to the fallback file. encrypted secrets are written to this file after each successful fetch. secrets will be read from this file if subsequent connections are unsuccessful.")
 	enclaveSecretsDownloadCmd.Flags().Bool("no-cache", false, "disable using the fallback file to speed up fetches. the fallback file is only used when the API indicates that it's still current.")

--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -16,6 +16,8 @@ limitations under the License.
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/spf13/cobra"
 )
@@ -121,6 +123,7 @@ func init() {
 	enclaveSecretsDownloadCmd.Flags().String("format", models.JSON.String(), "output format. one of [json, env]")
 	enclaveSecretsDownloadCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the secrets file. the default passphrase is computed using your current configuration.")
 	enclaveSecretsDownloadCmd.Flags().Bool("no-file", false, "print the response to stdout")
+	enclaveSecretsDownloadCmd.Flags().String("name-transformer", "", fmt.Sprintf("(BETA) output name transformer. one of %v", validNameTransformersList))
 	// fallback flags
 	enclaveSecretsDownloadCmd.Flags().String("fallback", "", "path to the fallback file. encrypted secrets are written to this file after each successful fetch. secrets will be read from this file if subsequent connections are unsuccessful.")
 	enclaveSecretsDownloadCmd.Flags().Bool("no-cache", false, "disable using the fallback file to speed up fetches. the fallback file is only used when the API indicates that it's still current.")

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -26,7 +26,7 @@ import (
 func GetSecretNames(config models.ScopedOptions) ([]string, Error) {
 	utils.RequireValue("token", config.Token.Value)
 
-	response, err := http.GetSecrets(config.APIHost.Value, utils.GetBool(config.VerifyTLS.Value, true), config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value)
+	response, err := http.GetSecrets(config.APIHost.Value, utils.GetBool(config.VerifyTLS.Value, true), config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value, nil, false, 0)
 	if !err.IsNil() {
 		return nil, Error{Err: err.Unwrap(), Message: err.Message}
 	}

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -14,6 +14,7 @@ export DOPPLER_CONFIG="prd_e2e_tests"
 "$DIR/e2e/run-fallback.sh"
 "$DIR/e2e/configure.sh"
 "$DIR/e2e/install-sh-install-path.sh"
+"$DIR/e2e/legacy-commands.sh"
 
 echo -e "\nAll tests completed successfully!"
 exit 0

--- a/tests/e2e/legacy-commands.sh
+++ b/tests/e2e/legacy-commands.sh
@@ -1,0 +1,68 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_NAME="legacy-commands"
+
+cleanup() {
+  exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    echo "ERROR: '$TEST_NAME' tests failed during execution"
+    afterAll || echo "ERROR: Cleanup failed"
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+beforeAll() {
+  echo "INFO: Executing '$TEST_NAME' tests"
+}
+
+beforeEach() {
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+afterAll() {
+  echo "INFO: Completed '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+beforeAll
+
+beforeEach
+
+# test 'doppler enclave'
+"$DOPPLER_BINARY" enclave > /dev/null 2>&1 || (echo "ERROR: doppler enclave" && exit 1)
+
+beforeEach
+
+# test 'doppler enclave configs'
+"$DOPPLER_BINARY" enclave configs > /dev/null 2>&1 || (echo "ERROR: doppler enclave configs" && exit 1)
+
+beforeEach
+
+# test 'doppler enclave environments'
+"$DOPPLER_BINARY" enclave environments > /dev/null 2>&1 || (echo "ERROR: doppler enclave environments" && exit 1)
+
+beforeEach
+
+# test 'doppler enclave projects'
+"$DOPPLER_BINARY" enclave projects > /dev/null 2>&1 || (echo "ERROR: doppler enclave projects" && exit 1)
+
+beforeEach
+
+# test 'doppler enclave secrets'
+"$DOPPLER_BINARY" enclave secrets > /dev/null 2>&1 || (echo "ERROR: doppler enclave secrets" && exit 1)
+
+beforeEach
+
+# test 'doppler enclave secrets download'
+"$DOPPLER_BINARY" enclave secrets download --no-file > /dev/null 2>&1 || (echo "ERROR: doppler enclave secrets download" && exit 1)
+
+beforeEach
+
+# test 'doppler enclave secrets get'
+"$DOPPLER_BINARY" enclave secrets get DOPPLER_CONFIG > /dev/null 2>&1 || (echo "ERROR: doppler enclave secrets get DOPPLER_CONFIG" && exit 1)
+
+afterAll


### PR DESCRIPTION
- `doppler secrets`, `doppler secrets download`, `doppler secrets substitute`, `doppler run`
  - Will issue and return dynamic secrets by default, if they exist
  - Accepts optional `--dynamics-expire <duration>`, otherwise uses system default 
  - `doppler secrets --only-names` will not issue any dynamic secrets
- `doppler secrets get <secret_name>`
  - Will not issue dynamic secrets, by design