### PR TITLE
chore: run release workflow from production environment

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -15,6 +15,7 @@ on:
 jobs:
   publish:
     runs-on: ubuntu-latest
+    environment: "production"
     if: github.actor == 'piccirello'
     permissions:
       contents: write


### PR DESCRIPTION
This allows us to better control which branches can access the synced secrets, as well as requiring an approval flow.