### PR TITLE
Use existing installation location if one exists

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -528,6 +528,25 @@ elif [ "$format" = "tar" ]; then
       fi
     fi
 
+    # check for an existing Doppler binary
+    if [ "$binary_installed" -eq 0 ]; then
+      existing_install_dir="$(command -v doppler || true)"
+      if [ "$existing_install_dir" != "" ]; then
+        install_dir="$(dirname "$existing_install_dir")"
+        # capture exit code without exiting
+        set +e
+        install_binary "$install_dir"
+        exit_code=$?
+        set -e
+        if [ $exit_code -eq 0 ]; then
+          binary_installed=1
+          BINARY_INSTALLED_PATH="$install_dir"
+        elif [ $exit_code -eq 1 ]; then
+          found_non_writable_path=1
+        fi
+      fi
+    fi
+
     if [ "$binary_installed" -eq 0 ]; then
       install_dir="/usr/local/bin"
       # capture exit code without exiting

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -14,6 +14,7 @@ export DOPPLER_CONFIG="prd_e2e_tests"
 "$DIR/e2e/run-fallback.sh"
 "$DIR/e2e/configure.sh"
 "$DIR/e2e/install-sh-install-path.sh"
+"$DIR/e2e/install-sh-update-in-place.sh"
 "$DIR/e2e/legacy-commands.sh"
 
 echo -e "\nAll tests completed successfully!"

--- a/tests/e2e/install-sh-update-in-place.sh
+++ b/tests/e2e/install-sh-update-in-place.sh
@@ -1,0 +1,161 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_NAME="install.sh-update-in-place"
+TEMP_INSTALL_DIR="$PWD/temp-install-dir"
+ORIG_DOPPLER="$(command -v doppler || true)"
+PATH="$TEMP_INSTALL_DIR:$PATH"
+
+######################################################################
+
+cleanup() {
+  exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    echo "ERROR: '$TEST_NAME' tests failed during execution"
+    afterAll || echo "ERROR: Cleanup failed"
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+beforeAll() {
+  echo "INFO: Executing '$TEST_NAME' tests"
+  rm -rf "$TEMP_INSTALL_DIR"
+
+  if test ! -z "$ORIG_DOPPLER"; then
+    echo "INFO: Moving original doppler executable"
+    mv "$ORIG_DOPPLER" ./doppler.orig
+  fi
+}
+
+beforeEach() {
+  header
+  rm -rf "$TEMP_INSTALL_DIR"
+}
+
+afterEach() {
+  footer
+}
+
+header() {
+  echo "========================================="
+  echo "EXECUTING: $name"
+}
+
+footer() {
+  echo "========================================="
+}
+
+afterAll() {
+  echo "INFO: Completed '$TEST_NAME' tests"
+  rm -rf "$TEMP_INSTALL_DIR"
+
+  if test ! -z "$ORIG_DOPPLER"; then
+    echo "INFO: Restoring original doppler executable"
+    mv ./doppler.orig "$ORIG_DOPPLER"
+  fi
+}
+
+md5hash() {
+  md5 -rq $1 || md5sum $1 | awk '{print $1}'
+}
+
+######################################################################
+
+beforeAll
+
+######################################################################
+#
+
+name="custom install path works"
+
+beforeEach
+
+set +e
+mkdir "$TEMP_INSTALL_DIR"
+output="$("$DOPPLER_SCRIPTS_DIR/install.sh" --install-path $TEMP_INSTALL_DIR 2>&1)"
+exit_code=$?
+set -e
+installed_at="$(command -v doppler || true)"
+
+actual="$(dirname "$installed_at")"
+expected="$TEMP_INSTALL_DIR"
+
+####################
+
+[ "$actual" == "$expected" ] || \
+  (echo "ERROR: binary not installed at expected custom install path. Expected: $expected, Actual: $actual" && \
+    echo "SCRIPT OUTPUT:" && echo "$output" && \
+    exit 1)
+
+afterEach
+
+######################################################################
+#
+
+name="default /usr/local/bin works"
+
+beforeEach
+
+set +e
+mkdir "$TEMP_INSTALL_DIR"
+output="$("$DOPPLER_SCRIPTS_DIR/install.sh" --no-package-manager 2>&1)"
+exit_code=$?
+set -e
+installed_at="$(command -v doppler || true)"
+
+actual="$(dirname "$installed_at")"
+expected="/usr/local/bin"
+
+rm -rf /usr/local/bin/doppler
+
+####################
+
+[ "$actual" == "$expected" ] || \
+  (echo "ERROR: binary not installed at expected default path. Expected: $expected, Actual: $actual" && \
+     echo "SCRIPT OUTPUT:" && echo "$output" && \
+     exit 1)
+
+afterEach
+
+######################################################################
+#
+
+name="updates pre-existing binary if it exists"
+
+beforeEach
+
+set +e
+mkdir "$TEMP_INSTALL_DIR"
+touch "$TEMP_INSTALL_DIR/doppler" && chmod +x "$TEMP_INSTALL_DIR/doppler"
+
+empty_hash="$(md5hash "$TEMP_INSTALL_DIR/doppler")"
+output="$("$DOPPLER_SCRIPTS_DIR/install.sh" --no-package-manager 2>&1)"
+exit_code=$?
+set -e
+
+updated_hash="$(md5hash "$TEMP_INSTALL_DIR/doppler")"
+installed_at="$(command -v doppler || true)"
+
+actual_dir="$(dirname "$installed_at")"
+# TEMP_INSTALL_DIR is the first dir on the PATH, so we expect that
+expected_dir="$TEMP_INSTALL_DIR"
+
+####################
+
+[ "$expected_dir" == "$actual_dir" ] || \
+  (echo "ERROR: binary not installed to expected path. Expected: $expected_dir, Actual: $actual_dir" && \
+    echo "SCRIPT OUTPUT:" && echo "$output" && \
+    exit 1)
+[ "$updated_hash" != "$empty_hash" ] || \
+  (echo "ERROR: expected binary wasn't updated" && \
+    echo "SCRIPT OUTPUT:" && echo "$output" && \
+    exit 1)
+
+afterEach
+
+######################################################################
+
+afterAll


### PR DESCRIPTION
This adds an additional check to see if the Doppler CLI already exists on the PATH somewhere. If it does, it uses that as the installation location. It addresses problems introduced by Homebrew switching to installing under `/opt/homebrew` and will also make it so users who installed to a custom location using `--install-path` get updated properly when `doppler update` is run.

Closes ENG-2166