### PR TITLE
Add secrets mount support for ASP.NET settings files

### DIFF
--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -114,6 +114,7 @@ doppler secrets delete API_KEY CRYPTO_KEY`,
 var validFormatList = strings.Join(models.SecretFormats, ", ")
 var validNameTransformersList = strings.Join(models.SecretsNameTransformerTypes, ", ")
 var validEnvCompatNameTransformersList = strings.Join(models.SecretsEnvCompatNameTransformerTypes, ", ")
+var validMountFormatsList = strings.Join(models.SecretsMountFormatTypes, ", ")
 var secretsDownloadCmd = &cobra.Command{
 	Use:   "download <filepath>",
 	Short: "Download a config's secrets for later use",

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -114,7 +114,6 @@ doppler secrets delete API_KEY CRYPTO_KEY`,
 var validFormatList = strings.Join(models.SecretFormats, ", ")
 var validNameTransformersList = strings.Join(models.SecretsNameTransformerTypes, ", ")
 var validEnvCompatNameTransformersList = strings.Join(models.SecretsEnvCompatNameTransformerTypes, ", ")
-var validMountFormatsList = strings.Join(models.SecretsMountFormatTypes, ", ")
 var secretsDownloadCmd = &cobra.Command{
 	Use:   "download <filepath>",
 	Short: "Download a config's secrets for later use",

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -54,26 +54,6 @@ func GetSecretNames(config models.ScopedOptions) ([]string, Error) {
 	return secretsNames, Error{}
 }
 
-func MapToEnvFormat(secrets map[string]string, wrapInQuotes bool) []string {
-	var env []string
-	for k, v := range secrets {
-		if wrapInQuotes {
-			v = strings.ReplaceAll(v, "\\", "\\\\")
-			v = strings.ReplaceAll(v, "\"", "\\\"")
-			env = append(env, fmt.Sprintf("%s=\"%s\"", k, v))
-		} else {
-			env = append(env, fmt.Sprintf("%s=%s", k, v))
-		}
-	}
-
-	// sort keys alphabetically for deterministic order
-	sort.Slice(env, func(a, b int) bool {
-		return env[a] < env[b]
-	})
-
-	return env
-}
-
 func MountSecrets(secrets map[string]string, format string, mountPath string, maxReads int, templateBody string) (string, func(), Error) {
 	if !utils.SupportsNamedPipes {
 		return "", nil, Error{Err: errors.New("This OS does not support mounting a secrets file")}
@@ -84,18 +64,25 @@ func MountSecrets(secrets map[string]string, format string, mountPath string, ma
 	}
 
 	var mountData []byte
-	if format == models.TemplateMountFormat.Type {
+	if format == models.TemplateMountFormat {
 		mountData = []byte(RenderSecretsTemplate(templateBody, secrets))
-	} else if format == models.EnvMountFormat.Type {
-		mountData = []byte(strings.Join(MapToEnvFormat(secrets, true), "\n"))
-	} else if format == models.JSONMountFormat.Type {
+	} else if format == models.EnvMountFormat {
+		mountData = []byte(strings.Join(utils.MapToEnvFormat(secrets, true), "\n"))
+	} else if format == models.JSONMountFormat {
 		envStr, err := json.Marshal(secrets)
 		if err != nil {
 			return "", nil, Error{Err: err, Message: "Unable to marshall secrets to json"}
 		}
 		mountData = envStr
+	} else if format == models.DotNETJSONMountFormat {
+		envStr, err := json.Marshal(utils.MapToDotNETJSONFormat(secrets))
+		if err != nil {
+			return "", nil, Error{Err: err, Message: "Unable to marshall .NET formatted secrets to json"}
+		}
+		mountData = envStr
 	} else {
-		return "", nil, Error{Err: fmt.Errorf("Invalid mount format: %s", format)}
+		return "", nil, Error{Err: fmt.Errorf("invalid mount format. Valid formats are %s", models.SecretsMountFormats)}
+
 	}
 
 	// convert mount path to absolute path

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -84,11 +84,11 @@ func MountSecrets(secrets map[string]string, format string, mountPath string, ma
 	}
 
 	var mountData []byte
-	if format == "template" {
+	if format == models.TemplateMountFormat.Type {
 		mountData = []byte(RenderSecretsTemplate(templateBody, secrets))
-	} else if format == "env" {
+	} else if format == models.EnvMountFormat.Type {
 		mountData = []byte(strings.Join(MapToEnvFormat(secrets, true), "\n"))
-	} else if format == "json" {
+	} else if format == models.JSONMountFormat.Type {
 		envStr, err := json.Marshal(secrets)
 		if err != nil {
 			return "", nil, Error{Err: err, Message: "Unable to marshall secrets to json"}

--- a/pkg/models/secrets_mount.go
+++ b/pkg/models/secrets_mount.go
@@ -1,0 +1,50 @@
+/*
+Copyright © 2021 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package models
+
+type SecretsMountFormat struct {
+	Name string
+	Type string
+}
+
+var JSONMountFormat = &SecretsMountFormat{
+	Name: "json",
+	Type: "json",
+}
+var EnvMountFormat = &SecretsMountFormat{
+	Name: "env",
+	Type: "env",
+}
+var TemplateMountFormat = &SecretsMountFormat{
+	Name: "template",
+	Type: "template",
+}
+var SecretsMountFormatList = []*SecretsMountFormat{
+	EnvMountFormat,
+	JSONMountFormat,
+	TemplateMountFormat,
+}
+
+var SecretsMountFormatTypes []string
+var SecretsMountFormatMap map[string]*SecretsMountFormat
+
+func init() {
+	SecretsMountFormatMap = map[string]*SecretsMountFormat{}
+	for _, format := range SecretsMountFormatList {
+		SecretsMountFormatMap[format.Type] = format
+		SecretsMountFormatTypes = append(SecretsMountFormatTypes, format.Type)
+	}
+}

--- a/pkg/models/secrets_mount.go
+++ b/pkg/models/secrets_mount.go
@@ -15,36 +15,21 @@ limitations under the License.
 */
 package models
 
-type SecretsMountFormat struct {
-	Name string
-	Type string
-}
+const JSONMountFormat = "json"
+const EnvMountFormat = "env"
+const TemplateMountFormat = "template"
+const DotNETJSONMountFormat = "dotnet-json"
 
-var JSONMountFormat = &SecretsMountFormat{
-	Name: "json",
-	Type: "json",
-}
-var EnvMountFormat = &SecretsMountFormat{
-	Name: "env",
-	Type: "env",
-}
-var TemplateMountFormat = &SecretsMountFormat{
-	Name: "template",
-	Type: "template",
-}
-var SecretsMountFormatList = []*SecretsMountFormat{
+var SecretsMountFormats = []string{
 	EnvMountFormat,
 	JSONMountFormat,
+	DotNETJSONMountFormat,
 	TemplateMountFormat,
 }
 
-var SecretsMountFormatTypes []string
-var SecretsMountFormatMap map[string]*SecretsMountFormat
-
-func init() {
-	SecretsMountFormatMap = map[string]*SecretsMountFormat{}
-	for _, format := range SecretsMountFormatList {
-		SecretsMountFormatMap[format.Type] = format
-		SecretsMountFormatTypes = append(SecretsMountFormatTypes, format.Type)
-	}
+var SecretsMountFormatMap = map[string]string{
+	EnvMountFormat:        EnvMountFormat,
+	JSONMountFormat:       JSONMountFormat,
+	DotNETJSONMountFormat: DotNETJSONMountFormat,
+	TemplateMountFormat:   TemplateMountFormat,
 }

--- a/pkg/models/secrets_name_transformer.go
+++ b/pkg/models/secrets_name_transformer.go
@@ -46,7 +46,7 @@ var DotNETTransformer = &SecretsNameTransformer{
 	Type:      "dotnet",
 	EnvCompat: false,
 }
-var DotNETENVTransformer = &SecretsNameTransformer{
+var DotNETEnvTransformer = &SecretsNameTransformer{
 	Name:      ".NET (ENV)",
 	Type:      "dotnet-env",
 	EnvCompat: true,
@@ -58,7 +58,7 @@ var SecretsNameTransformersList = []*SecretsNameTransformer{
 	LowerSnakeTransformer,
 	TFVarTransformer,
 	DotNETTransformer,
-	DotNETENVTransformer,
+	DotNETEnvTransformer,
 }
 
 var SecretsNameTransformerTypes []string

--- a/pkg/utils/name_transformers.go
+++ b/pkg/utils/name_transformers.go
@@ -1,0 +1,70 @@
+/*
+Copyright © 2022 Doppler <support@doppler.com>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+func UpperCamel(name string) string {
+	var parts []string
+	for _, part := range strings.Split(name, "_") {
+		if len(part) == 0 {
+			continue
+		}
+
+		upperCamel := strings.ToUpper(part[0:1]) + strings.ToLower(part[1:])
+		parts = append(parts, upperCamel)
+
+	}
+	return strings.Join(parts, "")
+}
+
+func DotNETNameTransform(name string) string {
+	var parts []string
+	for _, part := range strings.Split(name, "__") {
+		parts = append(parts, UpperCamel(part))
+	}
+	return strings.Join(parts, ":")
+}
+
+func MapToEnvFormat(secrets map[string]string, wrapInQuotes bool) []string {
+	var env []string
+	for k, v := range secrets {
+		if wrapInQuotes {
+			v = strings.ReplaceAll(v, "\\", "\\\\")
+			v = strings.ReplaceAll(v, "\"", "\\\"")
+			env = append(env, fmt.Sprintf("%s=\"%s\"", k, v))
+		} else {
+			env = append(env, fmt.Sprintf("%s=%s", k, v))
+		}
+	}
+
+	// sort keys alphabetically for deterministic order
+	sort.Slice(env, func(a, b int) bool {
+		return env[a] < env[b]
+	})
+
+	return env
+}
+
+func MapToDotNETJSONFormat(secrets map[string]string) map[string]string {
+	var dotnetJSON = make(map[string]string)
+	for key, value := range secrets {
+		keyTransform := DotNETNameTransform(key)
+		dotnetJSON[keyTransform] = value
+	}
+	return dotnetJSON
+}

--- a/pkg/utils/name_transformers_test.go
+++ b/pkg/utils/name_transformers_test.go
@@ -1,0 +1,82 @@
+/*
+Copyright © 2019 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"reflect"
+	"testing"
+)
+
+type testCase struct {
+	name          string
+	nameTransform string
+}
+
+func TestUpperCamel(t *testing.T) {
+	testCases := []testCase{
+		{"TEST", "Test"},
+		{"TEST_", "Test"},
+		{"TEST_SECRET", "TestSecret"},
+		{"TEST_SECRET_NAME", "TestSecretName"},
+		{"TEST__SECRET", "TestSecret"},
+	}
+
+	for _, testCase := range testCases {
+		nameTransform := UpperCamel(testCase.name)
+		if testCase.nameTransform != nameTransform {
+			t.Errorf("Expected '%s' to be '%s' but got '%s'", testCase.name, testCase.nameTransform, nameTransform)
+		}
+	}
+}
+
+func TestDotNETNameTransform(t *testing.T) {
+	testCases := []testCase{
+		{"TEST", "Test"},
+		{"TEST_", "Test"},
+		{"TEST_SECRET", "TestSecret"},
+		{"TEST_SECRET_NAME", "TestSecretName"},
+		{"TEST__SECRET", "Test:Secret"},
+	}
+
+	for _, testCase := range testCases {
+		nameTransform := DotNETNameTransform(testCase.name)
+		if testCase.nameTransform != nameTransform {
+			t.Errorf("Expected '%s' to be '%s' but got '%s'", testCase.name, testCase.nameTransform, nameTransform)
+		}
+	}
+}
+
+func TestMapToDotNETJSONFormat(t *testing.T) {
+	secrets := map[string]string{
+		"TEST":             "",
+		"TEST_SECRET":      "",
+		"TEST_SECRET_NAME": "",
+		"TEST__SECRET":     "",
+	}
+
+	transformedSecrets := map[string]string{
+		"Test":           "",
+		"TestSecret":     "",
+		"TestSecretName": "",
+		"Test:Secret":    "",
+	}
+
+	transformedSecretsResult := MapToDotNETJSONFormat(secrets)
+
+	if !reflect.DeepEqual(transformedSecrets, transformedSecretsResult) {
+		t.Errorf("Expected '%s' to be '%s' but got '%s'", secrets, transformedSecrets, transformedSecretsResult)
+	}
+}

--- a/pkg/utils/secrets_mount.go
+++ b/pkg/utils/secrets_mount.go
@@ -1,0 +1,22 @@
+/*
+Copyright © 2022 Doppler <support@doppler.com>
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+    http://www.apache.org/licenses/LICENSE-2.0
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"regexp"
+)
+
+func IsDotNETSettingsFile(fileName string) bool {
+	matched, _ := regexp.MatchString(`(?i)appsettings(\.[a-z0-9_-]+)?\.json`, fileName)
+	return matched
+}

--- a/pkg/utils/secrets_mount_test.go
+++ b/pkg/utils/secrets_mount_test.go
@@ -1,0 +1,44 @@
+/*
+Copyright © 2019 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package utils
+
+import (
+	"testing"
+)
+
+func TestIsDotNETSettingsFile(t *testing.T) {
+	type testCase struct {
+		fileName string
+		match    bool
+	}
+
+	testCases := []testCase{
+		{"appSettings.json", true},
+		{"appsettings.json", true},
+		{"appsettings.Development.json", true},
+		{"appSettings.Production.json", true},
+		{"appSettings.Other_Environment.json", true},
+		{"settings.json", false},
+		{"app.settings.json", false},
+	}
+
+	for _, testCase := range testCases {
+		matched := IsDotNETSettingsFile(testCase.fileName)
+		if testCase.match != matched {
+			t.Errorf("Expected '%s' match result to be '%t' but got '%t'", testCase.fileName, testCase.match, matched)
+		}
+	}
+}


### PR DESCRIPTION
`doppler run --mount` currently only supports environment variable compatible name transformers.

This PR defines a new models collection of available mount formats and adds support for the `dotnet-json` name transformer.

https://user-images.githubusercontent.com/133014/183775750-e576a9fd-f6d8-4459-9adb-9e59cfe166f9.mp4

Closes DEVRL-417