### PR TITLE
ENG-6137: Fix bug where interactive setups weren't working

### DIFF
--- a/pkg/controllers/repo_config.go
+++ b/pkg/controllers/repo_config.go
@@ -68,6 +68,12 @@ func RepoConfig() (models.MultiRepoConfig, Error) {
 		return repoConfig, Error{}
 	} else if utils.Exists(ymlRepoConfigFile) {
 		utils.LogWarning(fmt.Sprintf("Found %s file, please rename to %s for repo configuration", ymlRepoConfigFile, repoConfigFileName))
+	} else {
+		// If no config file exists, then this is for an interactive setup, so
+		// return a MultiRepoConfig object containing an empty ProjectConfig object
+		var repoConfig models.MultiRepoConfig
+		repoConfig.Setup = append(repoConfig.Setup, models.ProjectConfig{})
+		return repoConfig, Error{}
 	}
 	return models.MultiRepoConfig{}, Error{}
 }


### PR DESCRIPTION
This fixes a bug introduced in #374 that caused interactive invocations of `doppler setup` to operate as no-ops.