### PR TITLE
chore: log request before performing request

### DIFF
--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -207,6 +207,8 @@ func performRequest(req *http.Request, verifyTLS bool, params []queryParam) (int
 		Proxy:             http.ProxyURL(proxyUrl),
 	}
 
+	utils.LogDebug(fmt.Sprintf("Performing HTTP %s to %s", req.Method, req.URL))
+
 	startTime := time.Now()
 	var response *http.Response
 	response = nil
@@ -231,7 +233,6 @@ func performRequest(req *http.Request, verifyTLS bool, params []queryParam) (int
 
 		response = resp
 
-		utils.LogDebug(fmt.Sprintf("Performing HTTP %s to %s", req.Method, req.URL))
 		if requestID := resp.Header.Get("x-request-id"); requestID != "" {
 			utils.LogDebug(fmt.Sprintf("Request ID %s", requestID))
 		}


### PR DESCRIPTION
This makes it easier to see what's happening. In the event the server takes a while to respond, it'll be more clear that a request has been sent, rather than the CLI appearing like it's hanging.

Closes ENG-5675.