### PR TITLE
Only fetch requested secrets when using `run --only-secrets`

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -468,19 +468,6 @@ func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOp
 			}
 		}
 
-		// TODO remove this when releasing CLI v4 (DPLR-435)
-		if fallbackOpts.legacyPath != "" && localConfig.EnclaveProject.Value != "" && localConfig.EnclaveConfig.Value != "" {
-			utils.LogDebug(fmt.Sprintf("Writing to legacy fallback file %s", fallbackOpts.legacyPath))
-			if err := utils.WriteFile(fallbackOpts.legacyPath, []byte(encryptedResponse), utils.RestrictedFilePerms()); err != nil {
-				utils.Log("Unable to write to legacy fallback file")
-				if fallbackOpts.exitOnWriteFailure {
-					utils.HandleError(err, "", strings.Join(writeFailureMessage(), "\n"))
-				} else {
-					utils.LogDebugError(err)
-				}
-			}
-		}
-
 		if enableCache {
 			if etag := respHeaders.Get("etag"); etag != "" {
 				hash := crypto.Hash(encryptedResponse)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -592,19 +592,6 @@ func legacyFallbackFile(project string, config string) string {
 	return filepath.Join(defaultFallbackDir, fileName)
 }
 
-func defaultFallbackFile(token string, project string, config string) string {
-	var fileName string
-	var name string
-	if project == "" && config == "" {
-		name = fmt.Sprintf("%s", token)
-	} else {
-		name = fmt.Sprintf("%s:%s:%s", token, project, config)
-	}
-
-	fileName = fmt.Sprintf(".secrets-%s.json", crypto.Hash(name))
-	return filepath.Join(defaultFallbackDir, fileName)
-}
-
 // generate the passphrase used for encrypting a secrets file
 func getPassphrase(cmd *cobra.Command, flag string, config models.ScopedOptions) string {
 	if cmd.Flags().Changed(flag) {
@@ -628,7 +615,8 @@ func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, exitOnWrit
 			utils.HandleError(err, "Unable to parse --fallback flag")
 		}
 	} else {
-		fallbackPath = defaultFallbackFile(config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value)
+		fallbackFileName := fmt.Sprintf(".secrets-%s.json", controllers.GenerateFallbackFileHash(config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value))
+		fallbackPath = filepath.Join(defaultFallbackDir, fallbackFileName)
 		// TODO remove this when releasing CLI v4 (DPLR-435)
 		if config.EnclaveProject.Value != "" && config.EnclaveConfig.Value != "" {
 			// save to old path to maintain backwards compatibility

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -111,10 +111,10 @@ doppler run --mount secrets.json -- cat secrets.json`,
 		legacyFallbackPath := ""
 		metadataPath := ""
 		if enableFallback {
-			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, format, exitOnWriteFailure)
+			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, format, nameTransformer, exitOnWriteFailure)
 		}
 		if enableCache {
-			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format)
+			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer)
 		}
 
 		passphrase := getPassphrase(cmd, "passphrase", localConfig)
@@ -593,7 +593,7 @@ func getPassphrase(cmd *cobra.Command, flag string, config models.ScopedOptions)
 	return config.Token.Value
 }
 
-func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, format models.SecretsFormat, exitOnWriteFailure bool) (string, string) {
+func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, format models.SecretsFormat, nameTransformer *models.SecretsNameTransformer, exitOnWriteFailure bool) (string, string) {
 	fallbackPath := ""
 	legacyFallbackPath := ""
 	if cmd.Flags().Changed("fallback") {
@@ -603,7 +603,7 @@ func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, format mod
 			utils.HandleError(err, "Unable to parse --fallback flag")
 		}
 	} else {
-		fallbackFileName := fmt.Sprintf(".secrets-%s.json", controllers.GenerateFallbackFileHash(config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value, format))
+		fallbackFileName := fmt.Sprintf(".secrets-%s.json", controllers.GenerateFallbackFileHash(config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value, format, nameTransformer))
 		fallbackPath = filepath.Join(defaultFallbackDir, fallbackFileName)
 		// TODO remove this when releasing CLI v4 (DPLR-435)
 		if config.EnclaveProject.Value != "" && config.EnclaveConfig.Value != "" {

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -399,14 +399,11 @@ func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOp
 		if !fallbackOpts.enable {
 			utils.HandleError(errors.New("Conflict: unable to specify --no-fallback with --fallback-only"))
 		}
-		if nameTransformer != nil {
-			utils.HandleError(errors.New("Conflict: unable to specify --name-transformer with --fallback-only"))
-		}
 		return readFallbackFile(fallbackOpts.path, fallbackOpts.legacyPath, fallbackOpts.passphrase, false)
 	}
 
 	// this scenario likely isn't possible, but just to be safe, disable using cache when there's no metadata file
-	enableCache = enableCache && nameTransformer == nil && metadataPath != ""
+	enableCache = enableCache && metadataPath != ""
 	etag := ""
 	if enableCache {
 		etag = getCacheFileETag(metadataPath, fallbackOpts.path)

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -111,10 +111,10 @@ doppler run --mount secrets.json -- cat secrets.json`,
 		legacyFallbackPath := ""
 		metadataPath := ""
 		if enableFallback {
-			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, exitOnWriteFailure)
+			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, format, exitOnWriteFailure)
 		}
 		if enableCache {
-			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format)
 		}
 
 		passphrase := getPassphrase(cmd, "passphrase", localConfig)
@@ -141,7 +141,7 @@ doppler run --mount secrets.json -- cat secrets.json`,
 			passphrase:         passphrase,
 		}
 		// retrieve secrets
-		dopplerSecrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL)
+		dopplerSecrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format)
 
 		mountPath := cmd.Flag("mount").Value.String()
 		mountFormatString := cmd.Flag("mount-format").Value.String()
@@ -395,7 +395,7 @@ var runCleanCmd = &cobra.Command{
 }
 
 // fetchSecrets from Doppler and handle fallback file
-func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOpts fallbackOptions, metadataPath string, nameTransformer *models.SecretsNameTransformer, dynamicSecretsTTL time.Duration) map[string]string {
+func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOpts fallbackOptions, metadataPath string, nameTransformer *models.SecretsNameTransformer, dynamicSecretsTTL time.Duration, format models.SecretsFormat) map[string]string {
 	if fallbackOpts.exclusive {
 		if !fallbackOpts.enable {
 			utils.HandleError(errors.New("Conflict: unable to specify --no-fallback with --fallback-only"))
@@ -413,7 +413,7 @@ func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOp
 		etag = getCacheFileETag(metadataPath, fallbackOpts.path)
 	}
 
-	statusCode, respHeaders, response, httpErr := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, models.JSON, nameTransformer, etag, dynamicSecretsTTL)
+	statusCode, respHeaders, response, httpErr := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer, etag, dynamicSecretsTTL)
 	if !httpErr.IsNil() {
 		if fallbackOpts.enable {
 			utils.Log("Unable to fetch secrets from the Doppler API")
@@ -593,7 +593,7 @@ func getPassphrase(cmd *cobra.Command, flag string, config models.ScopedOptions)
 	return config.Token.Value
 }
 
-func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, exitOnWriteFailure bool) (string, string) {
+func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, format models.SecretsFormat, exitOnWriteFailure bool) (string, string) {
 	fallbackPath := ""
 	legacyFallbackPath := ""
 	if cmd.Flags().Changed("fallback") {
@@ -603,7 +603,7 @@ func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, exitOnWrit
 			utils.HandleError(err, "Unable to parse --fallback flag")
 		}
 	} else {
-		fallbackFileName := fmt.Sprintf(".secrets-%s.json", controllers.GenerateFallbackFileHash(config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value))
+		fallbackFileName := fmt.Sprintf(".secrets-%s.json", controllers.GenerateFallbackFileHash(config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value, format))
 		fallbackPath = filepath.Join(defaultFallbackDir, fallbackFileName)
 		// TODO remove this when releasing CLI v4 (DPLR-435)
 		if config.EnclaveProject.Value != "" && config.EnclaveConfig.Value != "" {

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -448,10 +448,10 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 		legacyFallbackPath := ""
 		metadataPath := ""
 		if enableFallback {
-			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, format, nameTransformer, exitOnWriteFailure)
+			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, format, nameTransformer, nil, exitOnWriteFailure)
 		}
 		if enableCache {
-			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer)
+			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer, nil)
 		}
 
 		fallbackOpts := fallbackOptions{
@@ -463,7 +463,7 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 			exitOnWriteFailure: exitOnWriteFailure,
 			passphrase:         fallbackPassphrase,
 		}
-		secrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format)
+		secrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format, nil)
 
 		var err error
 		body, err = json.Marshal(secrets)
@@ -482,7 +482,7 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 		}
 
 		var apiError http.Error
-		_, _, body, apiError = http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer, "", dynamicSecretsTTL)
+		_, _, body, apiError = http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer, "", dynamicSecretsTTL, nil)
 		if !apiError.IsNil() {
 			utils.HandleError(apiError.Unwrap(), apiError.Message)
 		}

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -448,10 +448,10 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 		legacyFallbackPath := ""
 		metadataPath := ""
 		if enableFallback {
-			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, format, exitOnWriteFailure)
+			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, format, nameTransformer, exitOnWriteFailure)
 		}
 		if enableCache {
-			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format)
+			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer)
 		}
 
 		fallbackOpts := fallbackOptions{

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -448,10 +448,10 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 		legacyFallbackPath := ""
 		metadataPath := ""
 		if enableFallback {
-			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, exitOnWriteFailure)
+			fallbackPath, legacyFallbackPath = initFallbackDir(cmd, localConfig, format, exitOnWriteFailure)
 		}
 		if enableCache {
-			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value)
+			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format)
 		}
 
 		fallbackOpts := fallbackOptions{
@@ -463,7 +463,7 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 			exitOnWriteFailure: exitOnWriteFailure,
 			passphrase:         fallbackPassphrase,
 		}
-		secrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL)
+		secrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format)
 
 		var err error
 		body, err = json.Marshal(secrets)

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -21,6 +21,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/DopplerHQ/cli/pkg/crypto"
 	"github.com/DopplerHQ/cli/pkg/models"
@@ -31,16 +32,19 @@ import (
 // DefaultMetadataDir the directory containing metadata files
 var DefaultMetadataDir string
 
-// MetadataFilePath calculates the name of the metadata file
-func MetadataFilePath(token string, project string, config string) string {
-	var name string
-	if project == "" && config == "" {
-		name = fmt.Sprintf("%s", token)
-	} else {
-		name = fmt.Sprintf("%s:%s:%s", token, project, config)
+func GenerateFallbackFileHash(token string, project string, config string) string {
+	parts := []string{token}
+	if project != "" && config != "" {
+		parts = append(parts, project)
+		parts = append(parts, config)
 	}
 
-	fileName := fmt.Sprintf(".metadata-%s.json", crypto.Hash(name))
+	return crypto.Hash(strings.Join(parts, ":"))
+}
+
+// MetadataFilePath calculates the name of the metadata file
+func MetadataFilePath(token string, project string, config string) string {
+	fileName := fmt.Sprintf(".metadata-%s.json", GenerateFallbackFileHash(token, project, config))
 	path := filepath.Join(DefaultMetadataDir, fileName)
 	if absPath, err := filepath.Abs(path); err == nil {
 		return absPath

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -32,20 +32,23 @@ import (
 // DefaultMetadataDir the directory containing metadata files
 var DefaultMetadataDir string
 
-func GenerateFallbackFileHash(token string, project string, config string, format models.SecretsFormat) string {
+func GenerateFallbackFileHash(token string, project string, config string, format models.SecretsFormat, nameTransformer *models.SecretsNameTransformer) string {
 	parts := []string{token}
 	if project != "" && config != "" {
 		parts = append(parts, project)
 		parts = append(parts, config)
 	}
 	parts = append(parts, format.String())
+	if nameTransformer != nil {
+		parts = append(parts, nameTransformer.Type)
+	}
 
 	return crypto.Hash(strings.Join(parts, ":"))
 }
 
 // MetadataFilePath calculates the name of the metadata file
-func MetadataFilePath(token string, project string, config string, format models.SecretsFormat) string {
-	fileName := fmt.Sprintf(".metadata-%s.json", GenerateFallbackFileHash(token, project, config, format))
+func MetadataFilePath(token string, project string, config string, format models.SecretsFormat, nameTransformer *models.SecretsNameTransformer) string {
+	fileName := fmt.Sprintf(".metadata-%s.json", GenerateFallbackFileHash(token, project, config, format, nameTransformer))
 	path := filepath.Join(DefaultMetadataDir, fileName)
 	if absPath, err := filepath.Abs(path); err == nil {
 		return absPath

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -32,19 +32,20 @@ import (
 // DefaultMetadataDir the directory containing metadata files
 var DefaultMetadataDir string
 
-func GenerateFallbackFileHash(token string, project string, config string) string {
+func GenerateFallbackFileHash(token string, project string, config string, format models.SecretsFormat) string {
 	parts := []string{token}
 	if project != "" && config != "" {
 		parts = append(parts, project)
 		parts = append(parts, config)
 	}
+	parts = append(parts, format.String())
 
 	return crypto.Hash(strings.Join(parts, ":"))
 }
 
 // MetadataFilePath calculates the name of the metadata file
-func MetadataFilePath(token string, project string, config string) string {
-	fileName := fmt.Sprintf(".metadata-%s.json", GenerateFallbackFileHash(token, project, config))
+func MetadataFilePath(token string, project string, config string, format models.SecretsFormat) string {
+	fileName := fmt.Sprintf(".metadata-%s.json", GenerateFallbackFileHash(token, project, config, format))
 	path := filepath.Join(DefaultMetadataDir, fileName)
 	if absPath, err := filepath.Abs(path); err == nil {
 		return absPath

--- a/pkg/controllers/fallback_test.go
+++ b/pkg/controllers/fallback_test.go
@@ -1,0 +1,69 @@
+/*
+Copyright © 2022 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"testing"
+
+	"github.com/DopplerHQ/cli/pkg/models"
+	"github.com/stretchr/testify/assert"
+)
+
+type fallbackFileHashTestCase struct {
+	name          string
+	secretNamesA  []string
+	secretNamesB  []string
+	expectedEqual bool
+}
+
+func TestGenerateFallbackFileHash(t *testing.T) {
+	testCases := []fallbackFileHashTestCase{
+		{
+			name:          "unique hash per secret names",
+			secretNamesA:  []string{"A"},
+			secretNamesB:  []string{"B"},
+			expectedEqual: false,
+		},
+		{
+			name:          "sort secret names",
+			secretNamesA:  []string{"A", "B"},
+			secretNamesB:  []string{"B", "A"},
+			expectedEqual: true,
+		},
+		{
+			name:          "dedupe secret names",
+			secretNamesA:  []string{"A", "B"},
+			secretNamesB:  []string{"A", "B", "B"},
+			expectedEqual: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			const token = "abc"
+			const project = "abc"
+			const config = "abc"
+
+			if testCase.expectedEqual {
+				assert.Equal(t, GenerateFallbackFileHash(token, project, config, models.JSON, nil, testCase.secretNamesA), GenerateFallbackFileHash(token, project, config, models.JSON, nil, testCase.secretNamesB))
+			} else {
+				assert.NotEqual(t, GenerateFallbackFileHash(token, project, config, models.JSON, nil, testCase.secretNamesA), GenerateFallbackFileHash(token, project, config, models.JSON, nil, testCase.secretNamesB))
+			}
+		})
+
+	}
+
+}

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -226,22 +226,15 @@ func RenderSecretsTemplate(templateBody string, secretsMap map[string]string) st
 	return buffer.String()
 }
 
-func SelectSecrets(secrets map[string]string, secretsToSelect []string) (map[string]string, error) {
-	selectedSecrets := utils.FilterMap(secrets, secretsToSelect)
-	nonExistentSecretNames := []string{}
-
-	for _, secretName := range secretsToSelect {
-		if _, found := selectedSecrets[secretName]; !found {
-			nonExistentSecretNames = append(nonExistentSecretNames, secretName)
+func MissingSecrets(secrets map[string]string, secretsToInclude []string) []string {
+	var missingSecrets []string
+	for _, name := range secretsToInclude {
+		if _, ok := secrets[name]; !ok {
+			missingSecrets = append(missingSecrets, name)
 		}
 	}
 
-	var err error
-	if len(nonExistentSecretNames) > 0 {
-		err = fmt.Errorf("the following secrets you are trying to include do not exist in your config:\n- %v", strings.Join(nonExistentSecretNames, "\n- "))
-	}
-
-	return selectedSecrets, err
+	return missingSecrets
 }
 
 // CheckForDangerousSecretNames checks for potential dangerous secret names.

--- a/pkg/controllers/secrets_test.go
+++ b/pkg/controllers/secrets_test.go
@@ -17,7 +17,6 @@ limitations under the License.
 package controllers
 
 import (
-	"reflect"
 	"strings"
 	"testing"
 
@@ -71,56 +70,6 @@ func TestCheckForDangerousSecretNames(t *testing.T) {
 				}
 			}
 		})
-	}
-}
-
-type selectSecretsTestCase struct {
-	name         string
-	origMap      map[string]string
-	keysToSelect []string
-	expectedMap  map[string]string
-	missingKeys  []string
-}
-
-func TestSelectSecrets(t *testing.T) {
-	testCases := []selectSecretsTestCase{
-		{
-			name:         "Select one exisiting secret and two nonexistent secrets",
-			origMap:      map[string]string{"MY_SECRET": "value"},
-			keysToSelect: []string{"DEV", "LOGGING", "MY_SECRET"},
-			expectedMap:  map[string]string{"MY_SECRET": "value"},
-			missingKeys:  []string{"DEV", "LOGGING"},
-		},
-		{
-			name:         "Select one secret",
-			origMap:      map[string]string{"DEV": "true", "LOGGING": "true"},
-			keysToSelect: []string{"DEV"},
-			expectedMap:  map[string]string{"DEV": "true"},
-		},
-		{
-			name:         "Select multiple secrets",
-			origMap:      map[string]string{"DEV": "true", "LOGGING": "true", "MY_SECRET": "value", "PROD": "false"},
-			keysToSelect: []string{"DEV", "LOGGING", "PROD"},
-			expectedMap:  map[string]string{"DEV": "true", "LOGGING": "true", "PROD": "false"},
-		},
-	}
-
-	for _, testCase := range testCases {
-		t.Run(testCase.name, func(t *testing.T) {
-			filteredSecrets, err := SelectSecrets(testCase.origMap, testCase.keysToSelect)
-
-			if testCase.missingKeys != nil {
-				assert.NotNil(t, err)
-				for _, missingKey := range testCase.missingKeys {
-					assert.Contains(t, err.Error(), missingKey)
-				}
-			} else {
-				assert.Nil(t, err)
-			}
-
-			assert.True(t, reflect.DeepEqual(filteredSecrets, testCase.expectedMap))
-		})
-
 	}
 }
 

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -138,12 +138,15 @@ func RevokeAuthToken(host string, verifyTLS bool, token string) (map[string]inte
 }
 
 // DownloadSecrets for specified project and config
-func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string, config string, format models.SecretsFormat, nameTransformer *models.SecretsNameTransformer, etag string, dynamicSecretsTTL time.Duration) (int, http.Header, []byte, Error) {
+func DownloadSecrets(host string, verifyTLS bool, apiKey string, project string, config string, format models.SecretsFormat, nameTransformer *models.SecretsNameTransformer, etag string, dynamicSecretsTTL time.Duration, secrets []string) (int, http.Header, []byte, Error) {
 	var params []queryParam
 	params = append(params, queryParam{Key: "project", Value: project})
 	params = append(params, queryParam{Key: "config", Value: config})
 	params = append(params, queryParam{Key: "format", Value: format.String()})
 	params = append(params, queryParam{Key: "include_dynamic_secrets", Value: "true"})
+	if len(secrets) > 0 {
+		params = append(params, queryParam{Key: "secrets", Value: strings.Join(secrets, ",")})
+	}
 
 	if dynamicSecretsTTL > 0 {
 		ttlSeconds := int(dynamicSecretsTTL.Seconds())


### PR DESCRIPTION
This PR also adds support for fallback files when using name transformers.