### PR TITLE
Surface gpg error without --debug and fix typo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ google.json
 
 # CLI completions
 completions/
+.DS_Store

--- a/pkg/controllers/update.go
+++ b/pkg/controllers/update.go
@@ -69,12 +69,17 @@ func RunInstallScript() (bool, string, Error) {
 		exitCode := 1
 		if exitError, ok := err.(*exec.ExitError); ok {
 			exitCode = exitError.ExitCode()
-		}
+		}		
 
 		message := "Unable to install the latest Doppler CLI"
 		permissionError := exitCode == 2 || strings.Contains(strOut, "dpkg: error: requested operation requires superuser privilege")
 		if permissionError {
 			message = "Error: update failed due to improper permissions\nPlease re-run with `sudo` or as an admin"
+		}
+
+		gpgError := strings.Contains(strOut, "Unable to find gpg")
+		if gpgError {
+			message = "Error: Unable to find gpg binary for signature verification\nYou can resolve this error by installing your system's gnupg package"
 		}
 
 		return false, "", Error{Err: err, Message: message}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -378,7 +378,7 @@ gpg_binary="$(command -v gpg || true)";
 if [ -x "$gpg_binary" ]; then
   log_debug "Using $gpg_binary for signature verification"
 else
-  log "ERROR: Unable to find gpg binary for signature verficiation"
+  log "ERROR: Unable to find gpg binary for signature verification"
   log "You can resolve this error by installing your system's gnupg package"
   clean_exit 1
 fi


### PR DESCRIPTION
Given that some folks are going to run into issues with `doppler update` due to gpg now being required, I think it's worth surfacing this error without `--debug`.

The error output would now be:

```sh
doppler update
Updating...
Error: Unable to find gpg binary for signature verification. You can resolve this error by installing your system's gnupg package
Doppler Error: exit status 1
```

Also fixed a typo in install.sh