### PR TITLE
Add support for secret visibility types

### DIFF
--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -97,6 +97,7 @@ func init() {
 	enclaveSecretsCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
 	enclaveSecretsCmd.Flags().StringP("config", "c", "", "enclave config (e.g. dev)")
 	enclaveSecretsCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
+	enclaveSecretsCmd.Flags().Bool("visibility", false, "include secret visibility in table output")
 	enclaveSecretsCmd.Flags().Bool("only-names", false, "only print the secret names; omit all values")
 
 	enclaveSecretsGetCmd.Flags().StringP("project", "p", "", "enclave project (e.g. backend)")
@@ -104,6 +105,7 @@ func init() {
 	enclaveSecretsGetCmd.Flags().Bool("plain", false, "print values without formatting")
 	enclaveSecretsGetCmd.Flags().Bool("copy", false, "copy the value(s) to your clipboard")
 	enclaveSecretsGetCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
+	enclaveSecretsGetCmd.Flags().Bool("visibility", false, "include secret visibility in table output")
 	enclaveSecretsGetCmd.Flags().Bool("no-exit-on-missing-secret", false, "do not exit if unable to find a requested secret")
 	enclaveSecretsCmd.AddCommand(enclaveSecretsGetCmd)
 

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -159,6 +159,7 @@ JSON Secret: "{\"logging\": \"info\"}"`,
 func secrets(cmd *cobra.Command, args []string) {
 	jsonFlag := utils.OutputJSON
 	raw := utils.GetBoolFlag(cmd, "raw")
+	visibility := utils.GetBoolFlag(cmd, "visibility")
 	onlyNames := utils.GetBoolFlag(cmd, "only-names")
 	localConfig := configuration.LocalConfig(cmd)
 
@@ -181,7 +182,7 @@ func secrets(cmd *cobra.Command, args []string) {
 			utils.HandleError(parseErr, "Unable to parse API response")
 		}
 
-		printer.Secrets(secrets, []string{}, jsonFlag, false, raw, false)
+		printer.Secrets(secrets, []string{}, jsonFlag, false, raw, false, visibility)
 	}
 }
 
@@ -190,6 +191,7 @@ func getSecrets(cmd *cobra.Command, args []string) {
 	plain := utils.GetBoolFlag(cmd, "plain")
 	copy := utils.GetBoolFlag(cmd, "copy")
 	raw := utils.GetBoolFlag(cmd, "raw")
+	visibility := utils.GetBoolFlag(cmd, "visibility")
 	exitOnMissingSecret := !utils.GetBoolFlag(cmd, "no-exit-on-missing-secret")
 	localConfig := configuration.LocalConfig(cmd)
 
@@ -226,7 +228,7 @@ func getSecrets(cmd *cobra.Command, args []string) {
 		}
 	}
 
-	printer.Secrets(secrets, args, jsonFlag, plain, raw, copy)
+	printer.Secrets(secrets, args, jsonFlag, plain, raw, copy, visibility)
 }
 
 func setSecrets(cmd *cobra.Command, args []string) {
@@ -331,7 +333,7 @@ func setSecrets(cmd *cobra.Command, args []string) {
 	}
 
 	if !utils.Silent {
-		printer.Secrets(response, keys, jsonFlag, false, raw, false)
+		printer.Secrets(response, keys, jsonFlag, false, raw, false, false)
 	}
 }
 
@@ -363,7 +365,7 @@ func uploadSecrets(cmd *cobra.Command, args []string) {
 	}
 
 	if !utils.Silent {
-		printer.Secrets(response, []string{}, jsonFlag, false, raw, false)
+		printer.Secrets(response, []string{}, jsonFlag, false, raw, false, false)
 	}
 }
 
@@ -387,7 +389,7 @@ func deleteSecrets(cmd *cobra.Command, args []string) {
 		}
 
 		if !utils.Silent {
-			printer.Secrets(response, []string{}, jsonFlag, false, raw, false)
+			printer.Secrets(response, []string{}, jsonFlag, false, raw, false, false)
 		}
 	}
 }
@@ -590,6 +592,7 @@ func init() {
 	secretsCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")
 	secretsCmd.Flags().StringP("config", "c", "", "config (e.g. dev)")
 	secretsCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
+	secretsCmd.Flags().Bool("visibility", false, "include secret visibility in table output")
 	secretsCmd.Flags().Bool("only-names", false, "only print the secret names; omit all values")
 
 	secretsGetCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")
@@ -597,6 +600,7 @@ func init() {
 	secretsGetCmd.Flags().Bool("plain", false, "print values without formatting")
 	secretsGetCmd.Flags().Bool("copy", false, "copy the value(s) to your clipboard")
 	secretsGetCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
+	secretsGetCmd.Flags().Bool("visibility", false, "include secret visibility in table output")
 	secretsGetCmd.Flags().Bool("no-exit-on-missing-secret", false, "do not exit if unable to find a requested secret")
 	secretsCmd.AddCommand(secretsGetCmd)
 

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -551,7 +551,11 @@ func substituteSecrets(cmd *cobra.Command, args []string) {
 
 	secretsMap := map[string]string{}
 	for _, secret := range secrets {
-		secretsMap[secret.Name] = secret.ComputedValue
+		if secret.ComputedValue != nil {
+			// By not providing a default value when ComputedValue is nil (e.g. it's a restricted secret), we default
+			// to the same behavior the substituter provides if the template file contains a secret that doesn't exist.
+			secretsMap[secret.Name] = *secret.ComputedValue
+		}
 	}
 
 	templateBody := controllers.ReadTemplateFile(args[0])

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -247,22 +247,13 @@ func SetSecrets(host string, verifyTLS bool, apiKey string, project string, conf
 		return nil, Error{Err: err, Message: "Unable to set secrets", Code: statusCode}
 	}
 
-	var result map[string]interface{}
+	var result models.APISecretResponse
 	err = json.Unmarshal(response, &result)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to parse API response", Code: statusCode}
 	}
 
-	computed := map[string]models.ComputedSecret{}
-	for key, secret := range result["secrets"].(map[string]interface{}) {
-		val, ok := secret.(map[string]interface{})
-		if !ok {
-			return nil, Error{Err: fmt.Errorf("Unexpected type mismatch for secret, expected map[string]interface{}, got %T", secret), Message: "Unable to parse API response", Code: statusCode}
-		}
-		computed[key] = models.ComputedSecret{Name: key, RawValue: val["raw"].(string), ComputedValue: val["computed"].(string)}
-	}
-
-	return computed, Error{}
+	return models.ConvertAPIToComputedSecrets(result.Secrets), Error{}
 }
 
 // SetSecretNote for specified project and config
@@ -346,22 +337,13 @@ func UploadSecrets(host string, verifyTLS bool, apiKey string, project string, c
 		return nil, Error{Err: err, Message: "Unable to upload secrets", Code: statusCode}
 	}
 
-	var result map[string]interface{}
+	var result models.APISecretResponse
 	err = json.Unmarshal(response, &result)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to parse API response", Code: statusCode}
 	}
 
-	computed := map[string]models.ComputedSecret{}
-	for key, secret := range result["secrets"].(map[string]interface{}) {
-		val, ok := secret.(map[string]interface{})
-		if !ok {
-			return nil, Error{Err: fmt.Errorf("Unexpected type for secret, expected map[string]interface{}, got %T", secret), Message: "Unable to parse API response", Code: statusCode}
-		}
-		computed[key] = models.ComputedSecret{Name: key, RawValue: val["raw"].(string), ComputedValue: val["computed"].(string)}
-	}
-
-	return computed, Error{}
+	return models.ConvertAPIToComputedSecrets(result.Secrets), Error{}
 }
 
 // GetWorkplaceSettings get specified workplace settings

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -17,10 +17,12 @@ package models
 
 // ComputedSecret holds all info about a secret
 type ComputedSecret struct {
-	Name          string `json:"name"`
-	RawValue      string `json:"raw"`
-	ComputedValue string `json:"computed"`
-	Note          string `json:"note"`
+	Name               string  `json:"name"`
+	RawValue           *string `json:"raw"`
+	ComputedValue      *string `json:"computed"`
+	RawVisibility      string  `json:"rawVisibility"`
+	ComputedVisibility string  `json:"computedVisibility"`
+	Note               string  `json:"note"`
 }
 
 // SecretNote contains a secret and its note
@@ -116,4 +118,19 @@ type ConfigServiceToken struct {
 	Environment string `json:"environment"`
 	Config      string `json:"config"`
 	Access      string `json:"access"`
+}
+
+// APISecretResponse is the response the secrets endpoint returns
+type APISecretResponse struct {
+	Success bool                 `json:"success"`
+	Secrets map[string]APISecret `json:"secrets"`
+}
+
+// APISecret is the object the API returns for a given secret
+type APISecret struct {
+	RawValue           *string `json:"raw"`
+	ComputedValue      *string `json:"computed"`
+	RawVisibility      string  `json:"rawVisibility"`
+	ComputedVisibility string  `json:"computedVisibility"`
+	Note               string  `json:"note"`
 }

--- a/pkg/printer/enclave.go
+++ b/pkg/printer/enclave.go
@@ -214,7 +214,11 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 		vals := []string{}
 		for _, name := range secretsToPrint {
 			if secrets[name] != (models.ComputedSecret{}) {
-				vals = append(vals, secrets[name].ComputedValue)
+				if secrets[name].ComputedValue == nil {
+					utils.HandleError(fmt.Errorf("Unable to copy restricted value to clipboard"))
+				} else {
+					vals = append(vals, *secrets[name].ComputedValue)
+				}
 			}
 		}
 
@@ -224,14 +228,28 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 	}
 
 	if jsonFlag {
-		secretsMap := map[string]map[string]string{}
+		secretsMap := map[string]map[string]interface{}{}
 		for _, name := range secretsToPrint {
 			if secrets[name] != (models.ComputedSecret{}) {
-				secretsMap[name] = map[string]string{"computed": secrets[name].ComputedValue, "note": secrets[name].Note}
-				if raw {
-					secretsMap[name]["raw"] = secrets[name].RawValue
+				secretsMap[name] = map[string]interface{}{
+					"note":               secrets[name].Note,
+					"computedVisibility": secrets[name].ComputedVisibility,
 				}
-				secretsMap[name]["note"] = secrets[name].Note
+
+				if secrets[name].ComputedValue != nil {
+					secretsMap[name]["computed"] = *secrets[name].ComputedValue
+				} else {
+					secretsMap[name]["computed"] = nil
+				}
+
+				if raw {
+					secretsMap[name]["rawVisibility"] = secrets[name].RawVisibility
+					if secrets[name].RawValue != nil {
+						secretsMap[name]["raw"] = *secrets[name].RawValue
+					} else {
+						secretsMap[name]["raw"] = nil
+					}
+				}
 			}
 		}
 
@@ -250,9 +268,17 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 		vals := []string{}
 		for _, secret := range matchedSecrets {
 			if raw {
-				vals = append(vals, secret.RawValue)
+				if secret.RawValue != nil {
+					vals = append(vals, *secret.RawValue)
+				} else {
+					vals = append(vals, "")
+				}
 			} else {
-				vals = append(vals, secret.ComputedValue)
+				if secret.ComputedValue != nil {
+					vals = append(vals, *secret.ComputedValue)
+				} else {
+					vals = append(vals, "")
+				}
 			}
 		}
 
@@ -268,10 +294,24 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 
 	var rows [][]string
 	for _, secret := range matchedSecrets {
-		row := []string{secret.Name, secret.ComputedValue}
-		if raw {
-			row = append(row, secret.RawValue)
+		var computedValue string
+		if secret.ComputedValue != nil {
+			computedValue = *secret.ComputedValue
+		} else {
+			computedValue = "[RESTRICTED]"
 		}
+
+		row := []string{secret.Name, computedValue}
+		if raw {
+			var rawValue string
+			if secret.RawValue != nil {
+				rawValue = *secret.RawValue
+			} else {
+				rawValue = "[RESTRICTED]"
+			}
+			row = append(row, rawValue)
+		}
+
 		row = append(row, secret.Note)
 
 		rows = append(rows, row)

--- a/pkg/printer/enclave.go
+++ b/pkg/printer/enclave.go
@@ -202,7 +202,7 @@ func ProjectInfo(info models.ProjectInfo, jsonFlag bool) {
 }
 
 // Secrets print secrets
-func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, jsonFlag bool, plain bool, raw bool, copy bool) {
+func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, jsonFlag bool, plain bool, raw bool, copy bool, visibility bool) {
 	if len(secretsToPrint) == 0 {
 		for name := range secrets {
 			secretsToPrint = append(secretsToPrint, name)
@@ -286,9 +286,16 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 		return
 	}
 
-	headers := []string{"name", "value"}
+	headers := []string{"name"}
+	if visibility {
+		headers = append(headers, "visibility")
+	}
+	headers = append(headers, "value")
 	if raw {
-		headers = append(headers, "raw")
+		if visibility {
+			headers = append(headers, "raw visibility")
+		}
+		headers = append(headers, "raw value")
 	}
 	headers = append(headers, "note")
 
@@ -301,13 +308,20 @@ func Secrets(secrets map[string]models.ComputedSecret, secretsToPrint []string, 
 			computedValue = "[RESTRICTED]"
 		}
 
-		row := []string{secret.Name, computedValue}
+		row := []string{secret.Name}
+		if visibility {
+			row = append(row, secret.ComputedVisibility)
+		}
+		row = append(row, computedValue)
 		if raw {
 			var rawValue string
 			if secret.RawValue != nil {
 				rawValue = *secret.RawValue
 			} else {
 				rawValue = "[RESTRICTED]"
+			}
+			if visibility {
+				row = append(row, secret.RawVisibility)
 			}
 			row = append(row, rawValue)
 		}


### PR DESCRIPTION
This PR adds CLI support for secret visibility types. It:
  - Correctly handles NULLs and includes the vistypes when using `doppler secrets --json`
  - Prints `[RESTRICTED]` in the table when appropriate
  - Adds the `--visibility` flag to explicitly show the visibility types in the table

Note that this should only be merged after visibility types has been released as the code expects the new properties from the API.

```
» doppler secrets
┌──────────────────────┬─────────────────────────────────────┬──────┐
│ NAME                 │ VALUE                               │ NOTE │
├──────────────────────┼─────────────────────────────────────┼──────┤
│ S1                   │ [RESTRICTED]                        │      │
│ S2                   │ v2                                  │      │
│ S3                   │ v3                                  │      │
└──────────────────────┴─────────────────────────────────────┴──────┘

» doppler secrets --visibility
┌──────────────────────┬────────────┬─────────────────────────────────────┬──────┐
│ NAME                 │ VISIBILITY │ VALUE                               │ NOTE │
├──────────────────────┼────────────┼─────────────────────────────────────┼──────┤
│ S1                   │ restricted │ [RESTRICTED]                        │      │
│ S2                   │ masked     │ v2                                  │      │
│ S3                   │ masked     │ v3                                  │      │
└──────────────────────┴────────────┴─────────────────────────────────────┴──────┘

» doppler secrets --visibility --raw
┌──────────────────────┬────────────┬──────────────┬────────────────┬──────────────────────────┬──────┐
│ NAME                 │ VISIBILITY │ VALUE        │ RAW VISIBILITY │ RAW VALUE                │ NOTE │
├──────────────────────┼────────────┼──────────────┼────────────────┼──────────────────────────┼──────┤
│ S1                   │ restricted │ [RESTRICTED] │ unmasked       │ ${stg.RESTRICTED_SECRET} │      │
│ S2                   │ masked     │ v2           │ masked         │ v2                       │      │
│ S3                   │ masked     │ v3           │ masked         │ v3                       │      │
└──────────────────────┴────────────┴──────────────┴────────────────┴──────────────────────────┴──────┘

» doppler secrets --json --raw | jq
{
  "S1": {
    "computed": null,
    "computedVisibility": "restricted",
    "note": "",
    "raw": "${stg.RESTRICTED_SECRET}",
    "rawVisibility": "unmasked"
  },
  "S2": {
    "computed": "v2",
    "computedVisibility": "masked",
    "note": "",
    "raw": "v2",
    "rawVisibility": "masked"
  },
  "S3": {
    "computed": "v3",
    "computedVisibility": "masked",
    "note": "",
    "raw": "v3",
    "rawVisibility": "masked"
  }
}
```

Closes ENG-6140