### PR TITLE
Add error when using --mount-template without --mount

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -153,6 +153,10 @@ doppler run --mount secrets.json -- cat secrets.json`,
 			}
 		}
 
+		if shouldMountTemplate && !shouldMountFile {
+			utils.HandleError(errors.New("--mount-template must be used with --mount"))
+		}
+
 		originalEnv := os.Environ()
 		existingEnvKeys := map[string]string{}
 		for _, envVar := range originalEnv {

--- a/tests/e2e/run-mount.sh
+++ b/tests/e2e/run-mount.sh
@@ -120,6 +120,12 @@ beforeEach
 
 beforeEach
 
+# verify --mount-template cannot be used without --mount
+"$DOPPLER_BINARY" run --mount-template /dev/stdin --command "cat \$DOPPLER_CLI_SECRETS_PATH" <<<'{{.DOPPLER_CONFIG}}' && \
+  (echo "ERROR: mounted secrets with template was successful without --mount" && exit 1)
+
+beforeEach
+
 # verify existing env value is ignored even when --preserve-env is specified
 EXPECTED_SECRETS='{"DOPPLER_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_CONFIG":"prd_e2e_tests","DOPPLER_ENCLAVE_ENVIRONMENT":"prd","DOPPLER_ENCLAVE_PROJECT":"cli","DOPPLER_ENVIRONMENT":"prd","DOPPLER_PROJECT":"cli","HOME":"123"}'
 actual="$(DOPPLER_CONFIG="test" "$DOPPLER_BINARY" run --preserve-env --config prd_e2e_tests --mount secrets.json --command "cat \$DOPPLER_CLI_SECRETS_PATH")"


### PR DESCRIPTION
This PR adds an error message (and tests) when `--mount-template` is specified without `--mount`.

Closes ENG-4343
