### PR TITLE
ENG-5298: Fix deprecations and clean up cli code

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,8 +13,9 @@ test-packages:
 	./tests/packages.sh
 
 test-release:
-	doppler run -- goreleaser release --snapshot --skip-publish --rm-dist --parallelism=4
+	@if [ ! -f "$$GOPATH/bin/goreleaser" ]; then echo "Error: goreleaser is not installed\n\nYou can install goreleaser with 'go install github.com/goreleaser/goreleaser@latest'" && exit 1; fi
+	$$GOPATH/bin/doppler run -- goreleaser release --snapshot --skip-publish --rm-dist --parallelism=4
 
 scan:
-	if [ ! -f "$$GOPATH/bin/gosec" ]; then echo "Error: gosec is not installed\n\nYou can install gosec with 'go get github.com/securego/gosec/cmd/gosec'\n" && exit 1; fi
+	@if [ ! -f "$$GOPATH/bin/gosec" ]; then echo "Error: gosec is not installed\n\nYou can install gosec with 'go install github.com/securego/gosec/cmd/gosec@latest'\n" && exit 1; fi
 	$$GOPATH/bin/gosec -quiet ./pkg/...

--- a/go.mod
+++ b/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/spf13/cobra v1.4.0
 	github.com/zalando/go-keyring v0.2.1
 	golang.org/x/crypto v0.0.0-20220525230936-793ad666bf5e
+	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467
 	gopkg.in/gookit/color.v1 v1.1.6
 	gopkg.in/yaml.v3 v3.0.1
 )
@@ -37,6 +38,5 @@ require (
 	github.com/stretchr/objx v0.2.0 // indirect
 	go.mongodb.org/mongo-driver v1.9.1 // indirect
 	golang.org/x/sys v0.0.0-20220722155257-8c9f86f7a55f // indirect
-	golang.org/x/term v0.0.0-20220526004731-065cf7ba2467 // indirect
 	golang.org/x/text v0.3.8 // indirect
 )

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -127,7 +127,7 @@ var completionInstallCmd = &cobra.Command{
 func getShell(args []string) string {
 	shell := os.Getenv("SHELL")
 	if len(args) > 0 {
-		shell = fmt.Sprintf("%s", args[0])
+		shell = args[0]
 	}
 	if shell == "" {
 		utils.HandleError(errors.New("Unable to determine current shell"), "Please provide your shell name as an argument")

--- a/pkg/cmd/completion.go
+++ b/pkg/cmd/completion.go
@@ -75,7 +75,7 @@ var completionInstallCmd = &cobra.Command{
 		var name string
 
 		if utils.IsWindows() {
-			utils.HandleError(errors.New("Completion files are not supported on Windows. You can use completion files with Windows Subsystem for Linux (WSL)."))
+			utils.HandleError(errors.New("Completion files are not supported on Windows. You can use completion files with Windows Subsystem for Linux (WSL)"))
 		}
 
 		if strings.HasSuffix(shell, "/bash") {

--- a/pkg/cmd/configs.go
+++ b/pkg/cmd/configs.go
@@ -139,7 +139,7 @@ func createConfigs(cmd *cobra.Command, args []string) {
 		utils.HandleError(errors.New("you must specify a name"))
 	}
 
-	if environment == "" && strings.Index(name, "_") != -1 {
+	if environment == "" && strings.Contains(name, "_") {
 		environment = name[0:strings.Index(name, "_")]
 	}
 

--- a/pkg/cmd/import.go
+++ b/pkg/cmd/import.go
@@ -17,7 +17,7 @@ package cmd
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/DopplerHQ/cli/pkg/configuration"
@@ -56,7 +56,7 @@ func readTemplateFile(projectTemplateFile string) []byte {
 		utils.HandleError(fmt.Errorf("Unable to find project template file: %s", projectTemplateFile))
 	}
 	utils.LogDebug(fmt.Sprintf("Reading template file %s", projectTemplateFile))
-	yamlFile, err := ioutil.ReadFile(projectTemplateFile) // #nosec G304
+	yamlFile, err := os.ReadFile(projectTemplateFile) // #nosec G304
 	if err != nil {
 		utils.HandleError(err, fmt.Sprintf("Unable to read project template file: %s", projectTemplateFile))
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -146,9 +146,10 @@ func loadFlags(cmd *cobra.Command) {
 	// DNS resolver
 	if configuration.CanReadEnv {
 		enableDNSResovler := os.Getenv("DOPPLER_ENABLE_DNS_RESOLVER")
-		if enableDNSResovler == "true" {
+		switch enableDNSResovler {
+		case "true":
 			http.UseCustomDNSResolver = true
-		} else if enableDNSResovler == "false" {
+		case "false":
 			http.UseCustomDNSResolver = false
 		}
 	}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -302,7 +301,7 @@ var runCleanCmd = &cobra.Command{
 			utils.HandleError(err, "Unable to read fallback directory")
 		}
 
-		entries, err := ioutil.ReadDir(defaultFallbackDir)
+		entries, err := os.ReadDir(defaultFallbackDir)
 		if err != nil {
 			utils.HandleError(err, "Unable to read fallback directory")
 		}
@@ -324,7 +323,11 @@ var runCleanCmd = &cobra.Command{
 			if all {
 				delete = true
 			} else {
-				validUntil := entry.ModTime().Add(maxAge)
+				fileInfo, err := entry.Info()
+				if err != nil {
+					utils.HandleError(err)
+				}
+				validUntil := fileInfo.ModTime().Add(maxAge)
 				if validUntil.Before(now) {
 					delete = true
 				}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -509,7 +509,7 @@ func readFallbackFile(path string, legacyPath string, passphrase string, silent 
 		utils.HandleError(err, "Unable to read fallback file")
 	}
 
-	response, err := ioutil.ReadFile(path) // #nosec G304
+	response, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		utils.HandleError(err, "Unable to read fallback file")
 	}
@@ -643,7 +643,7 @@ func getCacheFileETag(metadataPath string, cachePath string) string {
 	}
 
 	// verify hash
-	cacheFileBytes, err := ioutil.ReadFile(cachePath) // #nosec G304
+	cacheFileBytes, err := os.ReadFile(cachePath) // #nosec G304
 	if err == nil {
 		cacheFileContents := string(cacheFileBytes)
 		hash := crypto.Hash(cacheFileContents)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -252,9 +252,7 @@ doppler run --mount secrets.json -- cat secrets.json`,
 				}
 			}
 
-			for _, envVar := range utils.MapToEnvFormat(secrets, false) {
-				env = append(env, envVar)
-			}
+			env = append(env, utils.MapToEnvFormat(secrets, false)...)
 		}
 
 		exitCode := 0

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -570,7 +570,7 @@ func defaultFallbackFile(token string, project string, config string) string {
 	var fileName string
 	var name string
 	if project == "" && config == "" {
-		name = fmt.Sprintf("%s", token)
+		name = token
 	} else {
 		name = fmt.Sprintf("%s:%s:%s", token, project, config)
 	}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -223,7 +223,7 @@ doppler run --mount secrets.json -- cat secrets.json`,
 			// remove any reserved keys from secrets
 			reservedKeys := []string{"PATH", "PS1", "HOME"}
 			for _, reservedKey := range reservedKeys {
-				if _, found := dopplerSecrets[reservedKey]; found == true {
+				if _, found := dopplerSecrets[reservedKey]; found {
 					utils.LogDebug(fmt.Sprintf("Ignoring reserved secret %s", reservedKey))
 					delete(dopplerSecrets, reservedKey)
 				}
@@ -236,7 +236,7 @@ doppler run --mount secrets.json -- cat secrets.json`,
 				}
 				// then use existing env vars
 				for name, value := range existingEnvKeys {
-					if _, found := secrets[name]; found == true {
+					if _, found := secrets[name]; found {
 						utils.LogDebug(fmt.Sprintf("Ignoring Doppler secret %s", name))
 					}
 					secrets[name] = value

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -20,7 +20,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -347,7 +346,7 @@ func uploadSecrets(cmd *cobra.Command, args []string) {
 	}
 
 	var file []byte
-	file, err = ioutil.ReadFile(filePath) // #nosec G304
+	file, err = os.ReadFile(filePath) // #nosec G304
 	if err != nil {
 		utils.HandleError(err, "Unable to read upload file")
 	}

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -42,9 +42,9 @@ var updateCmd = &cobra.Command{
 
 		if !available {
 			if force {
-				utils.Log(fmt.Sprintf("Already running the latest version but proceeding anyway due to --force flag"))
+				utils.Log("Already running the latest version but proceeding anyway due to --force flag")
 			} else {
-				utils.Print(fmt.Sprintf("You are already running the latest version"))
+				utils.Print("You are already running the latest version")
 				return
 			}
 		}
@@ -71,7 +71,7 @@ func installCLIUpdate() {
 
 		utils.Print("")
 	} else {
-		utils.Print(fmt.Sprintf("You are already running the latest version"))
+		utils.Print("You are already running the latest version")
 	}
 
 }

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -18,7 +18,6 @@ package configuration
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -429,7 +428,7 @@ func readConfig() (models.ConfigFile, int, int) {
 		utils.HandleError(err, "Unable to stat user config file")
 	}
 
-	fileContents, err := ioutil.ReadFile(UserConfigFile) // #nosec G304
+	fileContents, err := os.ReadFile(UserConfigFile) // #nosec G304
 	if err != nil {
 		utils.HandleError(err, "Unable to read user config file")
 	}

--- a/pkg/configuration/migration.go
+++ b/pkg/configuration/migration.go
@@ -17,7 +17,7 @@ package configuration
 
 import (
 	"encoding/json"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/DopplerHQ/cli/pkg/models"
@@ -58,7 +58,7 @@ func convertOldConfig(oldConfig map[string]oldConfig) models.ConfigFile {
 }
 
 func parseJSONConfig() map[string]oldConfig {
-	fileContents, err := ioutil.ReadFile(jsonFile) // #nosec G304
+	fileContents, err := os.ReadFile(jsonFile) // #nosec G304
 	if err != nil {
 		utils.HandleError(err)
 	}

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -35,7 +35,7 @@ var DefaultMetadataDir string
 func MetadataFilePath(token string, project string, config string) string {
 	var name string
 	if project == "" && config == "" {
-		name = fmt.Sprintf("%s", token)
+		name = token
 	} else {
 		name = fmt.Sprintf("%s:%s:%s", token, project, config)
 	}

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -18,7 +18,6 @@ package controllers
 import (
 	"encoding/json"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -65,7 +64,7 @@ func MetadataFile(path string) (models.SecretsFileMetadata, Error) {
 	}
 
 	utils.LogDebug(fmt.Sprintf("Reading metadata file %s", path))
-	response, err := ioutil.ReadFile(path) // #nosec G304
+	response, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		return models.SecretsFileMetadata{}, Error{Err: err, Message: "Unable to read metadata file"}
 	}
@@ -108,7 +107,7 @@ func SecretsCacheFile(path string, passphrase string) (map[string]string, Error)
 		return nil, Error{Err: err, Message: "Unable to stat cache file"}
 	}
 
-	response, err := ioutil.ReadFile(path) // #nosec G304
+	response, err := os.ReadFile(path) // #nosec G304
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to read cache file"}
 	}

--- a/pkg/controllers/keyring.go
+++ b/pkg/controllers/keyring.go
@@ -39,11 +39,12 @@ func GenerateKeyringID(id string) string {
 func GetKeyring(id string) (string, Error) {
 	value, err := keyring.Get(keyringService, id)
 	if err != nil {
-		if err == keyring.ErrUnsupportedPlatform {
+		switch err {
+		case keyring.ErrUnsupportedPlatform:
 			return "", Error{Err: err, Message: "Your OS does not support keyring"}
-		} else if err == keyring.ErrNotFound {
+		case keyring.ErrNotFound:
 			return "", Error{Err: err, Message: "Token not found in system keyring"}
-		} else {
+		default:
 			return "", Error{Err: err, Message: "Unable to retrieve value from system keyring"}
 		}
 	}

--- a/pkg/controllers/repo_config.go
+++ b/pkg/controllers/repo_config.go
@@ -17,7 +17,7 @@ package controllers
 
 import (
 	"fmt"
-	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	"github.com/DopplerHQ/cli/pkg/models"
@@ -40,7 +40,7 @@ func RepoConfig() (models.RepoConfig, Error) {
 	if utils.Exists(repoConfigFile) {
 		utils.LogDebug(fmt.Sprintf("Reading repo config file %s", repoConfigFile))
 
-		yamlFile, err := ioutil.ReadFile(repoConfigFile) // #nosec G304
+		yamlFile, err := os.ReadFile(repoConfigFile) // #nosec G304
 
 		if err != nil {
 			var e Error

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -63,23 +63,24 @@ func MountSecrets(secrets map[string]string, format string, mountPath string, ma
 	}
 
 	var mountData []byte
-	if format == models.TemplateMountFormat {
+	switch format {
+	case models.TemplateMountFormat:
 		mountData = []byte(RenderSecretsTemplate(templateBody, secrets))
-	} else if format == models.EnvMountFormat {
+	case models.EnvMountFormat:
 		mountData = []byte(strings.Join(utils.MapToEnvFormat(secrets, true), "\n"))
-	} else if format == models.JSONMountFormat {
+	case models.JSONMountFormat:
 		envStr, err := json.Marshal(secrets)
 		if err != nil {
 			return "", nil, Error{Err: err, Message: "Unable to marshall secrets to json"}
 		}
 		mountData = envStr
-	} else if format == models.DotNETJSONMountFormat {
+	case models.DotNETJSONMountFormat:
 		envStr, err := json.Marshal(utils.MapToDotNETJSONFormat(secrets))
 		if err != nil {
 			return "", nil, Error{Err: err, Message: "Unable to marshall .NET formatted secrets to json"}
 		}
 		mountData = envStr
-	} else {
+	default:
 		return "", nil, Error{Err: fmt.Errorf("invalid mount format. Valid formats are %s", models.SecretsMountFormats)}
 
 	}

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -19,7 +19,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"sort"
@@ -158,7 +157,7 @@ func ReadTemplateFile(filePath string) string {
 	}
 
 	var templateFile []byte
-	templateFile, err = ioutil.ReadFile(templateFilePath) // #nosec G304
+	templateFile, err = os.ReadFile(templateFilePath) // #nosec G304
 	if err != nil {
 		utils.HandleError(err, "Unable to read template file")
 	}

--- a/pkg/controllers/update.go
+++ b/pkg/controllers/update.go
@@ -51,6 +51,9 @@ func RunInstallScript() (bool, string, Error) {
 
 	// write script to temp file
 	tmpFile, err := utils.WriteTempFile("install.sh", script, 0555)
+	if err != nil {
+		return false, "", Error{Err: err, Message: "Unable to create temporary install.sh file"}
+	}
 	// clean up temp file once we're done with it
 	defer os.Remove(tmpFile)
 

--- a/pkg/crypto/aes.go
+++ b/pkg/crypto/aes.go
@@ -59,7 +59,7 @@ func Encrypt(passphrase string, plaintext []byte, encoding string) (string, erro
 		return "", err
 	}
 
-	utils.LogDebug(fmt.Sprintf("PBKDF2 key derivation took %d ms", time.Now().Sub(now).Milliseconds()))
+	utils.LogDebug(fmt.Sprintf("PBKDF2 key derivation took %d ms", time.Since(now).Milliseconds()))
 
 	iv := make([]byte, 12)
 	// http://nvlpubs.nist.gov/nistpubs/Legacy/SP/nistspecialpublication800-38d.pdf

--- a/pkg/crypto/aes.go
+++ b/pkg/crypto/aes.go
@@ -139,9 +139,7 @@ func decodeBase64(passphrase string, ciphertext string) ([]byte, []byte, []byte,
 func decodeHex(passphrase string, ciphertext string) ([]byte, []byte, []byte, error) {
 	// prefix is optional
 	// TODO make this required when releasing CLI v4 (DPLR-435)
-	if strings.HasPrefix(ciphertext, HexEncodingPrefix) {
-		ciphertext = ciphertext[len(HexEncodingPrefix):]
-	}
+	ciphertext = strings.TrimPrefix(ciphertext, HexEncodingPrefix)
 
 	arr := strings.SplitN(string(ciphertext), "-", 3)
 	if len(arr) != 3 {

--- a/pkg/crypto/aes.go
+++ b/pkg/crypto/aes.go
@@ -85,17 +85,18 @@ func Encrypt(passphrase string, plaintext []byte, encoding string) (string, erro
 	var encodedSalt string
 	var encodedIV string
 	var encodedData string
-	if encoding == "base64" {
+	switch encoding {
+	case "base64":
 		prefix = Base64EncodingPrefix
 		encodedSalt = base64.StdEncoding.EncodeToString(salt)
 		encodedIV = base64.StdEncoding.EncodeToString(iv)
 		encodedData = base64.StdEncoding.EncodeToString(data)
-	} else if encoding == "hex" {
+	case "hex":
 		prefix = HexEncodingPrefix
 		encodedSalt = hex.EncodeToString(salt)
 		encodedIV = hex.EncodeToString(iv)
 		encodedData = hex.EncodeToString(data)
-	} else {
+	default:
 		return "", errors.New("Invalid encoding, must be one of [base64, hex]")
 	}
 
@@ -175,19 +176,20 @@ func Decrypt(passphrase string, ciphertext []byte, encoding string) (string, err
 	var salt []byte
 	var iv []byte
 	var data []byte
-	if encoding == "base64" {
+	switch encoding {
+	case "base64":
 		var err error
 		salt, iv, data, err = decodeBase64(passphrase, string(ciphertext))
 		if err != nil {
 			return "", err
 		}
-	} else if encoding == "hex" {
+	case "hex":
 		var err error
 		salt, iv, data, err = decodeHex(passphrase, string(ciphertext))
 		if err != nil {
 			return "", err
 		}
-	} else {
+	default:
 		return "", errors.New("Invalid encoding, must be one of [base64, hex]")
 	}
 

--- a/pkg/crypto/aes_test.go
+++ b/pkg/crypto/aes_test.go
@@ -40,7 +40,7 @@ func TestDecrypt(t *testing.T) {
 
 	// decode base64 w/o prefix (should error)
 	ciphertext = "qwbkFMWB7FE=-Ew968YdkAXRb6l46-eA4o9Pf9mSIaOofa8YIEP+FqJ6DwScHsYIObAw3dvKvHbe5SDTzB"
-	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext), "base64")
+	_, err = Decrypt(originalPassphrase, []byte(ciphertext), "base64")
 	if err == nil {
 		t.Error("Expected error when decrypting non-prefixed base64 value")
 	}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -22,7 +22,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"net"
 	"net/http"
 	"net/url"
@@ -251,7 +251,7 @@ func performRequest(req *http.Request, verifyTLS bool, params []queryParam) (int
 		return 0, nil, nil, requestErr
 	}
 
-	body, err := ioutil.ReadAll(response.Body)
+	body, err := io.ReadAll(response.Body)
 	if err != nil {
 		return response.StatusCode, nil, nil, err
 	}

--- a/pkg/printer/print.go
+++ b/pkg/printer/print.go
@@ -26,7 +26,7 @@ import (
 	goVersion "github.com/hashicorp/go-version"
 	"github.com/jedib0t/go-pretty/table"
 	"github.com/jedib0t/go-pretty/text"
-	"golang.org/x/crypto/ssh/terminal"
+	"golang.org/x/term"
 	"gopkg.in/gookit/color.v1"
 )
 
@@ -40,7 +40,7 @@ type tableOptions struct {
 var maxTableWidth = 80
 
 func init() {
-	w, _, err := terminal.GetSize(int(os.Stdout.Fd()))
+	w, _, err := term.GetSize(int(os.Stdout.Fd()))
 	if err != nil {
 		utils.LogDebugError(err)
 		utils.LogDebug("Unable to determine terminal size")

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -18,7 +18,6 @@ package utils
 import (
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 )
 
@@ -39,7 +38,7 @@ func WriteFile(filename string, data []byte, perm os.FileMode) error {
 	// write to a unique temp file first before performing an atomic move to the actual file name
 	// this prevents a race condition between multiple CLIs reading/writing the same file
 	LogDebug(fmt.Sprintf("Writing to temp file %s", temp))
-	if err := ioutil.WriteFile(temp, data, os.FileMode(perm)); err != nil {
+	if err := os.WriteFile(temp, data, os.FileMode(perm)); err != nil {
 		return err
 	}
 

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -56,7 +56,7 @@ func WriteFile(filename string, data []byte, perm os.FileMode) error {
 // WriteTempFile writes data to a unique temp file and returns the file name
 func WriteTempFile(name string, data []byte, perm os.FileMode) (string, error) {
 	// create hidden file in user's home dir to ensure no other users have write access
-	tmpFile, err := ioutil.TempFile(HomeDir(), fmt.Sprintf(".%s.", name))
+	tmpFile, err := os.CreateTemp(HomeDir(), fmt.Sprintf(".%s.", name))
 	if err != nil {
 		return "", err
 	}

--- a/pkg/utils/util_test.go
+++ b/pkg/utils/util_test.go
@@ -48,33 +48,33 @@ func init() {
 func TestParsePathTilde(t *testing.T) {
 	path, err := ParsePath("~")
 	if err != nil || path != homeDir {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, homeDir))
+		t.Errorf("Got %s, expected %s", path, homeDir)
 	}
 
 	path, err = ParsePath("~/")
 	if err != nil || path != homeDir {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, homeDir))
+		t.Errorf("Got %s, expected %s", path, homeDir)
 	}
 
 	path, err = ParsePath(fmt.Sprintf("~%s", username))
 	if err != nil || path != homeDir {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, homeDir))
+		t.Errorf("Got %s, expected %s", path, homeDir)
 	}
 
 	path, err = ParsePath(fmt.Sprintf("~%s/", username))
 	if err != nil || path != homeDir {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, homeDir))
+		t.Errorf("Got %s, expected %s", path, homeDir)
 	}
 
 	// expect error
 	path, err = ParsePath(fmt.Sprintf("~%s/", username+"1"))
 	if err == nil || path != "" {
-		t.Error(fmt.Sprintf("Got %s, expected error", path))
+		t.Errorf("Got %s, expected error", path)
 	}
 
 	path, err = ParsePath("")
 	if err == nil || path != "" {
-		t.Error(fmt.Sprintf("Got %s, expected error", path))
+		t.Errorf("Got %s, expected error", path)
 	}
 }
 
@@ -83,44 +83,44 @@ func TestParsePathRelative(t *testing.T) {
 
 	path, err := ParsePath(".")
 	if err != nil || path != cwd {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, cwd))
+		t.Errorf("Got %s, expected %s", path, cwd)
 	}
 
 	path, err = ParsePath("./")
 	if err != nil || path != cwd {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, cwd))
+		t.Errorf("Got %s, expected %s", path, cwd)
 	}
 
 	path, err = ParsePath("..")
 	if err != nil || path != parentDir {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, parentDir))
+		t.Errorf("Got %s, expected %s", path, parentDir)
 	}
 
 	path, err = ParsePath("../")
 	if err != nil || path != parentDir {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, parentDir))
+		t.Errorf("Got %s, expected %s", path, parentDir)
 	}
 
 	path, err = ParsePath("./..")
 	if err != nil || path != parentDir {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, parentDir))
+		t.Errorf("Got %s, expected %s", path, parentDir)
 	}
 }
 
 func TestParsePathAbsolute(t *testing.T) {
 	path, err := ParsePath("/")
 	if err != nil || path != "/" {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, "/"))
+		t.Errorf("Got %s, expected %s", path, "/")
 	}
 
 	path, err = ParsePath("/root")
 	if err != nil || path != "/root" {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, "/root"))
+		t.Errorf("Got %s, expected %s", path, "/root")
 	}
 
 	path, err = ParsePath("root")
 	if err != nil || path != filepath.Join(cwd, "root") {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, filepath.Join(cwd, "root")))
+		t.Errorf("Got %s, expected %s", path, filepath.Join(cwd, "root"))
 	}
 }
 
@@ -128,11 +128,11 @@ func TestGetFilePath(t *testing.T) {
 	expected := filepath.Join(cwd, "doppler.env")
 	path, err := GetFilePath("./doppler.env")
 	if err != nil || path != expected {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, expected))
+		t.Errorf("Got %s, expected %s", path, expected)
 	}
 
 	path, err = GetFilePath("/root/")
 	if err != nil || path != "/root" {
-		t.Error(fmt.Sprintf("Got %s, expected %s", path, "/root"))
+		t.Errorf("Got %s, expected %s", path, "/root")
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -72,9 +72,7 @@ func CompareVersions(a Version, b Version) int {
 
 // ParseVersion from a string
 func ParseVersion(s string) (Version, error) {
-	if strings.HasPrefix(s, "v") {
-		s = s[1:]
-	}
+	s = strings.TrimPrefix(s, "v")
 	parts := strings.Split(s, ".")
 	if len(parts) != 3 {
 		return Version{}, fmt.Errorf("Invalid version %s", s)

--- a/semgrep_configs/writefile.yaml
+++ b/semgrep_configs/writefile.yaml
@@ -5,5 +5,5 @@ rules:
     message: >
       Use utils.WriteFile to ensure writes are atomic.
     pattern-either:
-      - pattern: ioutil.WriteFile
+      - pattern: os.WriteFile
     severity: ERROR


### PR DESCRIPTION
## Description

This PR addresses warnings and suggestions made by `staticcheck` as well as `go vet`
- Address warnings and suggestions from the result of: `staticcheck ./... ; go vet ./...` 
- Replace `ioutil` package with `io` and `os` by following this blog post: https://go.dev/doc/go1.16#ioutil
- Replace `golang.org/x/crypto/ssh/terminal` with `golang.org/x/term` instead
  **Deprecation notice**: https://pkg.go.dev/golang.org/x/crypto/ssh/terminal#pkg-overview

## Suggestion / Recommendation
We should incorporate linters such as `staticcheck` or `golangci-lint` (which is an aggregation of linters which contains staticcheck) and `go vet` to our github CI actions

We should address the `golangci-lint` results below as well but I want to start this conversation instead of fixing those right now.


## golangci-lint example
Here is an example of `golangci-lint run ./...`. 
⚠️ **These are not currently covered by this PR**
```
❯ golangci-lint run ./...                                                                                                                                                       15:29:28
pkg/printer/print.go:121:4: S1038: should use fmt.Printf instead of fmt.Println(fmt.Sprintf(...)) (but don't forget the newline) (gosimple)
                        fmt.Println(fmt.Sprintf("· %s", change))
                        ^
pkg/cmd/secrets.go:37:6: type `secretsResponse` is unused (unused)
type secretsResponse struct {
     ^
pkg/cmd/secrets.go:469:3: ineffectual assignment to enableFallback (ineffassign)
                enableFallback = false
                ^
pkg/cmd/secrets.go:470:3: ineffectual assignment to enableCache (ineffassign)
                enableCache = false
                ^
pkg/utils/random.go:29:11: Error return value of `rand.Read` is not checked (errcheck)
        rand.Read(buffer) // #nosec G104
                 ^
pkg/utils/util.go:165:23: Error return value of `cmd.Process.Signal` is not checked (errcheck)
                                cmd.Process.Signal(sig) // #nosec G104
                                                  ^
pkg/utils/util.go:175:21: Error return value of `cmd.Process.Signal` is not checked (errcheck)
                cmd.Process.Signal(os.Kill) // #nosec G104
                                  ^
```