### PR TITLE
Support setting notes on secrets

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -16,10 +16,8 @@ limitations under the License.
 package cmd
 
 import (
-	"bufio"
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/DopplerHQ/cli/pkg/configuration"
@@ -166,25 +164,15 @@ doppler configure set key=123 otherkey=456`,
 		options := map[string]string{}
 
 		if len(args) == 1 && !strings.Contains(args[0], "=") {
-			var input []string
-			scanner := bufio.NewScanner(os.Stdin)
-			// read input from stdin
-			for {
-				if ok := scanner.Scan(); !ok {
-					if e := scanner.Err(); e != nil {
-						utils.HandleError(e, "Unable to read input from stdin")
-					}
-
-					break
-				}
-
-				s := scanner.Text()
-				input = append(input, s)
+			value, err := utils.GetStdIn()
+			if err != nil {
+				utils.HandleError(err)
+			}
+			if value == nil {
+				utils.HandleError(errors.New("Unable to read input from stdin"))
 			}
 
-			key := args[0]
-			value := strings.Join(input, "\n")
-			options[key] = value
+			options[args[0]] = *value
 		} else if !strings.Contains(args[0], "=") {
 			options[args[0]] = args[1]
 		} else {

--- a/pkg/cmd/secrets_notes.go
+++ b/pkg/cmd/secrets_notes.go
@@ -1,0 +1,101 @@
+/*
+Copyright © 2020 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"bufio"
+	"os"
+	"strings"
+
+	"github.com/DopplerHQ/cli/pkg/configuration"
+	"github.com/DopplerHQ/cli/pkg/http"
+	"github.com/DopplerHQ/cli/pkg/printer"
+	"github.com/DopplerHQ/cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var secretsNotesCmd = &cobra.Command{
+	Use:   "notes",
+	Short: "Manage secret notes",
+	Args:  cobra.NoArgs,
+}
+
+var secretsNotesSetCmd = &cobra.Command{
+	Use:   "set [secret] [note]",
+	Short: "Set a note on a secret. The secret must exist. Notes can be passed via arg or via stdin.",
+	Args:  cobra.RangeArgs(1, 2),
+	Run:   setSecretNote,
+}
+
+func setSecretNote(cmd *cobra.Command, args []string) {
+	jsonFlag := utils.OutputJSON
+	localConfig := configuration.LocalConfig(cmd)
+
+	utils.RequireValue("token", localConfig.Token.Value)
+
+	secret := args[0]
+	var note string
+	if len(args) > 1 {
+		note = args[1]
+	} else {
+		// read from stdin
+		hasData, e := utils.HasDataOnStdIn()
+		if e != nil {
+			utils.HandleError(e)
+		}
+
+		// note must be supplied
+		if !hasData {
+			utils.RequireValue("note", note)
+		}
+
+		var input []string
+		scanner := bufio.NewScanner(os.Stdin)
+		for {
+			if ok := scanner.Scan(); !ok {
+				if e := scanner.Err(); e != nil {
+					utils.HandleError(e, "Unable to read input from stdin")
+				}
+
+				break
+			}
+
+			s := scanner.Text()
+			input = append(input, s)
+		}
+
+		note = strings.Join(input, "\n")
+	}
+
+	utils.RequireValue("secret", secret)
+
+	response, httpErr := http.SetSecretNote(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, secret, note)
+	if !httpErr.IsNil() {
+		utils.HandleError(httpErr.Unwrap(), httpErr.Message)
+	}
+
+	if !utils.Silent {
+		printer.SecretNote(response, jsonFlag)
+	}
+}
+
+func init() {
+	secretsNotesSetCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")
+	secretsNotesSetCmd.Flags().StringP("config", "c", "", "config (e.g. dev)")
+	secretsNotesCmd.AddCommand(secretsNotesSetCmd)
+
+	secretsCmd.AddCommand(secretsNotesCmd)
+}

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -231,6 +231,31 @@ func SetSecrets(host string, verifyTLS bool, apiKey string, project string, conf
 	return computed, Error{}
 }
 
+// SetSecretNote for specified project and config
+func SetSecretNote(host string, verifyTLS bool, apiKey string, project string, config string, secret string, note string) (models.SecretNote, Error) {
+	body, err := json.Marshal(models.SecretNote{Secret: secret, Note: note})
+	if err != nil {
+		return models.SecretNote{}, Error{Err: err, Message: "Invalid secret note"}
+	}
+
+	var params []queryParam
+	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
+
+	statusCode, _, response, err := PostRequest(host, verifyTLS, apiKeyHeader(apiKey), "/v3/configs/config/secrets/note", params, body)
+	if err != nil {
+		return models.SecretNote{}, Error{Err: err, Message: "Unable to set secret note", Code: statusCode}
+	}
+
+	var secretNote models.SecretNote
+	err = json.Unmarshal(response, &secretNote)
+	if err != nil {
+		return models.SecretNote{}, Error{Err: err, Message: "Unable to parse API response", Code: statusCode}
+	}
+
+	return secretNote, Error{}
+}
+
 // GetSecretNames for specified project and config
 func GetSecretNames(host string, verifyTLS bool, apiKey string, project string, config string, includeDynamicSecrets bool) ([]string, Error) {
 	var params []queryParam

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -22,6 +22,12 @@ type ComputedSecret struct {
 	ComputedValue string `json:"computed"`
 }
 
+// SecretNote contains a secret and its note
+type SecretNote struct {
+	Secret string `json:"secret"`
+	Note   string `json:"note"`
+}
+
 // WorkplaceSettings workplace settings
 type WorkplaceSettings struct {
 	ID           string `json:"id"`

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -20,6 +20,7 @@ type ComputedSecret struct {
 	Name          string `json:"name"`
 	RawValue      string `json:"raw"`
 	ComputedValue string `json:"computed"`
+	Note          string `json:"note"`
 }
 
 // SecretNote contains a secret and its note

--- a/pkg/models/parse.go
+++ b/pkg/models/parse.go
@@ -258,6 +258,9 @@ func ParseSecrets(response []byte) (map[string]ComputedSecret, error) {
 		if val["computed"] != nil {
 			computedSecret.ComputedValue = val["computed"].(string)
 		}
+		if val["note"] != nil {
+			computedSecret.Note = val["note"].(string)
+		}
 		computed[key] = computedSecret
 	}
 

--- a/pkg/printer/enclave.go
+++ b/pkg/printer/enclave.go
@@ -227,10 +227,11 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 		secretsMap := map[string]map[string]string{}
 		for _, name := range secretsToPrint {
 			if secrets[name] != (models.ComputedSecret{}) {
-				secretsMap[name] = map[string]string{"computed": secrets[name].ComputedValue}
+				secretsMap[name] = map[string]string{"computed": secrets[name].ComputedValue, "note": secrets[name].Note}
 				if raw {
 					secretsMap[name]["raw"] = secrets[name].RawValue
 				}
+				secretsMap[name]["note"] = secrets[name].Note
 			}
 		}
 
@@ -263,6 +264,7 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 	if raw {
 		headers = append(headers, "raw")
 	}
+	headers = append(headers, "note")
 
 	var rows [][]string
 	for _, secret := range matchedSecrets {
@@ -270,6 +272,7 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 		if raw {
 			row = append(row, secret.RawValue)
 		}
+		row = append(row, secret.Note)
 
 		rows = append(rows, row)
 	}

--- a/pkg/printer/enclave.go
+++ b/pkg/printer/enclave.go
@@ -296,6 +296,22 @@ func SecretsNames(secretsNames []string, jsonFlag bool) {
 	Table([]string{"name"}, rows, TableOptions())
 }
 
+// SecretNote print a secret's note
+func SecretNote(secret models.SecretNote, jsonFlag bool) {
+	if jsonFlag {
+		note := map[string]string{}
+		note["name"] = secret.Secret
+		note["note"] = secret.Note
+
+		JSON(note)
+		return
+	}
+
+	var rows [][]string
+	rows = append(rows, []string{secret.Secret, secret.Note})
+	Table([]string{"name", "note"}, rows, TableOptions())
+}
+
 // Settings print settings
 func Settings(settings models.WorkplaceSettings, jsonFlag bool) {
 	if jsonFlag {

--- a/pkg/utils/io.go
+++ b/pkg/utils/io.go
@@ -16,10 +16,12 @@ limitations under the License.
 package utils
 
 import (
+	"bufio"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"strings"
 )
 
 // RestrictedFilePerms perms used for creating restrictied files meant to be accessible only to the user
@@ -87,4 +89,34 @@ func HasDataOnStdIn() (bool, error) {
 
 	hasData := (stat.Mode() & os.ModeCharDevice) == 0
 	return hasData, nil
+}
+
+func GetStdIn() (*string, error) {
+	// read from stdin
+	hasData, e := HasDataOnStdIn()
+	if e != nil {
+		return nil, e
+	}
+
+	if !hasData {
+		return nil, nil
+	}
+
+	var input []string
+	scanner := bufio.NewScanner(os.Stdin)
+	for {
+		if ok := scanner.Scan(); !ok {
+			if e := scanner.Err(); e != nil {
+				return nil, e
+			}
+
+			break
+		}
+
+		s := scanner.Text()
+		input = append(input, s)
+	}
+
+	s := strings.Join(input, "\n")
+	return &s, nil
 }


### PR DESCRIPTION
This PR adds a new command for setting notes on a secret: `doppler secrets notes set`. A separate command was added as adding this to `doppler secrets set` would mean that a user wouldn't be able to set a secret note without also setting the secret value.

This is in draft pending the server PR.

Closes ENG-1669.