### PR TITLE
Support passing list of secrets to --preserve-env flag

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -429,3 +429,12 @@ func RedactAuthToken(token string) string {
 
 	return "[REDACTED]"
 }
+
+func Contains[T comparable](s []T, e T) bool {
+	for _, v := range s {
+		if v == e {
+			return true
+		}
+	}
+	return false
+}

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -114,4 +114,29 @@ beforeEach
 value="$(TEST="foo" "$DOPPLER_BINARY" run --preserve-env=true -- printenv TEST)"
 [[ "$value" == "foo" ]] || error "ERROR: existing env vars not honored when preserve-env flag passed value of \"true\""
 
+beforeEach
+
+# verify preserve-env flag honors secret name
+value="$(TEST="foo" "$DOPPLER_BINARY" run --preserve-env="TEST" -- printenv TEST)"
+[[ "$value" == "foo" ]] || error "ERROR: existing env var not honored when preserve-env flag passed secret name"
+
+beforeEach
+
+# verify preserve-env flag only overrides specified secrets
+# TEST should be read from env but FOO should be read from Doppler
+value="$(TEST="foo" FOO="123" "$DOPPLER_BINARY" run --preserve-env="TEST" --command "printenv TEST && printenv FOO")"
+[[ "$value" == "$(echo -e "foo\nbar")" ]] || error "ERROR: env vars not honored when preserve-env flag passed one secret name"
+
+beforeEach
+
+# verify preserve-env flag honors list of secret names
+value="$(TEST="foo" "$DOPPLER_BINARY" run --preserve-env="INVALID,TEST" -- printenv TEST)"
+[[ "$value" == "foo" ]] || error "ERROR: existing env var not honored when preserve-env flag passed list of secret names"
+
+beforeEach
+
+# verify preserve-env flag ignores nonexistent secrets
+value="$(TEST="foo" "$DOPPLER_BINARY" run --preserve-env="INVALID" -- printenv TEST)"
+[[ "$value" == "abc" ]] || error "ERROR: existing env var not ignored when preserve-env flag passed list of nonexistent secret names"
+
 afterAll

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -88,4 +88,30 @@ beforeEach
 # verify flags specified after '--' are passed to subcommand
 "$DOPPLER_BINARY" run -- true --config invalidconfig || error "ERROR: flags specified after '--' are improperly handled"
 
+### --preserve-env flag
+
+beforeEach
+
+# verify not specifying preserve-env flag results in ignoring existing env vars
+value="$(TEST="foo" "$DOPPLER_BINARY" run -- printenv TEST)"
+[[ "$value" == "abc" ]] || error "ERROR: existing env vars not ignored when omitting preserve-env flag"
+
+beforeEach
+
+# verify preserve-env flag value of 'false' results in ignoring existing env vars
+value="$(TEST="foo" "$DOPPLER_BINARY" run --preserve-env=false -- printenv TEST)"
+[[ "$value" == "abc" ]] || error "ERROR: existing env vars not ignored when preserve-env flag passed value of \"false\""
+
+beforeEach
+
+# verify preserve-env flag without value preserves all existing env vars
+value="$(TEST="foo" "$DOPPLER_BINARY" run --preserve-env -- printenv TEST)"
+[[ "$value" == "foo" ]] || error "ERROR: existing env vars not honored when preserve-env flag specified without value"
+
+beforeEach
+
+# verify preserve-env flag value of 'true' preserves all existing env vars
+value="$(TEST="foo" "$DOPPLER_BINARY" run --preserve-env=true -- printenv TEST)"
+[[ "$value" == "foo" ]] || error "ERROR: existing env vars not honored when preserve-env flag passed value of \"true\""
+
 afterAll


### PR DESCRIPTION
This PR changes the `--preserve-env` flag from a boolean flag to a string flag. It supports the same syntax as before (i.e. `--preserve-env` is equivalent to `--preserve-env=true`) while allowing you to specify a comma separated list of secrets to override. For example, `DEBUG=1 doppler run --preserve-env="DEBUG" -- printenv DEBUG`. To ensure backwards compatibility, I verified that the tests in the first commit passed before pushing up the second commit.

Closes ENG-6327.