### PR TITLE
Allow the passphrase to be set via DOPPLER_PASSPHRASE

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -582,6 +582,14 @@ func getPassphrase(cmd *cobra.Command, flag string, config models.ScopedOptions)
 		return cmd.Flag(flag).Value.String()
 	}
 
+	if configuration.CanReadEnv {
+		passphrase := os.Getenv("DOPPLER_PASSPHRASE")
+		if passphrase != "" {
+			utils.Print(valueFromEnvironmentNotice("DOPPLER_PASSPHRASE"))
+			return passphrase
+		}
+	}
+
 	if config.EnclaveProject.Value != "" && config.EnclaveConfig.Value != "" {
 		return fmt.Sprintf("%s:%s:%s", config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value)
 	}

--- a/tests/e2e/run-fallback.sh
+++ b/tests/e2e/run-fallback.sh
@@ -66,6 +66,17 @@ beforeEach
 
 beforeEach
 
+# test 'run' respects custom passphrase from environment
+DOPPLER_PASSPHRASE=123456 "$DOPPLER_BINARY" run -- echo -n > /dev/null
+# ensure default passphrase fails
+"$DOPPLER_BINARY" run --fallback-only -- echo -n > /dev/null 2>&1 && (echo "ERROR: --passphrase flag is not respected (1)" && exit 1)
+# test decryption with custom passphrase flag
+"$DOPPLER_BINARY" run --fallback-only --passphrase=123456 -- echo -n > /dev/null || (echo "ERROR: --passphrase flag is not respected (2)" && exit 1)
+# test decryption with custom passphrase from environment
+DOPPLER_PASSPHRASE=123456 "$DOPPLER_BINARY" run --fallback-only -- echo -n > /dev/null || (echo "ERROR: --passphrase flag is not respected (3)" && exit 1)
+
+beforeEach
+
 # test 'run' respects --no-exit-on-write-failure
 mkdir ./temp-fallback
 chmod 500 ./temp-fallback

--- a/tests/e2e/secrets-download-fallback.sh
+++ b/tests/e2e/secrets-download-fallback.sh
@@ -66,6 +66,17 @@ beforeEach
 
 beforeEach
 
+# test 'secrets download' respects custom passphrase from environment
+DOPPLER_PASSPHRASE=123456 "$DOPPLER_BINARY" secrets download --no-file > /dev/null
+# ensure default passphrase fails
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only > /dev/null 2>&1 && (echo "ERROR: --passphrase flag is not respected (1)" && exit 1)
+# test decryption with custom passphrase flag
+"$DOPPLER_BINARY" secrets download --no-file --fallback-only --fallback-passphrase=123456 > /dev/null || (echo "ERROR: --passphrase flag is not respected (2)" && exit 1)
+# test decryption with custom passphrase from environment
+DOPPLER_PASSPHRASE=123456 "$DOPPLER_BINARY" secrets download --no-file --fallback-only > /dev/null || (echo "ERROR: --passphrase flag is not respected (3)" && exit 1)
+
+beforeEach
+
 # test 'secrets download' respects --no-exit-on-write-failure
 mkdir ./temp-fallback
 chmod 500 ./temp-fallback


### PR DESCRIPTION
This adds the ability to set the passphrase to be used when decrypting a fallback file via the `DOPPLER_PASSPHRASE` environment variable rather than relying solely on the `--passphrase` flag. This can help reduce the chance that the passphrase will be leaked in bash histories or by viewing process listings.

Closes ENG-5148.