### PR TITLE
Fix bug where --scope was ignored in manual setup

### DIFF
--- a/pkg/controllers/repo_config.go
+++ b/pkg/controllers/repo_config.go
@@ -20,6 +20,7 @@ import (
 	"io/ioutil"
 	"path/filepath"
 
+	"github.com/DopplerHQ/cli/pkg/configuration"
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/utils"
 	"gopkg.in/yaml.v3"
@@ -72,7 +73,7 @@ func RepoConfig() (models.MultiRepoConfig, Error) {
 		// If no config file exists, then this is for an interactive setup, so
 		// return a MultiRepoConfig object containing an empty ProjectConfig object
 		var repoConfig models.MultiRepoConfig
-		repoConfig.Setup = append(repoConfig.Setup, models.ProjectConfig{})
+		repoConfig.Setup = append(repoConfig.Setup, models.ProjectConfig{Path: configuration.Scope})
 		return repoConfig, Error{}
 	}
 	return models.MultiRepoConfig{}, Error{}


### PR DESCRIPTION
This fixes a bug where `doppler setup` wasn't working as expected if you passed in `--scope`. Rather than scoping to the directory you passed in, it would always use the current directory.

Fixes ENG-6276.