### PR TITLE
Allow MINGW64 environments to update

### DIFF
--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -30,7 +30,7 @@ var updateCmd = &cobra.Command{
 	Short: "update the Doppler CLI",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
-		if utils.IsWindows() {
+		if !utils.CanUpdate() {
 			utils.HandleError(fmt.Errorf("this command is not yet implemented for your operating system"))
 		}
 

--- a/pkg/controllers/update.go
+++ b/pkg/controllers/update.go
@@ -64,7 +64,15 @@ func RunInstallScript() (bool, string, Error) {
 	command := []string{tmpFile, "--debug"}
 
 	startTime = time.Now()
-	out, err := exec.Command(command[0], command[1:]...).CombinedOutput() // #nosec G204
+	var out []byte
+	if utils.IsWindows() {
+		// executing in sh on Windows avoids errors like this:
+		// Doppler Error: fork/exec C:\...\.install.sh.1063970983: %1 is not a valid Win32 application.
+		out, err = exec.Command("sh", command...).CombinedOutput() // #nosec G204
+	} else {
+		out, err = exec.Command(command[0], command[1:]...).CombinedOutput() // #nosec G204
+	}
+
 	executeDuration := time.Now().Sub(startTime).Milliseconds()
 
 	strOut := string(out)

--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -382,9 +382,26 @@ func HostArch() string {
 	return arch
 }
 
+// CanUpdate whether the host os supports updating via CLI
+func CanUpdate() bool {
+	if IsMINGW64() {
+		return true
+	} else if IsWindows() {
+		return false
+	} else {
+		return true
+	}
+}
+
 // IsWindows whether the host os is Windows
 func IsWindows() bool {
 	return runtime.GOOS == "windows"
+}
+
+// IsMINGW64 whether the host os is running in a MINGW64-based
+// environment like Git Bash, Cygwin, etc.
+func IsMINGW64() bool {
+	return os.Getenv("MSYSTEM") == "MINGW64"
 }
 
 // IsMacOS whether the host os is macOS


### PR DESCRIPTION
We added support for installing the CLI via the shell script installation method under Git Bash in #325. That works great, but when you try updating via `doppler update` after doing that, you're greeted with a `this command is not yet implemented for your operating system` error. This update adds an additional check that looks for a value of `MINGW64` in the `MSYSTEM` environment variable (which Git Bash sets automatically) and if it finds that allows for updates (the typical Go OS checks return a generic "windows" for Git Bash, which is why we had to resort to the environment variable). It also swaps to executing the install script inside of `sh`.