### PR TITLE
chore: Use latest Go minor version on GitHub Actions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18'
+        check-latest: true
     - name: Checkout
       uses: actions/checkout@v1
       with:

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -15,9 +15,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18'
+        check-latest: true
     - name: Checkout
       uses: actions/checkout@v1
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -20,9 +20,10 @@ jobs:
       contents: write
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18'
+        check-latest: true
     - name: Checkout
       uses: actions/checkout@v3
       with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18'
+        check-latest: true
     - name: Checkout
       uses: actions/checkout@v1
       with:
@@ -26,9 +27,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Set up Go
-      uses: actions/setup-go@v1
+      uses: actions/setup-go@v3
       with:
         go-version: '1.18'
+        check-latest: true
     - name: Checkout
       uses: actions/checkout@v1
       with:


### PR DESCRIPTION
This ensures our releases always use the latest minor version, and thus get the latest security fixes.

https://github.com/actions/setup-go#check-latest-version