### PR TITLE
Allow setting config dir with DOPPLER_CONFIG_DIR

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -58,6 +58,7 @@ and your config file. Flags have the highest priority; config file has the least
 		jsonFlag := utils.OutputJSON
 
 		utils.Print(fmt.Sprintf("%s %s", color.Green.Render("Configuration file:"), configuration.UserConfigFile))
+		utils.Print(fmt.Sprintf("%s %s", color.Green.Render("Configuration directory:"), configuration.UserConfigDir))
 
 		config := configuration.LocalConfig(cmd)
 		printer.ScopedConfigSource(config, jsonFlag, true, false)

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -150,6 +150,15 @@ func loadFlags(cmd *cobra.Command) {
 	configuration.Scope = normalizedScope
 
 	configuration.CanReadEnv = !utils.GetBoolFlag(cmd, "no-read-env")
+
+	// User Config Dir
+	if configuration.CanReadEnv {
+		userConfigDir := os.Getenv("DOPPLER_CONFIG_DIR")
+		if userConfigDir != "" {
+			utils.Log(valueFromEnvironmentNotice("DOPPLER_CONFIG_DIR"))
+			configuration.SetConfigDir(userConfigDir)
+		}
+	}
 	configuration.SetConfigDir(utils.GetPathFlagIfChanged(cmd, "config-dir", configuration.UserConfigDir))
 	configuration.UserConfigFile = utils.GetPathFlagIfChanged(cmd, "configuration", configuration.UserConfigFile)
 	http.UseTimeout = !utils.GetBoolFlag(cmd, "no-timeout")

--- a/tests/e2e/configure.sh
+++ b/tests/e2e/configure.sh
@@ -78,6 +78,14 @@ config="$("$DOPPLER_BINARY" configure get config --configuration=./temp-config-d
 
 beforeEach
 
+# test configure w/ custom config-dir from environment
+mkdir ./temp-config-dir
+DOPPLER_CONFIG_DIR=./temp-config-dir "$DOPPLER_BINARY" configure set config 123 --scope=/ --silent
+config="$(DOPPLER_CONFIG_DIR=./temp-config-dir "$DOPPLER_BINARY" configure get config --scope=/ --plain)"
+[[ "$config" == "123" ]] || error "ERROR: config-dir not properly used"
+
+beforeEach
+
 # test configure w/ custom config-dir AND custom configuration
 mkdir ./temp-config-dir
 "$DOPPLER_BINARY" configure set config 123 --config-dir=./temp-config-dir --configuration ./temp-config --scope=/ --silent


### PR DESCRIPTION
In some situations (e.g., a devcontainer that's being built), it can be advantageous to configure a specific config directory via environment variables rather than having to specify it with every CLI command. This allows you to set `DOPPLER_CONFIG_DIR` to set that value. Passing in `--config-dir` will still override this if needed.