### PR TITLE
Use standard zsh path for rpm/RHEL releases

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -166,6 +166,13 @@ nfpms:
         dst: /etc/bash_completion.d/doppler
       - src: ./completions/doppler.zsh
         dst: /usr/local/share/zsh/site-functions/_doppler
+        packager: deb
+      - src: ./completions/doppler.zsh
+        dst: /usr/local/share/zsh/site-functions/_doppler
+        packager: apk
+      - src: ./completions/doppler.zsh
+        dst: /usr/share/zsh/site-functions/_doppler
+        packager: rpm
       - src: ./completions/doppler.fish
         dst: /usr/share/fish/completions/doppler.fish
 


### PR DESCRIPTION
Due to a quirk with OSTree releases, the rpm releases should place the doppler zsh completion file in /usr/share/zsh/, which is the default for Fedora/RHEL/CentOS based systems. In theory this should fix #331 but I will need to perform testing to confirm. There may be a more elegant way to accomplish this, but this seems to be the most straight forward way that I can find for the moment.