### PR TITLE
ENG-4848: Make HTTP request attempts configurable

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -200,6 +200,7 @@ func init() {
 	rootCmd.PersistentFlags().Bool("no-verify-tls", false, "do not verify the validity of TLS certificates on HTTP requests (not recommended)")
 	rootCmd.PersistentFlags().Bool("no-timeout", !http.UseTimeout, "disable http timeout")
 	rootCmd.PersistentFlags().DurationVar(&http.TimeoutDuration, "timeout", http.TimeoutDuration, "max http request duration")
+	rootCmd.PersistentFlags().IntVar(&http.RequestAttempts, "attempts", http.RequestAttempts, "number of http request attempts made before failing")
 	// DNS resolver
 	rootCmd.PersistentFlags().Bool("no-dns-resolver", !http.UseCustomDNSResolver, "use the OS's default DNS resolver")
 	if err := rootCmd.PersistentFlags().MarkDeprecated("no-dns-resolver", "the DNS resolver is disabled by default"); err != nil {

--- a/pkg/http/config.go
+++ b/pkg/http/config.go
@@ -22,3 +22,6 @@ var UseTimeout = true
 
 // TimeoutDuration how long to wait for a request to complete before timing out
 var TimeoutDuration = 10 * time.Second
+
+// RequestAttempts how many request attempts are made before giving up
+var RequestAttempts = 5

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -200,7 +200,7 @@ func performRequest(req *http.Request, verifyTLS bool, params []queryParam) (int
 	var response *http.Response
 	response = nil
 
-	requestErr := retry(5, 100*time.Millisecond, func() error {
+	requestErr := retry(RequestAttempts, 100*time.Millisecond, func() error {
 		resp, err := client.Do(req)
 		if err != nil {
 			if resp != nil {


### PR DESCRIPTION
By default, the CLI has a 10 second timeout (configurable with `--timeout`) and will make 5 attempts (not configurable). This change makes the attempt count configurable, while continuing to default to the same number we did previously by adding the `--attempts` flag.

Some potential examples:

```
doppler secrets download --attempts 3
```

```
doppler run --timeout 3s --attempts 3 -- $COMMAND
```