### PR TITLE
Disallow using and delete fallback file on server 401/403

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -412,6 +412,15 @@ func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOp
 	statusCode, respHeaders, response, httpErr := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer, etag, dynamicSecretsTTL, secretNames)
 	if !httpErr.IsNil() {
 		canUseFallback := statusCode != 401 && statusCode != 403 && statusCode != 404
+		if !canUseFallback {
+			utils.LogDebug(fmt.Sprintf("Received %v. Deleting (if exists) %v", statusCode, fallbackOpts.path))
+			os.Remove(fallbackOpts.path)
+			utils.LogDebug(fmt.Sprintf("Received %v. Deleting (if exists) %v", statusCode, fallbackOpts.legacyPath))
+			os.Remove(fallbackOpts.legacyPath)
+			utils.LogDebug(fmt.Sprintf("Received %v. Deleting (if exists) %v", statusCode, metadataPath))
+			os.Remove(metadataPath)
+		}
+
 		if fallbackOpts.enable && canUseFallback {
 			utils.Log("Unable to fetch secrets from the Doppler API")
 			utils.LogError(httpErr.Unwrap())

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -411,7 +411,8 @@ func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOp
 
 	statusCode, respHeaders, response, httpErr := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer, etag, dynamicSecretsTTL, secretNames)
 	if !httpErr.IsNil() {
-		if fallbackOpts.enable {
+		canUseFallback := statusCode != 401 && statusCode != 403 && statusCode != 404
+		if fallbackOpts.enable && canUseFallback {
 			utils.Log("Unable to fetch secrets from the Doppler API")
 			utils.LogError(httpErr.Unwrap())
 			return readFallbackFile(fallbackOpts.path, fallbackOpts.legacyPath, fallbackOpts.passphrase, false)


### PR DESCRIPTION
If the Doppler server is accessible but returns a 401 or 403 when fetching secrets, we should not use the fallback file. Additionally, if it exists, we want to delete it from the user's FS.