### PR TITLE
Add anonymous analytics for tracking command usage

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,19 @@ jobs:
       run: make build
       env:
         GOPATH: ${{ runner.workspace }}
+
+  check:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Set up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: '1.19'
+        check-latest: true
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/${{ github.repository }}
     - name: GoReleaser Check
       uses: goreleaser/goreleaser-action@v1
       with:

--- a/pkg/cmd/analytics.go
+++ b/pkg/cmd/analytics.go
@@ -1,0 +1,88 @@
+/*
+Copyright © 2022 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/DopplerHQ/cli/pkg/configuration"
+	"github.com/DopplerHQ/cli/pkg/printer"
+	"github.com/DopplerHQ/cli/pkg/utils"
+	"github.com/spf13/cobra"
+)
+
+var analyticsCmd = &cobra.Command{
+	Use:   "analytics",
+	Short: "Manage anonymous analytics",
+	Args:  cobra.NoArgs,
+}
+
+var analyticsStatusCmd = &cobra.Command{
+	Use:   "status",
+	Short: "Check whether anonymous analytics are enabled",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		if utils.OutputJSON {
+			printer.JSON(map[string]bool{"enabled": configuration.IsAnalyticsEnabled()})
+		} else {
+			adjective := "enabled"
+			if !configuration.IsAnalyticsEnabled() {
+				adjective = "disabled"
+			}
+			utils.Log(fmt.Sprintf("Anonymous analytics are currently %s", adjective))
+		}
+	},
+}
+
+var analyticsEnableCmd = &cobra.Command{
+	Use:   "enable",
+	Short: "Enable anonymous analytics",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		configuration.EnableAnalytics()
+
+		if utils.OutputJSON {
+			printer.JSON(map[string]bool{"enabled": true})
+		} else {
+			utils.Log("Anonymous analytics have been enabled")
+		}
+	},
+}
+
+var analyticsDisableCmd = &cobra.Command{
+	Use:   "disable",
+	Short: "Disable anonymous analytics",
+	Args:  cobra.NoArgs,
+	Run: func(cmd *cobra.Command, args []string) {
+		configuration.DisableAnalytics()
+
+		if utils.OutputJSON {
+			printer.JSON(map[string]bool{"enabled": false})
+		} else {
+			utils.Log("Anonymous analytics have been disabled")
+		}
+	},
+}
+
+func init() {
+	analyticsCmd.AddCommand(analyticsStatusCmd)
+
+	analyticsCmd.AddCommand(analyticsEnableCmd)
+
+	analyticsCmd.AddCommand(analyticsDisableCmd)
+
+	rootCmd.AddCommand(analyticsCmd)
+}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -67,7 +67,7 @@ var rootCmd = &cobra.Command{
 		// --plain doesn't normally affect logging output, but due to legacy reasons it does here
 		// also don't want to display updates if user doesn't want to be prompted (--no-prompt/--no-interactive)
 		if isTTY && utils.CanLogInfo() && !plain && canPrompt {
-			checkVersion(cmd.CommandPath())
+			checkVersion(wg, cmd.CommandPath())
 		}
 	},
 	Run: func(cmd *cobra.Command, args []string) {
@@ -78,7 +78,7 @@ var rootCmd = &cobra.Command{
 	},
 }
 
-func checkVersion(command string) {
+func checkVersion(wg *sync.WaitGroup, command string) {
 	// disable version checking on commands commonly used in production workflows
 	// also disable when explicitly calling 'update' command to avoid checking twice
 	disabledCommands := []string{"run", "secrets download", "update"}
@@ -99,6 +99,9 @@ func checkVersion(command string) {
 		return
 	}
 
+	wg.Add(1)
+	go controllers.CaptureEvent(wg, "VersionCheck")
+
 	available, versionCheck, err := controllers.NewVersionAvailable(prevVersionCheck)
 	if err != nil {
 		// retry on next run
@@ -112,6 +115,9 @@ func checkVersion(command string) {
 	} else if utils.IsWindows() {
 		utils.Log(fmt.Sprintf("Update: Doppler CLI %s is available\n\nYou can update via 'scoop update doppler'\n", versionCheck.LatestVersion))
 	} else {
+		wg.Add(1)
+		go controllers.CaptureEvent(wg, "UpgradeAvailable")
+
 		utils.Print(color.Green.Sprintf("An update is available."))
 
 		changes, apiError := controllers.CLIChangeLog()
@@ -122,6 +128,9 @@ func checkVersion(command string) {
 
 		prompt := fmt.Sprintf("Install Doppler CLI %s", versionCheck.LatestVersion)
 		if utils.ConfirmationPrompt(prompt, true) {
+			wg.Add(1)
+			go controllers.CaptureEvent(wg, "UpgradeFromPrompt")
+
 			installCLIUpdate()
 		}
 	}

--- a/pkg/configuration/analytics.go
+++ b/pkg/configuration/analytics.go
@@ -1,0 +1,30 @@
+/*
+Copyright © 2022 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package configuration
+
+func IsAnalyticsEnabled() bool {
+	return !configContents.Analytics.Disable
+}
+
+func EnableAnalytics() {
+	configContents.Analytics.Disable = false
+	writeConfig(configContents)
+}
+
+func DisableAnalytics() {
+	configContents.Analytics.Disable = true
+	writeConfig(configContents)
+}

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -25,7 +25,6 @@ import (
 	"strconv"
 	"strings"
 
-	"github.com/DopplerHQ/cli/pkg/controllers"
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/utils"
 	"github.com/spf13/cobra"
@@ -156,9 +155,9 @@ func Get(scope string) models.ScopedOptions {
 		}
 	}
 
-	if controllers.IsKeyringSecret(scopedConfig.Token.Value) {
+	if IsKeyringSecret(scopedConfig.Token.Value) {
 		utils.LogDebug(fmt.Sprintf("Retrieving %s from system keyring", models.ConfigToken.String()))
-		token, err := controllers.GetKeyring(scopedConfig.Token.Value)
+		token, err := GetKeyring(scopedConfig.Token.Value)
 		if !err.IsNil() {
 			utils.HandleError(err.Unwrap(), err.Message)
 		}
@@ -282,9 +281,9 @@ func AllConfigs() map[string]models.FileScopedOptions {
 	for scope, scopedOptions := range configContents.Scoped {
 		options := scopedOptions
 
-		if controllers.IsKeyringSecret(options.Token) {
+		if IsKeyringSecret(options.Token) {
 			utils.LogDebug(fmt.Sprintf("Retrieving %s from system keyring", models.ConfigToken.String()))
-			token, err := controllers.GetKeyring(options.Token)
+			token, err := GetKeyring(options.Token)
 			if !err.IsNil() {
 				utils.HandleError(err.Unwrap(), err.Message)
 			}
@@ -319,18 +318,18 @@ func Set(scope string, options map[string]string) {
 			if err != nil {
 				utils.HandleError(err, "Unable to generate UUID for keyring")
 			}
-			id := controllers.GenerateKeyringID(uuid)
+			id := GenerateKeyringID(uuid)
 
-			if controllerError := controllers.SetKeyring(id, value); !controllerError.IsNil() {
+			if controllerError := SetKeyring(id, value); !controllerError.IsNil() {
 				utils.LogDebugError(controllerError.Unwrap())
 				utils.LogDebug(controllerError.Message)
 			} else {
 				value = id
 
 				// remove old token from keyring
-				if controllers.IsKeyringSecret(previousToken) {
+				if IsKeyringSecret(previousToken) {
 					utils.LogDebug("Removing previous token from system keyring")
-					if controllerError := controllers.DeleteKeyring(previousToken); !controllerError.IsNil() {
+					if controllerError := DeleteKeyring(previousToken); !controllerError.IsNil() {
 						utils.LogDebugError(controllerError.Unwrap())
 						utils.LogDebug(controllerError.Message)
 					}
@@ -367,8 +366,8 @@ func Unset(scope string, options []string) {
 		if key == models.ConfigToken.String() {
 			previousToken := config.Token
 			// remove old token from keyring
-			if controllers.IsKeyringSecret(previousToken) {
-				if controllerError := controllers.DeleteKeyring(previousToken); !controllerError.IsNil() {
+			if IsKeyringSecret(previousToken) {
+				if controllerError := DeleteKeyring(previousToken); !controllerError.IsNil() {
 					utils.LogDebugError(controllerError.Unwrap())
 					utils.LogDebug(controllerError.Message)
 				}
@@ -390,9 +389,9 @@ func Unset(scope string, options []string) {
 func ClearConfig() {
 	// delete existing tokens from keychain
 	for _, scopedOptions := range configContents.Scoped {
-		if controllers.IsKeyringSecret(scopedOptions.Token) {
+		if IsKeyringSecret(scopedOptions.Token) {
 			utils.LogDebug(fmt.Sprintf("Removing %s from keychain", scopedOptions.Token))
-			err := controllers.DeleteKeyring(scopedOptions.Token)
+			err := DeleteKeyring(scopedOptions.Token)
 			if !err.IsNil() {
 				utils.LogDebugError(err.Unwrap())
 			}

--- a/pkg/configuration/keyring.go
+++ b/pkg/configuration/keyring.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2020 Doppler <support@doppler.com>
+Copyright © 2022 Doppler <support@doppler.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package controllers
+package configuration
 
 import (
 	"fmt"
@@ -24,6 +24,17 @@ import (
 
 const keyringService = "doppler-cli"
 const keyringSecretPrefix = "secret"
+
+type Error struct {
+	Err     error
+	Message string
+}
+
+// Unwrap get the original error
+func (e *Error) Unwrap() error { return e.Err }
+
+// IsNil whether the error is nil
+func (e *Error) IsNil() bool { return e.Err == nil && e.Message == "" }
 
 // IsKeyringSecret checks whether the secret is stored in keyring
 func IsKeyringSecret(value string) bool {

--- a/pkg/controllers/analytics.go
+++ b/pkg/controllers/analytics.go
@@ -1,0 +1,38 @@
+/*
+Copyright © 2021 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"strings"
+	"sync"
+
+	"github.com/DopplerHQ/cli/pkg/http"
+)
+
+// This package collects anonymous analytics for the purpose of improving the Doppler CLI
+
+func CaptureCommand(wg *sync.WaitGroup, command string) {
+	defer wg.Done()
+
+	if !configuration.IsAnalyticsEnabled() {
+		return
+	}
+
+	command = strings.ReplaceAll(command, " ", ".")
+	if _, err := http.CaptureCommand(command); !err.IsNil() {
+		utils.LogDebugError(err.Unwrap())
+	}
+}

--- a/pkg/controllers/analytics.go
+++ b/pkg/controllers/analytics.go
@@ -19,7 +19,9 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/DopplerHQ/cli/pkg/configuration"
 	"github.com/DopplerHQ/cli/pkg/http"
+	"github.com/DopplerHQ/cli/pkg/utils"
 )
 
 // This package collects anonymous analytics for the purpose of improving the Doppler CLI
@@ -33,6 +35,18 @@ func CaptureCommand(wg *sync.WaitGroup, command string) {
 
 	command = strings.ReplaceAll(command, " ", ".")
 	if _, err := http.CaptureCommand(command); !err.IsNil() {
+		utils.LogDebugError(err.Unwrap())
+	}
+}
+
+func CaptureEvent(wg *sync.WaitGroup, event string) {
+	defer wg.Done()
+
+	if !configuration.IsAnalyticsEnabled() {
+		return
+	}
+
+	if _, err := http.CaptureEvent(event); !err.IsNil() {
 		utils.LogDebugError(err.Unwrap())
 	}
 }

--- a/pkg/http/analytics.go
+++ b/pkg/http/analytics.go
@@ -1,0 +1,39 @@
+/*
+Copyright © 2022 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package http
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/DopplerHQ/cli/pkg/utils"
+)
+
+func CaptureCommand(command string) ([]byte, Error) {
+	postBody := map[string]interface{}{"command": command}
+	body, err := json.Marshal(postBody)
+	if err != nil {
+		return nil, Error{Err: err, Message: "Unable to marshal command"}
+	}
+
+	utils.LogDebug(fmt.Sprintf("Sending anonymous analytics payload: '%s'", body))
+
+	_, _, resp, err := PostRequest("https://cli.doppler.com", true, map[string]string{"Content-Type": "application/json"}, "/v1/analytics", nil, body)
+	if err != nil {
+		return nil, Error{Err: err, Message: "Unable to send anonymous analytics"}
+	}
+	return resp, Error{}
+}

--- a/pkg/http/analytics.go
+++ b/pkg/http/analytics.go
@@ -37,3 +37,19 @@ func CaptureCommand(command string) ([]byte, Error) {
 	}
 	return resp, Error{}
 }
+
+func CaptureEvent(event string) ([]byte, Error) {
+	postBody := map[string]interface{}{"event": event}
+	body, err := json.Marshal(postBody)
+	if err != nil {
+		return nil, Error{Err: err, Message: "Unable to marshal event"}
+	}
+
+	utils.LogDebug(fmt.Sprintf("Sending anonymous analytics payload: '%s'", body))
+
+	_, _, resp, err := PostRequest("https://cli.doppler.com", true, map[string]string{"Content-Type": "application/json"}, "/v1/analytics", nil, body)
+	if err != nil {
+		return nil, Error{Err: err, Message: "Unable to send anonymous analytics"}
+	}
+	return resp, Error{}
+}

--- a/pkg/models/config.go
+++ b/pkg/models/config.go
@@ -23,6 +23,7 @@ import (
 type ConfigFile struct {
 	Scoped       map[string]FileScopedOptions `yaml:"scoped"`
 	VersionCheck VersionCheck                 `yaml:"version-check"`
+	Analytics    AnalyticsOptions             `yaml:"analytics"`
 }
 
 // FileScopedOptions config options
@@ -39,6 +40,12 @@ type FileScopedOptions struct {
 type VersionCheck struct {
 	LatestVersion string    `yaml:"latest-version,omitempty"`
 	CheckedAt     time.Time `yaml:"checked-at,omitempty"`
+}
+
+type AnalyticsOptions struct {
+	// we use the key 'disable' rather than 'enable' because blank value are automatically parsed as 'false',
+	// and we want this feature to be enabled by default
+	Disable bool `yaml:"disable"`
 }
 
 // ScopedOptions options with their scope

--- a/tests/e2e.sh
+++ b/tests/e2e.sh
@@ -19,6 +19,7 @@ export DOPPLER_CONFIG="e2e"
 "$DIR/e2e/install-sh-install-path.sh"
 "$DIR/e2e/install-sh-update-in-place.sh"
 "$DIR/e2e/legacy-commands.sh"
+"$DIR/e2e/analytics.sh"
 
 echo -e "\nAll tests completed successfully!"
 exit 0

--- a/tests/e2e/analytics.sh
+++ b/tests/e2e/analytics.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+set -euo pipefail
+
+TEST_NAME="analytics"
+
+cleanup() {
+  exit_code=$?
+  if [ "$exit_code" -ne 0 ]; then
+    echo "ERROR: '$TEST_NAME' tests failed during execution"
+    afterAll || echo "ERROR: Cleanup failed"
+  fi
+
+  exit "$exit_code"
+}
+trap cleanup EXIT
+
+beforeAll() {
+  echo "INFO: Executing '$TEST_NAME' tests"
+}
+
+beforeEach() {
+  rm -rf ./temp-config
+}
+
+afterAll() {
+  echo "INFO: Completed '$TEST_NAME' tests"
+  beforeEach
+}
+
+error() {
+  message=$1
+  echo "$message"
+  exit 1
+}
+
+beforeAll
+
+beforeEach
+
+# analytics defaults to enabled
+status="$("$DOPPLER_BINARY" analytics status --configuration=./temp-config --json)"
+[[ "$status" == '{"enabled":true}' ]] || error "ERROR: analytics not enabled"
+
+beforeEach
+
+# analytics defaults to enabled after clearing config
+"$DOPPLER_BINARY" configure reset --configuration=./temp-config --yes
+status="$("$DOPPLER_BINARY" analytics status --configuration=./temp-config --json)"
+[[ "$status" == '{"enabled":true}' ]] || error "ERROR: analytics not enabled after reset"
+
+beforeEach
+
+# analytics defaults to enabled after disabling and then clearing config
+"$DOPPLER_BINARY" analytics disable --configuration=./temp-config >/dev/null 2>&1
+"$DOPPLER_BINARY" configure reset --configuration=./temp-config --yes
+status="$("$DOPPLER_BINARY" analytics status --configuration=./temp-config --json)"
+[[ "$status" == '{"enabled":true}' ]] || error "ERROR: analytics not enabled after diabling and resetting"
+
+beforeEach
+
+# analytics can be disabled
+"$DOPPLER_BINARY" analytics disable --configuration=./temp-config >/dev/null 2>&1
+status="$("$DOPPLER_BINARY" analytics status --configuration=./temp-config --json)"
+[[ "$status" == '{"enabled":false}' ]] || error "ERROR: analytics not disabled"
+
+afterAll


### PR DESCRIPTION
This allows us to see what commands people are most frequently using. Analytics are enabled by default and are completely anonymous.

Data we collect:
- command name
- os
- architecture
- CLI version

To opt out: run `doppler analytics disable`.

Closes ENG-735.