### PR TITLE
Add --mount-template option to doppler run

### DIFF
--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -178,7 +178,7 @@ func ReadTemplateFile(filePath string) string {
 
 func RenderSecretsTemplate(templateBody string, secretsMap map[string]string) string {
 	funcs := map[string]interface{}{
-		"tojson": func(value string) (string, error) {
+		"tojson": func(value interface{}) (string, error) {
 			body, err := json.Marshal(value)
 			if err != nil {
 				return "", err

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -74,7 +74,7 @@ func MapToEnvFormat(secrets map[string]string, wrapInQuotes bool) []string {
 	return env
 }
 
-func MountSecrets(secrets map[string]string, format string, mountPath string, maxReads int) (string, func(), Error) {
+func MountSecrets(secrets map[string]string, format string, mountPath string, maxReads int, templateBody string) (string, func(), Error) {
 	if !utils.SupportsNamedPipes {
 		return "", nil, Error{Err: errors.New("This OS does not support mounting a secrets file")}
 	}
@@ -84,7 +84,9 @@ func MountSecrets(secrets map[string]string, format string, mountPath string, ma
 	}
 
 	var mountData []byte
-	if format == "env" {
+	if format == "template" {
+		mountData = []byte(RenderSecretsTemplate(templateBody, secrets))
+	} else if format == "env" {
 		mountData = []byte(strings.Join(MapToEnvFormat(secrets, true), "\n"))
 	} else if format == "json" {
 		envStr, err := json.Marshal(secrets)

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -11,6 +11,7 @@ export DOPPLER_CONFIG="prd_e2e_tests"
 
 # Run tests
 "$DIR/e2e/secrets-download-fallback.sh"
+"$DIR/e2e/secrets-substitute.sh"
 "$DIR/e2e/run.sh"
 "$DIR/e2e/run-fallback.sh"
 "$DIR/e2e/run-mount.sh"

--- a/tests/e2e/run-mount.sh
+++ b/tests/e2e/run-mount.sh
@@ -94,6 +94,32 @@ fi
 
 beforeEach
 
+# verify template is used
+EXPECTED_SECRETS='prd_e2e_tests'
+actual="$("$DOPPLER_BINARY" run --mount secrets.json --mount-template /dev/stdin --command "cat \$DOPPLER_CLI_SECRETS_PATH" <<<'{{.DOPPLER_CONFIG}}')"
+if [[ "$actual" != "$EXPECTED_SECRETS" ]]; then
+ echo "ERROR: mounted secrets file with template has invalid contents"
+ exit 1
+fi
+
+beforeEach
+
+# verify --mount-template can be used with --mount-format=template
+EXPECTED_SECRETS='prd_e2e_tests'
+actual="$("$DOPPLER_BINARY" run --mount secrets.json --mount-template /dev/stdin --mount-format template --command "cat \$DOPPLER_CLI_SECRETS_PATH" <<<'{{.DOPPLER_CONFIG}}')"
+if [[ "$actual" != "$EXPECTED_SECRETS" ]]; then
+ echo "ERROR: mounted secrets file with template has invalid contents"
+ exit 1
+fi
+
+beforeEach
+
+# verify --mount-template cannot be used with --mount-format=json
+"$DOPPLER_BINARY" run --mount secrets.json --mount-template /dev/stdin --mount-format json --command "cat \$DOPPLER_CLI_SECRETS_PATH" <<<'{{.DOPPLER_CONFIG}}' && \
+  (echo "ERROR: mounted secrets with template was successful with invalid --mount-format" && exit 1)
+
+beforeEach
+
 # verify existing env value is ignored even when --preserve-env is specified
 EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli","HOME":"123"}'
 actual="$(DOPPLER_CONFIG="test" "$DOPPLER_BINARY" run --preserve-env --config prd_e2e_tests --mount secrets.json --command "cat \$DOPPLER_CLI_SECRETS_PATH")"

--- a/tests/e2e/secrets-substitute.sh
+++ b/tests/e2e/secrets-substitute.sh
@@ -1,0 +1,49 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_NAME="secrets-substitute"
+
+cleanup() {
+  exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    echo "ERROR: '$TEST_NAME' tests failed during execution"
+    afterAll || echo "ERROR: Cleanup failed"
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+beforeAll() {
+  echo "INFO: Executing '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+beforeEach() {
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+afterAll() {
+  echo "INFO: Completed '$TEST_NAME' tests"
+  "$DOPPLER_BINARY" run clean --max-age=0s --silent
+}
+
+error() {
+  message=$1
+  echo "$message"
+  exit 1
+}
+
+beforeAll
+
+beforeEach
+
+# verify template substitution behavior
+config="$("$DOPPLER_BINARY" secrets substitute /dev/stdin <<<'{{.DOPPLER_CONFIG}}')"
+[[ "$config" == "prd_e2e_tests" ]] || error "ERROR: secrets substitute output was incorrect"
+
+"$DOPPLER_BINARY" secrets substitute nonexistent-file.txt && \
+  error "ERROR: secrets substitute did not fail on nonexistent file"
+
+afterAll


### PR DESCRIPTION
I took a few minutes to add tests to `doppler secrets substitute` and in the process, I realized it wasn't too difficult to add a `--mount-template` option to use the same functionality in `doppler run`.

If we'd rather hold off on adding this new flag right away, I'd still like to keep the other chores/fixes.

This branch is based on `fix-run-env`
