### PR TITLE
chore: fix platform error when building on arm64 machine

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -109,6 +109,7 @@ dockers:
       - "--label=org.label-schema.schema-version=1.0"
       - "--label=org.label-schema.version={{.Version}}"
       - "--label=org.label-schema.name={{.ProjectName}}"
+      - "--platform=linux/amd64"
 
 brews:
   - name: doppler


### PR DESCRIPTION
When our docker image is built on an arm64 machine, it fails to execute on amd64 machines. Conversely, when our image is built on an amd64 machine, it can run on both architecures. Thus, we now always build an amd64 image. This is an intermediate step until we ultimately build an image for each architecture.

Closes ENG-3657.