### PR TITLE
Add lower kebab name transformer

### DIFF
--- a/pkg/models/secrets_name_transformer.go
+++ b/pkg/models/secrets_name_transformer.go
@@ -31,6 +31,11 @@ var CamelTransformer = &SecretsNameTransformer{
 	Type:      "camel",
 	EnvCompat: true,
 }
+var LowerKebabTransformer = &SecretsNameTransformer{
+	Name:      "Lower Kebab",
+	Type:      "lower-kebab",
+	EnvCompat: true,
+}
 var LowerSnakeTransformer = &SecretsNameTransformer{
 	Name:      "Lower Snake",
 	Type:      "lower-snake",
@@ -55,6 +60,7 @@ var DotNETEnvTransformer = &SecretsNameTransformer{
 var SecretsNameTransformersList = []*SecretsNameTransformer{
 	UpperCamelTransformer,
 	CamelTransformer,
+	LowerKebabTransformer,
 	LowerSnakeTransformer,
 	TFVarTransformer,
 	DotNETTransformer,


### PR DESCRIPTION
This adds a new `lower-kebab` name transformer that will transform secrets from `SOME_SECRET` to `some-secret`.

Closes ENG-6375.