### PR TITLE
Add handling for gnupg error

### DIFF
--- a/pkg/controllers/update.go
+++ b/pkg/controllers/update.go
@@ -73,8 +73,11 @@ func RunInstallScript() (bool, string, Error) {
 
 		message := "Unable to install the latest Doppler CLI"
 		permissionError := exitCode == 2 || strings.Contains(strOut, "dpkg: error: requested operation requires superuser privilege")
+		gnupgError := exitCode == 3
 		if permissionError {
 			message = "Error: update failed due to improper permissions\nPlease re-run with `sudo` or as an admin"
+		} else if gnupgError {
+			message = "Error: Unable to find gpg binary for signature verification\nYou can resolve this error by installing your system's gnupg package"
 		}
 
 		return false, "", Error{Err: err, Message: message}

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -5,6 +5,7 @@ set -e
 # error codes
 # 1 general
 # 2 insufficient perms
+# 3 gnupg package not installed
 
 DOPPLER_DOMAIN="cli.doppler.com"
 DEBUG=0
@@ -391,7 +392,7 @@ if [ -x "$gpg_binary" ]; then
 else
   log "ERROR: Unable to find gpg binary for signature verification"
   log "You can resolve this error by installing your system's gnupg package"
-  clean_exit 1
+  clean_exit 3
 fi
 
 url="https://$DOPPLER_DOMAIN/download?os=$os&arch=$arch&format=$format"


### PR DESCRIPTION
This ensures the error that's encountered when updating via the install.sh script if gnupg isn't installed is passed through to the CLI binary.