### PR TITLE
Don't request secret values when only names are needed

### DIFF
--- a/pkg/cmd/configs.go
+++ b/pkg/cmd/configs.go
@@ -92,11 +92,12 @@ var configsCloneCmd = &cobra.Command{
 
 func configs(cmd *cobra.Command, args []string) {
 	jsonFlag := utils.OutputJSON
+	environment := cmd.Flag("environment").Value.String()
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
 
-	configs, err := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value)
+	configs, err := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, environment)
 	if !err.IsNil() {
 		utils.HandleError(err.Unwrap(), err.Message)
 	}
@@ -181,7 +182,7 @@ func deleteConfigs(cmd *cobra.Command, args []string) {
 		}
 
 		if !utils.Silent {
-			configs, err := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value)
+			configs, err := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, "")
 			if !err.IsNil() {
 				utils.HandleError(err.Unwrap(), err.Message)
 			}
@@ -352,6 +353,7 @@ func unlockedConfigNamesValidArgs(cmd *cobra.Command, args []string, toComplete 
 
 func init() {
 	configsCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")
+	configsCmd.Flags().StringP("environment", "e", "", "config environment")
 
 	configsGetCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")
 	configsGetCmd.Flags().StringP("config", "c", "", "config (e.g. dev)")

--- a/pkg/cmd/enclave_configs.go
+++ b/pkg/cmd/enclave_configs.go
@@ -92,6 +92,7 @@ var enclaveConfigsUnlockCmd = &cobra.Command{
 
 func init() {
 	enclaveConfigsCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
+	enclaveConfigsCmd.Flags().StringP("environment", "e", "", "config environment")
 
 	enclaveConfigsGetCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	enclaveConfigsGetCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -164,18 +164,23 @@ func secrets(cmd *cobra.Command, args []string) {
 
 	utils.RequireValue("token", localConfig.Token.Value)
 
-	response, err := http.GetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, nil, false, 0)
-	if !err.IsNil() {
-		utils.HandleError(err.Unwrap(), err.Message)
-	}
-	secrets, parseErr := models.ParseSecrets(response)
-	if parseErr != nil {
-		utils.HandleError(parseErr, "Unable to parse API response")
-	}
-
 	if onlyNames {
-		printer.SecretsNames(secrets, jsonFlag)
+		secretNames, err := http.GetSecretNames(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, false)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		printer.SecretsNames(secretNames, jsonFlag)
 	} else {
+		response, err := http.GetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, nil, false, 0)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+		secrets, parseErr := models.ParseSecrets(response)
+		if parseErr != nil {
+			utils.HandleError(parseErr, "Unable to parse API response")
+		}
+
 		printer.Secrets(secrets, []string{}, jsonFlag, false, raw, false)
 	}
 }

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -126,7 +126,7 @@ func setup(cmd *cobra.Command, args []string) {
 			break
 		}
 
-		configs, apiError := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, selectedProject)
+		configs, apiError := http.GetConfigs(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, selectedProject, "")
 		if !apiError.IsNil() {
 			utils.HandleError(apiError.Unwrap(), apiError.Message)
 		}

--- a/pkg/controllers/configs.go
+++ b/pkg/controllers/configs.go
@@ -24,7 +24,7 @@ import (
 func GetConfigs(config models.ScopedOptions) ([]models.ConfigInfo, Error) {
 	utils.RequireValue("token", config.Token.Value)
 
-	configs, err := http.GetConfigs(config.APIHost.Value, utils.GetBool(config.VerifyTLS.Value, true), config.Token.Value, config.EnclaveProject.Value)
+	configs, err := http.GetConfigs(config.APIHost.Value, utils.GetBool(config.VerifyTLS.Value, true), config.Token.Value, config.EnclaveProject.Value, "")
 	if !err.IsNil() {
 		return nil, Error{Err: err.Unwrap(), Message: err.Message}
 	}

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -62,20 +62,11 @@ var dangerousSecretNames = [...]string{
 func GetSecretNames(config models.ScopedOptions) ([]string, Error) {
 	utils.RequireValue("token", config.Token.Value)
 
-	response, err := http.GetSecrets(config.APIHost.Value, utils.GetBool(config.VerifyTLS.Value, true), config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value, nil, false, 0)
+	secretsNames, err := http.GetSecretNames(config.APIHost.Value, utils.GetBool(config.VerifyTLS.Value, true), config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value, false)
 	if !err.IsNil() {
 		return nil, Error{Err: err.Unwrap(), Message: err.Message}
 	}
 
-	secrets, parseErr := models.ParseSecrets(response)
-	if parseErr != nil {
-		return nil, Error{Err: parseErr, Message: "Unable to parse API response"}
-	}
-
-	var secretsNames []string
-	for name := range secrets {
-		secretsNames = append(secretsNames, name)
-	}
 	sort.Strings(secretsNames)
 
 	return secretsNames, Error{}

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -171,16 +171,11 @@ func GetSecrets(host string, verifyTLS bool, apiKey string, project string, conf
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
+	params = append(params, queryParam{Key: "include_dynamic_secrets", Value: strconv.FormatBool(includeDynamicSecrets)})
 
 	if secrets != nil {
 		params = append(params, queryParam{Key: "secrets", Value: strings.Join(secrets, ",")})
 	}
-
-	includeDynamicSecretsOption := "false"
-	if includeDynamicSecrets {
-		includeDynamicSecretsOption = "true"
-	}
-	params = append(params, queryParam{Key: "include_dynamic_secrets", Value: includeDynamicSecretsOption})
 
 	if dynamicSecretsTTL > 0 {
 		ttlSeconds := int(dynamicSecretsTTL.Seconds())

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -604,10 +604,13 @@ func RenameEnvironment(host string, verifyTLS bool, apiKey string, project strin
 }
 
 // GetConfigs get configs
-func GetConfigs(host string, verifyTLS bool, apiKey string, project string) ([]models.ConfigInfo, Error) {
+func GetConfigs(host string, verifyTLS bool, apiKey string, project string, environment string) ([]models.ConfigInfo, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "per_page", Value: "100"})
+	if environment != "" {
+		params = append(params, queryParam{Key: "environment", Value: environment})
+	}
 
 	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs", params)
 	if err != nil {

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -233,6 +233,29 @@ func SetSecrets(host string, verifyTLS bool, apiKey string, project string, conf
 	return computed, Error{}
 }
 
+// GetSecretNames for specified project and config
+func GetSecretNames(host string, verifyTLS bool, apiKey string, project string, config string, includeDynamicSecrets bool) ([]string, Error) {
+	var params []queryParam
+	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
+	params = append(params, queryParam{Key: "include_dynamic_secrets", Value: strconv.FormatBool(includeDynamicSecrets)})
+
+	statusCode, _, response, err := GetRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/secrets/names", params)
+	if err != nil {
+		return nil, Error{Err: err, Message: "Unable to fetch secret names", Code: statusCode}
+	}
+
+	var result struct {
+		Names []string `json:"names"`
+	}
+	err = json.Unmarshal(response, &result)
+	if err != nil {
+		return nil, Error{Err: err, Message: "Unable to parse API response", Code: statusCode}
+	}
+
+	return result.Names, Error{}
+}
+
 // UploadSecrets for specified project and config
 func UploadSecrets(host string, verifyTLS bool, apiKey string, project string, config string, secrets string) (map[string]models.ComputedSecret, Error) {
 	reqBody := map[string]interface{}{}

--- a/pkg/printer/enclave.go
+++ b/pkg/printer/enclave.go
@@ -278,13 +278,7 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 }
 
 // SecretsNames print secrets names
-func SecretsNames(secrets map[string]models.ComputedSecret, jsonFlag bool) {
-	var secretsNames []string
-	for name := range secrets {
-		secretsNames = append(secretsNames, name)
-	}
-	sort.Strings(secretsNames)
-
+func SecretsNames(secretsNames []string, jsonFlag bool) {
 	if jsonFlag {
 		secretsMap := map[string]map[string]string{}
 		for _, name := range secretsNames {


### PR DESCRIPTION
This PR also limits commands to only revealing the necessary secrets, rather than revealing all and then filtering client-side.