### PR TITLE
chore: add explicit version number to encrypted files

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -230,6 +230,8 @@ doppler run --mount secrets.json -- cat secrets.json`,
 				}
 			}
 
+			utils.LogDebug(fmt.Sprintf("Using %s format", mountFormat))
+
 			var templateBody string
 			if shouldMountTemplate {
 				if mountFormat != models.TemplateMountFormat {
@@ -240,7 +242,11 @@ doppler run --mount secrets.json -- cat secrets.json`,
 				utils.HandleError(errors.New("--mount-template must be specified when using --mount-format=template"))
 			}
 
-			absMountPath, handler, err := controllers.MountSecrets(secrets, mountFormat, mountPath, maxReads, templateBody)
+			secretsBytes, err := controllers.SecretsToBytes(secrets, mountFormat, templateBody)
+			if !err.IsNil() {
+				utils.HandleError(err.Unwrap(), err.Message)
+			}
+			absMountPath, handler, err := controllers.MountSecrets(secretsBytes, mountPath, maxReads)
 			if !err.IsNil() {
 				utils.HandleError(err.Unwrap(), err.Message)
 			}

--- a/pkg/controllers/secrets_test.go
+++ b/pkg/controllers/secrets_test.go
@@ -18,6 +18,7 @@ package controllers
 
 import (
 	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -121,5 +122,26 @@ func TestSelectSecrets(t *testing.T) {
 		})
 
 	}
+}
 
+func TestSecretsToBytes(t *testing.T) {
+	secrets := map[string]string{"S1": "foo", "SECRET2": "bar"}
+
+	format := "env"
+	bytes, err := SecretsToBytes(secrets, format, "")
+	if !err.IsNil() || string(bytes) != strings.Join([]string{`S1="foo"`, `SECRET2="bar"`}, "\n") {
+		t.Errorf("Unable to convert secrets to byte array in %s format", format)
+	}
+
+	format = "json"
+	bytes, err = SecretsToBytes(secrets, format, "")
+	if !err.IsNil() || string(bytes) != `{"S1":"foo","SECRET2":"bar"}` {
+		t.Errorf("Unable to convert secrets to byte array in %s format", format)
+	}
+
+	format = "dotnet-json"
+	bytes, err = SecretsToBytes(secrets, format, "")
+	if !err.IsNil() || string(bytes) != `{"S1":"foo","Secret2":"bar"}` {
+		t.Errorf("Unable to convert secrets to byte array in %s format", format)
+	}
 }

--- a/pkg/crypto/aes_test.go
+++ b/pkg/crypto/aes_test.go
@@ -26,43 +26,57 @@ const originalPlaintext = "{\"TEST_SECRET\":\"value\"}"
 func TestDecrypt(t *testing.T) {
 	var ciphertext string
 
-	// decode hex w/o prefix
+	// decode v1: hex w/o prefix
 	ciphertextData := "9bc0a6db97dadea4-0d16d53716f505651f894aba-11b04a80eafd8ea700c7755de860aeb0347cff4ae93b626e858681e7e123034b4c11691a412843"
 	plaintext, err := Decrypt(originalPassphrase, []byte(ciphertextData))
 	if err != nil || plaintext != originalPlaintext {
 		t.Error("Invalid plaintext when decrypting non-prefixed hex value")
 	}
 
-	// decode hex w/ prefix
+	// decode v2: hex w/ prefix
 	ciphertext = fmt.Sprintf("hex:%s", ciphertextData)
 	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext))
 	if err != nil || plaintext != originalPlaintext {
 		t.Error("Invalid plaintext when decrypting hex value")
 	}
 
-	// decode hex w/ prefix and num rounds
+	// decode v3: hex w/ prefix and num rounds
 	ciphertext = fmt.Sprintf("hex:50000:%s", ciphertextData)
 	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext))
 	if err != nil || plaintext != originalPlaintext {
 		t.Error("Invalid plaintext when decrypting hex value")
 	}
 
-	// decode base64 w/o prefix (should error)
+	// decode v4: hex w/ prefix, num rounds, and version
+	ciphertext = fmt.Sprintf("4:hex:50000:%s", ciphertextData)
+	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext))
+	if err != nil || plaintext != originalPlaintext {
+		t.Error("Invalid plaintext when decrypting hex value")
+	}
+
+	// decode v1: base64 w/o prefix (should error, only hex is supported)
 	ciphertextData = "qwbkFMWB7FE=-Ew968YdkAXRb6l46-eA4o9Pf9mSIaOofa8YIEP+FqJ6DwScHsYIObAw3dvKvHbe5SDTzB"
 	_, err = Decrypt(originalPassphrase, []byte(ciphertextData))
 	if err == nil {
 		t.Error("Expected error when decrypting non-prefixed base64 value")
 	}
 
-	// decode base64 w/ prefix
+	// decode v2: base64 w/ prefix
 	ciphertext = fmt.Sprintf("base64:%s", ciphertextData)
 	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext))
 	if err != nil || plaintext != originalPlaintext {
 		t.Error("Invalid plaintext when decrypting base64 value")
 	}
 
-	// decode base64 w/ prefix and num rounds
+	// decode v3: base64 w/ prefix and num rounds
 	ciphertext = fmt.Sprintf("base64:50000:%s", ciphertextData)
+	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext))
+	if err != nil || plaintext != originalPlaintext {
+		t.Error("Invalid plaintext when decrypting base64 value")
+	}
+
+	// decode v4: base64 w/ prefix, num rounds, and version
+	ciphertext = fmt.Sprintf("4:base64:50000:%s", ciphertextData)
 	plaintext, err = Decrypt(originalPassphrase, []byte(ciphertext))
 	if err != nil || plaintext != originalPlaintext {
 		t.Error("Invalid plaintext when decrypting base64 value")

--- a/pkg/models/encrypted_file.go
+++ b/pkg/models/encrypted_file.go
@@ -1,0 +1,145 @@
+/*
+Copyright © 2022 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package models
+
+import (
+	"errors"
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/DopplerHQ/cli/pkg/utils"
+)
+
+const Pbkdf2Rounds = 500000
+const LegacyPbkdf2Rounds = 50000
+
+const Base64EncodingPrefix = "base64"
+const HexEncodingPrefix = "hex"
+
+type EncryptedFile struct {
+	Version    int
+	NumRounds  int
+	Encoding   string
+	Ciphertext string
+}
+
+type FileVersionOptions struct {
+	Version          int
+	HasVersionNumber bool
+	HasEncoding      bool
+	HasNumRounds     bool
+}
+
+var FileVersions = map[int]FileVersionOptions{
+	// just ciphertext
+	1: {Version: 1, HasEncoding: false, HasNumRounds: false, HasVersionNumber: false},
+	// ciphertext and encoding
+	2: {Version: 2, HasEncoding: true, HasNumRounds: false, HasVersionNumber: false},
+	// ciphertext, encoding, and pbkdf2 rounds
+	3: {Version: 3, HasEncoding: true, HasNumRounds: true, HasVersionNumber: false},
+	// ciphertext, encoding, pbkdf2 rounds, and explicit version number
+	4: {Version: 4, HasEncoding: true, HasNumRounds: true, HasVersionNumber: true},
+}
+
+func FileVersion(ciphertext string) (int, error) {
+	cParts := strings.Split(ciphertext, ":")
+	if len(cParts) == 4 {
+		return 4, nil
+	}
+	if len(cParts) == 3 {
+		return 3, nil
+	}
+	if len(cParts) == 2 {
+		return 2, nil
+	}
+	if len(cParts) == 1 {
+		return 1, nil
+	}
+	return -1, errors.New("Invalid ciphertext")
+}
+
+func (options *FileVersionOptions) Parse(ciphertext string) (EncryptedFile, error) {
+	var version string
+	var encoding string
+	var numRounds string
+	var data string
+
+	cParts := strings.SplitN(ciphertext, ":", 4)
+	if options.Version == 4 {
+		version = cParts[0]
+		encoding = cParts[1]
+		numRounds = cParts[2]
+		data = cParts[3]
+	} else if options.Version == 3 {
+		encoding = cParts[0]
+		numRounds = cParts[1]
+		data = cParts[2]
+	} else if options.Version == 2 {
+		encoding = cParts[0]
+		data = cParts[1]
+	} else if options.Version == 1 {
+		data = cParts[0]
+	} else {
+		return EncryptedFile{}, errors.New("Invalid version")
+	}
+
+	utils.LogDebug(fmt.Sprintf("Parsing encrypted file version %d", options.Version))
+
+	versionSpecified := version != ""
+	encodingSpecified := encoding != ""
+	numRoundsSpecified := numRounds != ""
+
+	// check required values
+	if data == "" {
+		return EncryptedFile{}, errors.New("Invalid format: ciphertext is required")
+	}
+	if options.HasVersionNumber && !versionSpecified {
+		return EncryptedFile{}, errors.New("Invalid format: version is required")
+	}
+	if options.HasEncoding && !encodingSpecified {
+		return EncryptedFile{}, errors.New("Invalid format: encoding is required")
+	}
+	if options.HasNumRounds && !numRoundsSpecified {
+		return EncryptedFile{}, errors.New("Invalid format: number of derivation rounds is required")
+	}
+
+	file := EncryptedFile{Version: options.Version, Ciphertext: data}
+	if options.HasVersionNumber && version != strconv.Itoa(options.Version) {
+		return EncryptedFile{}, fmt.Errorf("Invalid file version: %s", version)
+	}
+	if options.HasEncoding {
+		if encoding != Base64EncodingPrefix && encoding != HexEncodingPrefix {
+			return EncryptedFile{}, errors.New("Invalid encoding, must be one of [base64, hex]")
+		}
+		file.Encoding = encoding
+	} else {
+		// default to hex for backwards compatibility b/c we didn't always include an encoding prefix
+		// TODO remove support for v1 when releasing CLI v4 (DPLR-435)
+		file.Encoding = HexEncodingPrefix
+	}
+	if options.HasNumRounds {
+		n, err := strconv.ParseInt(numRounds, 10, 32)
+		if err != nil {
+			return EncryptedFile{}, errors.New("Unable to parse number of rounds")
+		}
+		file.NumRounds = int(n)
+	} else {
+		file.NumRounds = LegacyPbkdf2Rounds
+	}
+
+	return file, nil
+}


### PR DESCRIPTION
The format has changed as we've introduced new fields, so the explicit version number should help with parsing.