### PR TITLE
Fix `run` erroneously using local environment variable

### DIFF
--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -11,6 +11,7 @@ export DOPPLER_CONFIG="prd_e2e_tests"
 
 # Run tests
 "$DIR/e2e/secrets-download-fallback.sh"
+"$DIR/e2e/run.sh"
 "$DIR/e2e/run-fallback.sh"
 "$DIR/e2e/run-mount.sh"
 "$DIR/e2e/configure.sh"

--- a/tests/e2e/run-mount.sh
+++ b/tests/e2e/run-mount.sh
@@ -36,7 +36,7 @@ beforeAll
 beforeEach
 
 # verify content of mounted secrets file
-EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli"}'
+EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli","HOME":"123"}'
 actual="$("$DOPPLER_BINARY" run --mount secrets.json --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
 if [ "$actual" != "$EXPECTED_SECRETS" ]; then
  echo "ERROR: mounted secrets file has invalid contents"
@@ -65,7 +65,7 @@ fi
 beforeEach
 
 # verify format is auto detected
-EXPECTED_SECRETS='DOPPLER_CONFIG="prd_e2e_tests"\nDOPPLER_ENCLAVE_CONFIG="prd_e2e_tests"\nDOPPLER_ENCLAVE_ENVIRONMENT="prd"\nDOPPLER_ENCLAVE_PROJECT="cli"\nDOPPLER_ENVIRONMENT="prd"\nDOPPLER_PROJECT="cli"'
+EXPECTED_SECRETS='DOPPLER_CONFIG="prd_e2e_tests"\nDOPPLER_ENCLAVE_CONFIG="prd_e2e_tests"\nDOPPLER_ENCLAVE_ENVIRONMENT="prd"\nDOPPLER_ENCLAVE_PROJECT="cli"\nDOPPLER_ENVIRONMENT="prd"\nDOPPLER_PROJECT="cli"\nHOME="123"'
 actual="$("$DOPPLER_BINARY" run --mount secrets.env --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
 if [[ "$actual" != "$(echo -e "$EXPECTED_SECRETS")" ]]; then
  echo "ERROR: mounted secrets file with auto-detected env format has invalid contents"
@@ -75,7 +75,7 @@ fi
 beforeEach
 
 # verify specified format is used
-EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli"}'
+EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli","HOME":"123"}'
 actual="$("$DOPPLER_BINARY" run --mount secrets.env --mount-format json --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
 if [[ "$actual" != "$(echo -e "$EXPECTED_SECRETS")" ]]; then
  echo "ERROR: mounted secrets file with json format has invalid contents"
@@ -85,7 +85,7 @@ fi
 beforeEach
 
 # verify specified name transformer is used
-EXPECTED_SECRETS='{"TF_VAR_doppler_config":"prd_e2e_tests","TF_VAR_doppler_enclave_config":"prd_e2e_tests","TF_VAR_doppler_enclave_environment":"prd","TF_VAR_doppler_enclave_project":"cli","TF_VAR_doppler_environment":"prd","TF_VAR_doppler_project":"cli"}'
+EXPECTED_SECRETS='{"TF_VAR_doppler_config":"prd_e2e_tests","TF_VAR_doppler_enclave_config":"prd_e2e_tests","TF_VAR_doppler_enclave_environment":"prd","TF_VAR_doppler_enclave_project":"cli","TF_VAR_doppler_environment":"prd","TF_VAR_doppler_project":"cli","TF_VAR_home":"123"}'
 actual="$("$DOPPLER_BINARY" run --mount secrets.json --name-transformer tf-var --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
 if [[ "$actual" != "$EXPECTED_SECRETS" ]]; then
  echo "ERROR: mounted secrets file with name transformer has invalid contents"
@@ -95,7 +95,7 @@ fi
 beforeEach
 
 # verify existing env value is ignored even when --preserve-env is specified
-EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli"}'
+EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli","HOME":"123"}'
 actual="$(DOPPLER_CONFIG="test" "$DOPPLER_BINARY" run --preserve-env --config prd_e2e_tests --mount secrets.json --command "cat \$DOPPLER_CLI_SECRETS_PATH")"
 if [ "$actual" != "$EXPECTED_SECRETS" ]; then
  echo "ERROR: mounted secrets file with --preserve-env has invalid contents"

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -1,0 +1,73 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_NAME="run"
+
+cleanup() {
+  exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    echo "ERROR: '$TEST_NAME' tests failed during execution"
+    afterAll || echo "ERROR: Cleanup failed"
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+beforeAll() {
+  echo "INFO: Executing '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+beforeEach() {
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+afterAll() {
+  echo "INFO: Completed '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+error() {
+  message=$1
+  echo "$message"
+  exit 1
+}
+
+beforeAll
+
+beforeEach
+
+# verify local env is ignored
+config="$(DOPPLER_CONFIG=123 "$DOPPLER_BINARY" run --config prd_e2e_tests -- printenv DOPPLER_CONFIG)"
+[[ "$config" == "prd_e2e_tests" ]] || error "ERROR: conflicting local env var is not ignored"
+
+beforeEach
+
+# verify local env is used when specifying --preserve-env
+config="$(DOPPLER_CONFIG=123 "$DOPPLER_BINARY" run --config prd_e2e_tests --preserve-env -- printenv DOPPLER_CONFIG)"
+[[ "$config" == "123" ]] || error "ERROR: conflicting local env var is not used with --preserve-env"
+
+beforeEach
+
+# verify local env is used when key isn't specified in Doppler
+value="$(NONEXISTENT_KEY=123 "$DOPPLER_BINARY" run -- printenv NONEXISTENT_KEY)"
+[[ "$value" == "123" ]] || error "ERROR: local env var is not used"
+
+beforeEach
+
+# verify local env is used when key isn't specified in Doppler (and --preserve-env is specified)
+value="$(NONEXISTENT_KEY=123 "$DOPPLER_BINARY" run --preserve-env -- printenv NONEXISTENT_KEY)"
+[[ "$value" == "123" ]] || error "ERROR: local env var is not used with --preserve-env"
+
+beforeEach
+
+# verify reserved secrets are ignored
+# first verify the doppler config has a secret named 'HOME', or this test is useless
+"$DOPPLER_BINARY" secrets get HOME >/dev/null 2>&1 || error "ERROR: doppler config does not contain 'HOME' secret"
+home="$HOME"
+value="$("$DOPPLER_BINARY" run -- printenv HOME)"
+[[ "$value" == "$home" ]] || error "ERROR: reserved secret is not ignored"
+
+afterAll


### PR DESCRIPTION
The local env var should only be given precedence when `--preserve-env` is specified. This also simplifies the key reconciliation logic a bit.

Closes #307.