### PR TITLE
chore: upgrade to go 1.19

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
         check-latest: true
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -17,7 +17,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
         check-latest: true
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -22,7 +22,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
         check-latest: true
     - name: Checkout
       uses: actions/checkout@v3

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
         check-latest: true
     - name: Checkout
       uses: actions/checkout@v1
@@ -29,7 +29,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v3
       with:
-        go-version: '1.18'
+        go-version: '1.19'
         check-latest: true
     - name: Checkout
       uses: actions/checkout@v1

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/DopplerHQ/cli
 
-go 1.18
+go 1.19
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.4


### PR DESCRIPTION
I don't foresee any breaking changes. There was [one change](https://go.dev/doc/go1.19#os-exec-path) related to PATH lookups that affect `exec.Command` (which we use for `doppler run`), but in my testing all expected behavior seems to still work.