### PR TITLE
Capture timing metrics when performing update

### DIFF
--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -100,7 +100,7 @@ func checkVersion(command string) {
 	}
 
 	global.WaitGroup.Add(1)
-	go controllers.CaptureEvent("VersionCheck")
+	go controllers.CaptureEvent("VersionCheck", nil)
 
 	available, versionCheck, err := controllers.NewVersionAvailable(prevVersionCheck)
 	if err != nil {
@@ -116,7 +116,7 @@ func checkVersion(command string) {
 		utils.Log(fmt.Sprintf("Update: Doppler CLI %s is available\n\nYou can update via 'scoop update doppler'\n", versionCheck.LatestVersion))
 	} else {
 		global.WaitGroup.Add(1)
-		go controllers.CaptureEvent("UpgradeAvailable")
+		go controllers.CaptureEvent("UpgradeAvailable", nil)
 
 		utils.Print(color.Green.Sprintf("An update is available."))
 
@@ -129,7 +129,7 @@ func checkVersion(command string) {
 		prompt := fmt.Sprintf("Install Doppler CLI %s", versionCheck.LatestVersion)
 		if utils.ConfirmationPrompt(prompt, true) {
 			global.WaitGroup.Add(1)
-			go controllers.CaptureEvent("UpgradeFromPrompt")
+			go controllers.CaptureEvent("UpgradeFromPrompt", nil)
 
 			installCLIUpdate()
 		}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -44,8 +44,7 @@ var rootCmd = &cobra.Command{
 		configuration.Setup()
 		configuration.LoadConfig()
 
-		global.WaitGroup.Add(1)
-		go controllers.CaptureCommand(cmd.CommandPath())
+		controllers.CaptureCommand(cmd.CommandPath())
 
 		if utils.Debug && utils.Silent {
 			utils.LogWarning("--silent has no effect when used with --debug")
@@ -99,8 +98,7 @@ func checkVersion(command string) {
 		return
 	}
 
-	global.WaitGroup.Add(1)
-	go controllers.CaptureEvent("VersionCheck", nil)
+	controllers.CaptureEvent("VersionCheck", nil)
 
 	available, versionCheck, err := controllers.NewVersionAvailable(prevVersionCheck)
 	if err != nil {
@@ -115,8 +113,7 @@ func checkVersion(command string) {
 	} else if utils.IsWindows() {
 		utils.Log(fmt.Sprintf("Update: Doppler CLI %s is available\n\nYou can update via 'scoop update doppler'\n", versionCheck.LatestVersion))
 	} else {
-		global.WaitGroup.Add(1)
-		go controllers.CaptureEvent("UpgradeAvailable", nil)
+		controllers.CaptureEvent("UpgradeAvailable", nil)
 
 		utils.Print(color.Green.Sprintf("An update is available."))
 
@@ -128,8 +125,7 @@ func checkVersion(command string) {
 
 		prompt := fmt.Sprintf("Install Doppler CLI %s", versionCheck.LatestVersion)
 		if utils.ConfirmationPrompt(prompt, true) {
-			global.WaitGroup.Add(1)
-			go controllers.CaptureEvent("UpgradeFromPrompt", nil)
+			controllers.CaptureEvent("UpgradeFromPrompt", nil)
 
 			installCLIUpdate()
 		}

--- a/pkg/controllers/analytics.go
+++ b/pkg/controllers/analytics.go
@@ -27,6 +27,11 @@ import (
 // This package collects anonymous analytics for the purpose of improving the Doppler CLI
 
 func CaptureCommand(command string) {
+	global.WaitGroup.Add(1)
+	go captureCommand(command)
+}
+
+func captureCommand(command string) {
 	defer global.WaitGroup.Done()
 
 	if !configuration.IsAnalyticsEnabled() {
@@ -40,6 +45,11 @@ func CaptureCommand(command string) {
 }
 
 func CaptureEvent(event string, metadata map[string]interface{}) {
+	global.WaitGroup.Add(1)
+	go captureEvent(event, metadata)
+}
+
+func captureEvent(event string, metadata map[string]interface{}) {
 	defer global.WaitGroup.Done()
 
 	if !configuration.IsAnalyticsEnabled() {

--- a/pkg/controllers/analytics.go
+++ b/pkg/controllers/analytics.go
@@ -17,17 +17,17 @@ package controllers
 
 import (
 	"strings"
-	"sync"
 
 	"github.com/DopplerHQ/cli/pkg/configuration"
+	"github.com/DopplerHQ/cli/pkg/global"
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/utils"
 )
 
 // This package collects anonymous analytics for the purpose of improving the Doppler CLI
 
-func CaptureCommand(wg *sync.WaitGroup, command string) {
-	defer wg.Done()
+func CaptureCommand(command string) {
+	defer global.WaitGroup.Done()
 
 	if !configuration.IsAnalyticsEnabled() {
 		return
@@ -39,8 +39,8 @@ func CaptureCommand(wg *sync.WaitGroup, command string) {
 	}
 }
 
-func CaptureEvent(wg *sync.WaitGroup, event string) {
-	defer wg.Done()
+func CaptureEvent(event string) {
+	defer global.WaitGroup.Done()
 
 	if !configuration.IsAnalyticsEnabled() {
 		return

--- a/pkg/controllers/analytics.go
+++ b/pkg/controllers/analytics.go
@@ -39,14 +39,14 @@ func CaptureCommand(command string) {
 	}
 }
 
-func CaptureEvent(event string) {
+func CaptureEvent(event string, metadata map[string]interface{}) {
 	defer global.WaitGroup.Done()
 
 	if !configuration.IsAnalyticsEnabled() {
 		return
 	}
 
-	if _, err := http.CaptureEvent(event); !err.IsNil() {
+	if _, err := http.CaptureEvent(event, metadata); !err.IsNil() {
 		utils.LogDebugError(err.Unwrap())
 	}
 }

--- a/pkg/controllers/update.go
+++ b/pkg/controllers/update.go
@@ -24,7 +24,6 @@ import (
 	"strings"
 	"time"
 
-	"github.com/DopplerHQ/cli/pkg/global"
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/utils"
@@ -53,8 +52,7 @@ func RunInstallScript() (bool, string, Error) {
 	}
 	fetchScriptDuration := time.Now().Sub(startTime).Milliseconds()
 
-	global.WaitGroup.Add(1)
-	go CaptureEvent("InstallScriptDownloaded", map[string]interface{}{"durationMs": fetchScriptDuration})
+	CaptureEvent("InstallScriptDownloaded", map[string]interface{}{"durationMs": fetchScriptDuration})
 
 	// write script to temp file
 	tmpFile, err := utils.WriteTempFile("install.sh", script, 0555)
@@ -82,8 +80,7 @@ func RunInstallScript() (bool, string, Error) {
 			exitCode = exitError.ExitCode()
 		}
 
-		global.WaitGroup.Add(1)
-		go CaptureEvent("InstallScriptFailed", map[string]interface{}{"durationMs": executeDuration, "exitCode": exitCode})
+		CaptureEvent("InstallScriptFailed", map[string]interface{}{"durationMs": executeDuration, "exitCode": exitCode})
 
 		message := "Unable to install the latest Doppler CLI"
 		permissionError := exitCode == 2 || strings.Contains(strOut, "dpkg: error: requested operation requires superuser privilege")
@@ -101,8 +98,7 @@ func RunInstallScript() (bool, string, Error) {
 	}
 
 	// only capture when install is successful
-	global.WaitGroup.Add(1)
-	go CaptureEvent("InstallScriptCompleted", map[string]interface{}{"durationMs": executeDuration})
+	CaptureEvent("InstallScriptCompleted", map[string]interface{}{"durationMs": executeDuration})
 
 	// find installed version within script output
 	// Ex: `Installed Doppler CLI v3.7.1`

--- a/pkg/global/waitgroup.go
+++ b/pkg/global/waitgroup.go
@@ -1,0 +1,23 @@
+/*
+Copyright © 2020 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package global
+
+import "sync"
+
+// this variable is initialized in cmd/root.go before the user's specified command
+// is executed. the WaitGroup is then waited on after the user's command completes
+// but before exiting
+var WaitGroup *sync.WaitGroup

--- a/pkg/http/analytics.go
+++ b/pkg/http/analytics.go
@@ -36,7 +36,7 @@ func CaptureCommand(command string) ([]byte, Error) {
 		return nil, Error{Err: err, Message: "Unable to generate url"}
 	}
 
-	_, _, resp, err := PutRequest(url, true, map[string]string{"Content-Type": "application/json"}, body)
+	_, _, resp, err := PostRequest(url, true, map[string]string{"Content-Type": "application/json"}, body)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to send anonymous analytics"}
 	}

--- a/pkg/http/analytics.go
+++ b/pkg/http/analytics.go
@@ -43,8 +43,11 @@ func CaptureCommand(command string) ([]byte, Error) {
 	return resp, Error{}
 }
 
-func CaptureEvent(event string) ([]byte, Error) {
+func CaptureEvent(event string, metadata map[string]interface{}) ([]byte, Error) {
 	postBody := map[string]interface{}{"event": event}
+	if metadata != nil {
+		postBody["metadata"] = metadata
+	}
 	body, err := json.Marshal(postBody)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to marshal event"}


### PR DESCRIPTION
This change allows us to see how many installs succeed/fail, as well as how long the update process takes.