### PR TITLE
Fix salus failures

### DIFF
--- a/.github/workflows/salus.yaml
+++ b/.github/workflows/salus.yaml
@@ -6,6 +6,18 @@ on:
 name: Salus security scan
 
 jobs:
+  semgrep:
+    runs-on: ubuntu-latest
+    name: Semgrep
+    steps:
+      - uses: actions/checkout@v2
+      - name: Scan
+        id: scan
+        run: |
+          set -eo pipefail;
+          python3 -m pip install semgrep;
+          semgrep scan --error --config https://semgrep.dev/p/trailofbits --config semgrep_configs
+
   salus_scan_job:
     runs-on: ubuntu-latest
     name: Salus Security Scan

--- a/.github/workflows/salus.yaml
+++ b/.github/workflows/salus.yaml
@@ -13,7 +13,7 @@ jobs:
     - uses: actions/checkout@v2
     - name: Salus Scan
       id: salus_scan
-      uses: federacy/scan-action@0.1.3
+      uses: federacy/scan-action@0.1.4
       env:
         SALUS_CONFIGURATION: "file://salus-config.yaml"
       with:

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -226,7 +226,11 @@ func performRequest(req *http.Request, verifyTLS bool) (int, http.Header, []byte
 		resp, err := client.Do(req) // nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
 		if err != nil {
 			if resp != nil {
-				defer resp.Body.Close()
+				defer func() {
+					if closeErr := resp.Body.Close(); closeErr != nil {
+						utils.LogDebug(closeErr.Error())
+					}
+				}()
 			}
 
 			utils.LogDebug(err.Error())
@@ -264,7 +268,11 @@ func performRequest(req *http.Request, verifyTLS bool) (int, http.Header, []byte
 	})
 
 	if response != nil {
-		defer response.Body.Close()
+		defer func() {
+			if closeErr := response.Body.Close(); closeErr != nil {
+				utils.LogDebug(closeErr.Error())
+			}
+		}()
 	}
 
 	if requestErr != nil && response == nil {

--- a/salus-config.yaml
+++ b/salus-config.yaml
@@ -9,7 +9,16 @@ reports:
     format: txt
 
 # All scanners to execute, or the String value "all"/"none"
-active_scanners: "all"
+active_scanners:
+  - Gosec
+  - PatternSearch
+  - RepoNotEmpty
+  - Semgrep
+  - GoOSV
+  - GoVersionScanner
+  - GoPackageScanner
+  - ReportGoDep
+  - Trufflehog
 
 # All scanners that will exit non-zero if they fail, or the String value "all"/"none"
 enforced_scanners: "all"

--- a/salus-config.yaml
+++ b/salus-config.yaml
@@ -13,7 +13,6 @@ active_scanners:
   - Gosec
   - PatternSearch
   - RepoNotEmpty
-  - Semgrep
   - GoOSV
   - GoVersionScanner
   - GoPackageScanner
@@ -24,19 +23,6 @@ active_scanners:
 enforced_scanners: "all"
 
 scanner_configs:
-  Semgrep:
-    matches:
-      - config: https://semgrep.dev/p/trailofbits
-        forbidden: true
-      - config: semgrep_configs/print.yaml
-        forbidden: true
-        exclude:
-          - pkg/printer
-          - pkg/utils/log.go
-      - config: semgrep_configs/writefile.yaml
-        forbidden: true
-        exclude:
-          - pkg/utils/io.go
   GoVersionScanner:
     error:
       min_version: '1.18.0'

--- a/semgrep_configs/print.yaml
+++ b/semgrep_configs/print.yaml
@@ -8,3 +8,7 @@ rules:
       - pattern-regex: fmt\.Print[a-z]*
       - pattern-regex: fmt\.Fprint[a-z]*
     severity: ERROR
+    paths:
+      exclude:
+        - /pkg/printer
+        - /pkg/utils/log.go

--- a/semgrep_configs/writefile.yaml
+++ b/semgrep_configs/writefile.yaml
@@ -7,3 +7,6 @@ rules:
     pattern-either:
       - pattern: ioutil.WriteFile
     severity: ERROR
+    paths:
+      exclude:
+        - /pkg/utils/io.go


### PR DESCRIPTION
We started to notice errors from Salus relating to `cargo-audit`, which we don't use, so we now define the specific scanners for Salus to run.

The GitHub Action that we're using automatically pulls the latest Salus image which included some semgrep changes that seem to break with our custom rules. For this reason, I've also pulls semgrep into a separate step.