### PR TITLE
Log valueFromEnvironmentNotice messages to stderr

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -585,7 +585,7 @@ func getPassphrase(cmd *cobra.Command, flag string, config models.ScopedOptions)
 	if configuration.CanReadEnv {
 		passphrase := os.Getenv("DOPPLER_PASSPHRASE")
 		if passphrase != "" {
-			utils.Print(valueFromEnvironmentNotice("DOPPLER_PASSPHRASE"))
+			utils.Log(valueFromEnvironmentNotice("DOPPLER_PASSPHRASE"))
 			return passphrase
 		}
 	}

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -52,7 +52,7 @@ func setup(cmd *cobra.Command, args []string) {
 		case models.FlagSource.String():
 			saveToken = true
 		case models.EnvironmentSource.String():
-			utils.Print(valueFromEnvironmentNotice("DOPPLER_TOKEN"))
+			utils.Log(valueFromEnvironmentNotice("DOPPLER_TOKEN"))
 			saveToken = true
 		}
 	}
@@ -82,7 +82,7 @@ func setup(cmd *cobra.Command, args []string) {
 	case models.FlagSource.String():
 		selectedProject = localConfig.EnclaveProject.Value
 	case models.EnvironmentSource.String():
-		utils.Print(valueFromEnvironmentNotice("DOPPLER_PROJECT"))
+		utils.Log(valueFromEnvironmentNotice("DOPPLER_PROJECT"))
 		selectedProject = localConfig.EnclaveProject.Value
 	default:
 		if useRepoConfig && repoConfig.Setup.Project != "" {
@@ -117,7 +117,7 @@ func setup(cmd *cobra.Command, args []string) {
 	case models.FlagSource.String():
 		selectedConfig = localConfig.EnclaveConfig.Value
 	case models.EnvironmentSource.String():
-		utils.Print(valueFromEnvironmentNotice("DOPPLER_CONFIG"))
+		utils.Log(valueFromEnvironmentNotice("DOPPLER_CONFIG"))
 		selectedConfig = localConfig.EnclaveConfig.Value
 	default:
 		if useRepoConfig && repoConfig.Setup.Config != "" {


### PR DESCRIPTION
We had been printing these messages to `stdout`. This is fine for some operations, but others are more likely to be used in a scripted environment where just the value (e.g., `token=$(doppler configure get token --plain)`) is expected. By not printing to `stderr`, the message would end up in the value of the assignment. This just switches all uses of `valueFromEnvironmentNotice` to use `utils.Log` rather than `utils.Print`.