### PR TITLE
Don't create default config dir if --configuration used

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -140,6 +140,7 @@ func loadFlags(cmd *cobra.Command) {
 	configuration.Scope = normalizedScope
 
 	configuration.CanReadEnv = !utils.GetBoolFlag(cmd, "no-read-env")
+	configuration.SetConfigDir(utils.GetPathFlagIfChanged(cmd, "config-dir", configuration.UserConfigDir))
 	configuration.UserConfigFile = utils.GetPathFlagIfChanged(cmd, "configuration", configuration.UserConfigFile)
 	http.UseTimeout = !utils.GetBoolFlag(cmd, "no-timeout")
 
@@ -216,7 +217,14 @@ func init() {
 
 	rootCmd.PersistentFlags().Bool("no-read-env", false, "do not read config from the environment")
 	rootCmd.PersistentFlags().String("scope", configuration.Scope, "the directory to scope your config to")
+	rootCmd.PersistentFlags().String("config-dir", configuration.UserConfigDir, "config directory")
 	rootCmd.PersistentFlags().String("configuration", configuration.UserConfigFile, "config file")
+	if err := rootCmd.PersistentFlags().MarkDeprecated("configuration", "please use --config-dir instead"); err != nil {
+		utils.HandleError(err)
+	}
+	if err := rootCmd.PersistentFlags().MarkHidden("configuration"); err != nil {
+		utils.HandleError(err)
+	}
 	rootCmd.PersistentFlags().BoolVar(&utils.OutputJSON, "json", utils.OutputJSON, "output json")
 	rootCmd.PersistentFlags().BoolVar(&utils.Debug, "debug", utils.Debug, "output additional information")
 	rootCmd.PersistentFlags().BoolVar(&printConfig, "print-config", printConfig, "output active configuration")

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -32,9 +32,6 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-// baseConfigDir (e.g. /home/user/)
-var baseConfigDir string
-
 // UserConfigDir (e.g. /home/user/.doppler)
 var UserConfigDir string
 
@@ -53,13 +50,17 @@ var configUid = -1
 var configGid = -1
 
 func init() {
-	baseConfigDir = utils.HomeDir()
-	UserConfigDir = filepath.Join(baseConfigDir, ".doppler")
+	SetConfigDir(filepath.Join(utils.HomeDir(), ".doppler"))
+}
+
+func SetConfigDir(dir string) {
+	UserConfigDir = dir
 	UserConfigFile = filepath.Join(UserConfigDir, configFileName)
 }
 
 // Setup the config directory and config file
 func Setup() {
+	utils.LogDebug(fmt.Sprintf("Using config dir %s", UserConfigDir))
 	utils.LogDebug(fmt.Sprintf("Using config file %s", UserConfigFile))
 
 	if !utils.Exists(UserConfigDir) {

--- a/tests/e2e/configure.sh
+++ b/tests/e2e/configure.sh
@@ -20,7 +20,7 @@ beforeAll() {
 }
 
 beforeEach() {
-  rm -f ./temp-config
+  rm -rf ./temp-config ./temp-config-dir
 }
 
 afterAll() {
@@ -67,6 +67,22 @@ beforeEach
 "$DOPPLER_BINARY" configure set config 123 --configuration=./temp-config --scope=/ --silent
 config="$("$DOPPLER_BINARY" configure get config --configuration=./temp-config --scope=/ --plain)"
 [[ "$config" == "123" ]] || error "ERROR: config --plain contents do not match"
+
+beforeEach
+
+# test configure w/ custom config-dir
+mkdir ./temp-config-dir
+"$DOPPLER_BINARY" configure set config 123 --config-dir=./temp-config-dir --scope=/ --silent
+config="$("$DOPPLER_BINARY" configure get config --configuration=./temp-config-dir/.doppler.yaml --scope=/ --plain)"
+[[ "$config" == "123" ]] || error "ERROR: config-dir not properly used"
+
+beforeEach
+
+# test configure w/ custom config-dir AND custom configuration
+mkdir ./temp-config-dir
+"$DOPPLER_BINARY" configure set config 123 --config-dir=./temp-config-dir --configuration ./temp-config --scope=/ --silent
+config="$("$DOPPLER_BINARY" configure get config --configuration=./temp-config --scope=/ --plain)"
+[[ "$config" == "123" ]] || error "ERROR: configuration not properly used when specified with config-dir"
 
 beforeEach
 


### PR DESCRIPTION
This solves an issue where the CLI would always attempt to create the default config directory (`$HOME/.doppler`) even if a different location was specified using `--configuration`. Now, we provide a `--config-dir` flag that will set the entire directory being used. It also deprecates the `--configuration` flag, which was around from before we used a config directory (there is no real reason to have more than one config FILE). 