### PR TITLE
Add support for restarting process when secrets change

### DIFF
--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -36,9 +36,9 @@ jobs:
         path: ./dist/doppler_darwin_amd64_v1/doppler
     - uses: actions/upload-artifact@master
       with:
-        name: Linux build (amd64)
-        path: ./dist/doppler_linux_amd64/doppler
+        name: macOS build (arm64)
+        path: ./dist/doppler_darwin_arm64/doppler
     - uses: actions/upload-artifact@master
       with:
-        name: Windows build (amd64)
-        path: ./dist/doppler_windows_amd64/doppler.exe
+        name: Linux build (amd64)
+        path: ./dist/doppler_linux_amd64_v1/doppler

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -33,7 +33,7 @@ jobs:
     - uses: actions/upload-artifact@master
       with:
         name: macOS build (amd64)
-        path: ./dist/doppler_darwin_amd64/doppler
+        path: ./dist/doppler_darwin_amd64_v1/doppler
     - uses: actions/upload-artifact@master
       with:
         name: Linux build (amd64)

--- a/pkg/cmd/enclave_secrets.go
+++ b/pkg/cmd/enclave_secrets.go
@@ -136,7 +136,7 @@ func init() {
 	enclaveSecretsDownloadCmd.Flags().String("format", models.JSON.String(), "output format. one of [json, env]")
 	enclaveSecretsDownloadCmd.Flags().String("passphrase", "", "passphrase to use for encrypting the secrets file. the default passphrase is computed using your current configuration.")
 	enclaveSecretsDownloadCmd.Flags().Bool("no-file", false, "print the response to stdout")
-	enclaveSecretsDownloadCmd.Flags().String("name-transformer", "", fmt.Sprintf("(BETA) output name transformer. one of %v", validNameTransformersList))
+	enclaveSecretsDownloadCmd.Flags().String("name-transformer", "", fmt.Sprintf("output name transformer. one of %v", validNameTransformersList))
 	enclaveSecretsDownloadCmd.Flags().Duration("dynamic-ttl", 0, "(BETA) dynamic secrets will expire after specified duration, (e.g. '3h', '15m')")
 	// fallback flags
 	enclaveSecretsDownloadCmd.Flags().String("fallback", "", "path to the fallback file. encrypted secrets are written to this file after each successful fetch. secrets will be read from this file if subsequent connections are unsuccessful.")

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -262,7 +262,7 @@ doppler run --mount secrets.json -- cat secrets.json`,
 			// remove any reserved keys from secrets
 			reservedKeys := []string{"PATH", "PS1", "HOME"}
 			for _, reservedKey := range reservedKeys {
-				if _, found := dopplerSecrets[reservedKey]; found == true {
+				if _, found := dopplerSecrets[reservedKey]; found {
 					utils.LogDebug(fmt.Sprintf("Ignoring reserved secret %s", reservedKey))
 					delete(dopplerSecrets, reservedKey)
 				}

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -702,7 +702,7 @@ func init() {
 	// we must specify a default when no value is passed as this flag used to be a boolean
 	// https://github.com/spf13/pflag#setting-no-option-default-values-for-flags
 	runCmd.Flags().Lookup("preserve-env").NoOptDefVal = "true"
-	runCmd.Flags().String("name-transformer", "", fmt.Sprintf("(BETA) output name transformer. one of %v", validEnvCompatNameTransformersList))
+	runCmd.Flags().String("name-transformer", "", fmt.Sprintf("output name transformer. one of %v", validEnvCompatNameTransformersList))
 	runCmd.RegisterFlagCompletionFunc("name-transformer", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return models.SecretsEnvCompatNameTransformerTypes, cobra.ShellCompDirectiveDefault
 	})

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -162,16 +162,6 @@ doppler run --mount secrets.json -- cat secrets.json`,
 			utils.HandleError(errors.New("--mount-template must be used with --mount"))
 		}
 
-		originalEnv := os.Environ()
-		existingEnvKeys := map[string]string{}
-		for _, envVar := range originalEnv {
-			// key=value format
-			parts := strings.SplitN(envVar, "=", 2)
-			key := parts[0]
-			value := parts[1]
-			existingEnvKeys[key] = value
-		}
-
 		var templateBody string
 		if shouldMountFile {
 			if shouldAutoDetectFormat {
@@ -288,7 +278,7 @@ doppler run --mount secrets.json -- cat secrets.json`,
 			terminatedByWatch = false
 
 			var env []string
-			env, cleanupMount = controllers.PrepareSecrets(secrets, originalEnv, preserveEnv, existingEnvKeys, mountOptions)
+			env, cleanupMount = controllers.PrepareSecrets(secrets, os.Environ(), preserveEnv, mountOptions)
 
 			global.WaitGroup.Add(1)
 

--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -16,39 +16,31 @@ limitations under the License.
 package cmd
 
 import (
-	"encoding/json"
 	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
+	"sync"
+	"syscall"
 	"time"
 
 	"github.com/DopplerHQ/cli/pkg/configuration"
 	"github.com/DopplerHQ/cli/pkg/controllers"
 	"github.com/DopplerHQ/cli/pkg/crypto"
+	"github.com/DopplerHQ/cli/pkg/global"
 	"github.com/DopplerHQ/cli/pkg/http"
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/utils"
 	"github.com/mattn/go-isatty"
 	"github.com/spf13/cobra"
-	"gopkg.in/gookit/color.v1"
 )
 
 var defaultFallbackDir string
 
 const defaultFallbackFileMaxAge = 14 * 24 * time.Hour // 14 days
-
-type fallbackOptions struct {
-	enable             bool
-	path               string
-	legacyPath         string
-	readonly           bool
-	exclusive          bool
-	exitOnWriteFailure bool
-	passphrase         string
-}
 
 var secretsToInclude []string
 
@@ -90,6 +82,7 @@ doppler run --mount secrets.json -- cat secrets.json`,
 		forwardSignals := utils.GetBoolFlag(cmd, "forward-signals")
 		localConfig := configuration.LocalConfig(cmd)
 		dynamicSecretsTTL := utils.GetDurationFlag(cmd, "dynamic-ttl")
+		exitOnMissingIncludedSecrets := !cmd.Flags().Changed("no-exit-on-missing-only-secrets")
 
 		utils.RequireValue("token", localConfig.Token.Value)
 
@@ -131,14 +124,14 @@ doppler run --mount secrets.json -- cat secrets.json`,
 			}
 		}
 
-		fallbackOpts := fallbackOptions{
-			enable:             enableFallback,
-			path:               fallbackPath,
-			legacyPath:         legacyFallbackPath,
-			readonly:           fallbackReadonly,
-			exclusive:          fallbackOnly,
-			exitOnWriteFailure: exitOnWriteFailure,
-			passphrase:         passphrase,
+		fallbackOpts := controllers.FallbackOptions{
+			Enable:             enableFallback,
+			Path:               fallbackPath,
+			LegacyPath:         legacyFallbackPath,
+			Readonly:           fallbackReadonly,
+			Exclusive:          fallbackOnly,
+			ExitOnWriteFailure: exitOnWriteFailure,
+			Passphrase:         passphrase,
 		}
 
 		mountPath := cmd.Flag("mount").Value.String()
@@ -213,113 +206,214 @@ doppler run --mount secrets.json -- cat secrets.json`,
 			}
 		}
 
-		// retrieve secrets
-		dopplerSecrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format, secretsToInclude)
-
-		// The potentially dangerous secret names only are only dangerous when they are set
-		// as environment variables since they have the potential to change the default shell behavior.
-		// When mounting the secrets into a file these are not dangerous
-		if !shouldMountFile {
-			if err := controllers.CheckForDangerousSecretNames(dopplerSecrets); err != nil {
-				utils.LogWarning(err.Error())
-			}
+		mountOptions := controllers.MountOptions{
+			Enable:   shouldMountFile,
+			Format:   mountFormat,
+			Path:     mountPath,
+			Template: templateBody,
+			MaxReads: maxReads,
 		}
 
-		if len(secretsToInclude) > 0 {
-			noExitOnMissingIncludedSecrets := cmd.Flags().Changed("no-exit-on-missing-only-secrets")
-			missingSecrets := controllers.MissingSecrets(dopplerSecrets, secretsToInclude)
-			if len(missingSecrets) > 0 {
-				err := fmt.Errorf("the following secrets you are trying to include do not exist in your config:\n- %v", strings.Join(missingSecrets, "\n- "))
-				if noExitOnMissingIncludedSecrets {
-					utils.LogWarning(err.Error())
-				} else {
-					utils.HandleError(err)
-				}
-			}
+		watch := cmd.Flags().Changed("watch")
+
+		if watch && fallbackOpts.Exclusive {
+			utils.LogWarning("--watch has no effect when used with --fallback-only")
+			watch = false
 		}
 
-		env := []string{}
-		secrets := map[string]string{}
-		var onExit func()
-		if shouldMountFile {
-			secrets = dopplerSecrets
-			env = originalEnv
-
-			secretsBytes, err := controllers.SecretsToBytes(secrets, mountFormat, templateBody)
-			if !err.IsNil() {
-				utils.HandleError(err.Unwrap(), err.Message)
-			}
-			absMountPath, handler, err := controllers.MountSecrets(secretsBytes, mountPath, maxReads)
-			if !err.IsNil() {
-				utils.HandleError(err.Unwrap(), err.Message)
-			}
-			mountPath = absMountPath
-			onExit = handler
-
-			// export path to mounted file
-			env = append(env, fmt.Sprintf("%s=%s", "DOPPLER_CLI_SECRETS_PATH", mountPath))
-		} else {
-			// remove any reserved keys from secrets
-			reservedKeys := []string{"PATH", "PS1", "HOME"}
-			for _, reservedKey := range reservedKeys {
-				if _, found := dopplerSecrets[reservedKey]; found {
-					utils.LogDebug(fmt.Sprintf("Ignoring reserved secret %s", reservedKey))
-					delete(dopplerSecrets, reservedKey)
-				}
-			}
-
-			if preserveEnv != "false" {
-				secretsToPreserve := strings.Split(preserveEnv, ",")
-
-				// use doppler secrets
-				for name, value := range dopplerSecrets {
-					secrets[name] = value
-				}
-				// then use existing env vars
-				for name, value := range existingEnvKeys {
-					if preserveEnv != "true" && !utils.Contains(secretsToPreserve, name) {
-						continue
-					}
-
-					if _, found := secrets[name]; found == true {
-						utils.LogDebug(fmt.Sprintf("Ignoring Doppler secret %s", name))
-					}
-					secrets[name] = value
-				}
-			} else {
-				// use existing env vars
-				for name, value := range existingEnvKeys {
-					secrets[name] = value
-				}
-				// then use doppler secrets
-				for name, value := range dopplerSecrets {
-					secrets[name] = value
-				}
-			}
-
-			for _, envVar := range utils.MapToEnvFormat(secrets, false) {
-				env = append(env, envVar)
-			}
-		}
-
-		exitCode := 0
+		var c *exec.Cmd
+		var cleanupMount func()
 		var err error
+		var lastSecretsFetch time.Time
+		var lastUpdateEvent time.Time
+		// used to ensure we only run one process at a time
+		var processMutex sync.Mutex
+		// used to ensure we only process one event at a time
+		var watchMutex sync.Mutex
+		// this variable has the potential to be racey, but is made safe by our use of the mutex
+		terminatedByWatch := false
 
-		if cmd.Flags().Changed("command") {
-			command := cmd.Flag("command").Value.String()
-			exitCode, err = utils.RunCommandString(command, env, os.Stdin, os.Stdout, os.Stderr, forwardSignals, onExit)
-		} else {
-			exitCode, err = utils.RunCommand(args, env, os.Stdin, os.Stdout, os.Stderr, forwardSignals, onExit)
-		}
-
-		if err != nil {
-			if strings.HasPrefix(err.Error(), "exec") || strings.HasPrefix(err.Error(), "fork/exec") {
-				utils.LogError(err)
+		startProcess := func() {
+			// ensure we can fetch the new secrets before restarting the process
+			secrets := controllers.FetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format, secretsToInclude)
+			secretsFetchedAt := time.Now()
+			if secretsFetchedAt.After(lastSecretsFetch) {
+				lastSecretsFetch = secretsFetchedAt
 			}
-			utils.LogDebugError(err)
+
+			controllers.ValidateSecrets(secrets, secretsToInclude, exitOnMissingIncludedSecrets, mountOptions)
+
+			isRestart := c != nil
+			// terminate the old process
+			if isRestart {
+				terminatedByWatch = true
+
+				// killing the process here will cause the cleanup goroutine below to run, thereby unlocking the mutex
+				utils.LogDebug(fmt.Sprintf("Sending SIGTERM to process %d", c.Process.Pid))
+				c.Process.Signal(syscall.SIGTERM)
+				// wait up to 10 sec for the process to exit
+				for i := 0; i < 10; i++ {
+					if !utils.IsProcessRunning(c.Process) {
+						// process has been killed
+						break
+					}
+					if i == 5 {
+						utils.LogDebug("Still waiting for process to exit...")
+					}
+					time.Sleep(time.Second)
+				}
+
+				// if the process still hasn't exited, forcefully kill it
+				if utils.IsProcessRunning(c.Process) {
+					utils.LogDebug("Process has not exited; sending SIGKILL to process")
+					if e := c.Process.Kill(); e != nil {
+						utils.LogDebugError(e)
+					}
+				}
+
+				c = nil
+			}
+
+			// this lock ensures the old process, if any, has exited before we start a new process
+			processMutex.Lock()
+
+			// we could have received a new update event while we were waiting for the previous process to terminate.
+			// if so, don't bother starting the process as it'll just be immediately restarted again after fetching the latest secrets
+			if lastUpdateEvent.After(secretsFetchedAt) {
+				utils.LogDebug("Not starting new process; more recent update event has been received")
+				processMutex.Unlock()
+				return
+			}
+
+			terminatedByWatch = false
+
+			var env []string
+			env, cleanupMount = controllers.PrepareSecrets(secrets, originalEnv, preserveEnv, existingEnvKeys, mountOptions)
+
+			global.WaitGroup.Add(1)
+
+			if isRestart {
+				utils.Log("Restarting process")
+			}
+
+			// start the process
+			c, err = controllers.Run(cmd, args, env, forwardSignals)
+			if err != nil {
+				defer global.WaitGroup.Done()
+				if cleanupMount != nil {
+					cleanupMount()
+				}
+				utils.HandleError(err)
+			}
+
+			go func() {
+				defer processMutex.Unlock()
+				defer global.WaitGroup.Done()
+
+				exitCode, err := utils.WaitCommand(c)
+
+				if cleanupMount != nil {
+					cleanupMount()
+
+					// add arbitrary delay before re-mounting secrets to avoid a race-related "broken pipe" when writing to the named pipe
+					time.Sleep(100 * time.Millisecond)
+				}
+
+				// ignore errors if we were responsible for killing the process
+				if !terminatedByWatch {
+					if err != nil {
+						if strings.HasPrefix(err.Error(), "exec") || strings.HasPrefix(err.Error(), "fork/exec") {
+							utils.LogError(err)
+						}
+						utils.LogDebugError(err)
+					}
+
+					os.Exit(exitCode)
+				}
+			}()
 		}
 
-		os.Exit(exitCode)
+		watchHandler := func(data []byte) {
+			event := controllers.ParseWatchEvent(data)
+			if event.Type == "" {
+				return
+			}
+
+			// don't capture analytics for the ping event; it's too noisy
+			if event.Type != "ping" {
+				controllers.CaptureEvent("WatchDataReceived", map[string]interface{}{"event": event.Type})
+			}
+
+			if event.Type == "secrets.update" {
+				eventReceived := time.Now()
+				if lastUpdateEvent.Before(eventReceived) {
+					lastUpdateEvent = eventReceived
+				}
+
+				watchMutex.Lock()
+				defer watchMutex.Unlock()
+
+				utils.LogDebug(fmt.Sprintf("Received %s event", event.Type))
+
+				// due to the lock, we only process one event at a time, so this event could have come in many seconds ago.
+				// it's possible we've already refetched secrets since then, in which case we don't need to re-fetch
+				if lastSecretsFetch.After(eventReceived) {
+					utils.LogDebug("Ignoring event; newer secrets have already been fetched")
+					return
+				}
+
+				startProcess()
+			} else if event.Type == "connected" {
+				utils.LogDebug("Connected to secrets stream")
+			} else if event.Type == "ping" {
+				// do nothing
+			} else {
+				utils.Log(fmt.Sprintf("Received unknown event: %s", event.Type))
+			}
+		}
+
+		startProcess()
+
+		// initiate watch logic after starting the process so that failing to watch just degrades to normal 'run' behavior
+		if watch {
+			maxAttempts := 10
+			attempt := 0
+			_ = utils.Retry(maxAttempts, time.Second, func() error {
+				attempt = attempt + 1
+
+				statusCode, headers, httpErr := http.WatchSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, watchHandler)
+				if !httpErr.IsNil() {
+					e := httpErr.Unwrap()
+
+					msg := "Unable to watch for secrets changes"
+					// a 200 is sent as soon as the connection is established, so if it dies after that the status code
+					// will still be 200. we should retry these requests
+					canRetry := http.IsRetry(statusCode, headers.Get("content-type")) || statusCode == 200
+					if canRetry && attempt < maxAttempts {
+						msg += ". Will retry"
+					}
+					if statusCode == 200 {
+						// this connection was likely killed due to a timeout, so we can log quietly
+						utils.LogDebugError(errors.New(msg))
+					} else {
+						utils.LogError(errors.New(msg))
+					}
+
+					controllers.CaptureEvent("WatchConnectionError", map[string]interface{}{"statusCode": statusCode, "canRetry": canRetry})
+
+					if statusCode != 0 {
+						e = fmt.Errorf("%s. Status code: %d", e, statusCode)
+					}
+					utils.LogDebugError(e)
+
+					if !canRetry {
+						return utils.StopRetryError(e)
+					}
+				}
+
+				return httpErr.Unwrap()
+			})
+		}
 	},
 }
 
@@ -402,192 +496,6 @@ var runCleanCmd = &cobra.Command{
 	},
 }
 
-// fetchSecrets from Doppler and handle fallback file
-func fetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOpts fallbackOptions, metadataPath string, nameTransformer *models.SecretsNameTransformer, dynamicSecretsTTL time.Duration, format models.SecretsFormat, secretNames []string) map[string]string {
-	if fallbackOpts.exclusive {
-		if !fallbackOpts.enable {
-			utils.HandleError(errors.New("Conflict: unable to specify --no-fallback with --fallback-only"))
-		}
-		return readFallbackFile(fallbackOpts.path, fallbackOpts.legacyPath, fallbackOpts.passphrase, false)
-	}
-
-	// this scenario likely isn't possible, but just to be safe, disable using cache when there's no metadata file
-	enableCache = enableCache && metadataPath != ""
-	etag := ""
-	if enableCache {
-		etag = getCacheFileETag(metadataPath, fallbackOpts.path)
-	}
-
-	statusCode, respHeaders, response, httpErr := http.DownloadSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer, etag, dynamicSecretsTTL, secretNames)
-	if !httpErr.IsNil() {
-		canUseFallback := statusCode != 401 && statusCode != 403 && statusCode != 404
-		if !canUseFallback {
-			utils.LogDebug(fmt.Sprintf("Received %v. Deleting (if exists) %v", statusCode, fallbackOpts.path))
-			os.Remove(fallbackOpts.path)
-			utils.LogDebug(fmt.Sprintf("Received %v. Deleting (if exists) %v", statusCode, fallbackOpts.legacyPath))
-			os.Remove(fallbackOpts.legacyPath)
-			utils.LogDebug(fmt.Sprintf("Received %v. Deleting (if exists) %v", statusCode, metadataPath))
-			os.Remove(metadataPath)
-		}
-
-		if fallbackOpts.enable && canUseFallback {
-			utils.Log("Unable to fetch secrets from the Doppler API")
-			utils.LogError(httpErr.Unwrap())
-			return readFallbackFile(fallbackOpts.path, fallbackOpts.legacyPath, fallbackOpts.passphrase, false)
-		}
-		utils.HandleError(httpErr.Unwrap(), httpErr.Message)
-	}
-
-	if enableCache && statusCode == 304 {
-		utils.LogDebug("Using cached secrets from fallback file")
-		cache, err := controllers.SecretsCacheFile(fallbackOpts.path, fallbackOpts.passphrase)
-		if !err.IsNil() {
-			utils.LogDebugError(err.Unwrap())
-			utils.LogDebug(err.Message)
-
-			// we have to exit here as we don't have any secrets to parse
-			utils.HandleError(err.Unwrap(), err.Message)
-		}
-
-		return cache
-	}
-
-	// ensure the response can be parsed before proceeding
-	secrets, err := parseSecrets(response)
-	if err != nil {
-		utils.LogDebugError(err)
-
-		if fallbackOpts.enable {
-			utils.Log("Unable to parse the Doppler API response")
-			utils.LogError(httpErr.Unwrap())
-			return readFallbackFile(fallbackOpts.path, fallbackOpts.legacyPath, fallbackOpts.passphrase, false)
-		}
-		utils.HandleError(err, "Unable to parse API response")
-	}
-
-	writeFallbackFile := fallbackOpts.enable && !fallbackOpts.readonly && nameTransformer == nil
-	if writeFallbackFile {
-		utils.LogDebug("Encrypting secrets")
-		encryptedResponse, err := crypto.Encrypt(fallbackOpts.passphrase, response, "base64")
-		if err != nil {
-			utils.HandleError(err, "Unable to encrypt your secrets. No fallback file has been written.")
-		}
-
-		utils.LogDebug(fmt.Sprintf("Writing to fallback file %s", fallbackOpts.path))
-		if err := utils.WriteFile(fallbackOpts.path, []byte(encryptedResponse), utils.RestrictedFilePerms()); err != nil {
-			utils.Log("Unable to write to fallback file")
-			if fallbackOpts.exitOnWriteFailure {
-				utils.HandleError(err, "", strings.Join(writeFailureMessage(), "\n"))
-			} else {
-				utils.LogDebugError(err)
-			}
-		}
-
-		if enableCache {
-			if etag := respHeaders.Get("etag"); etag != "" {
-				hash := crypto.Hash(encryptedResponse)
-
-				if err := controllers.WriteMetadataFile(metadataPath, etag, hash); !err.IsNil() {
-					utils.LogDebugError(err.Unwrap())
-					utils.LogDebug(err.Message)
-				}
-			} else {
-				utils.LogDebug("API response does not contain ETag")
-			}
-		}
-	}
-
-	return secrets
-}
-
-func writeFailureMessage() []string {
-	var msg []string
-
-	msg = append(msg, "")
-	msg = append(msg, "=== More Info ===")
-	msg = append(msg, "")
-	msg = append(msg, color.Green.Render("Why did doppler exit?"))
-	msg = append(msg, "Doppler failed to make a local backup of your secrets, known as a fallback file.")
-	msg = append(msg, "The most common cause for this is insufficient permissions, including trying to use a fallback file created by a different user.")
-	msg = append(msg, "")
-	msg = append(msg, color.Green.Render("Why does this matter?"))
-	msg = append(msg, "Without the fallback file, your secrets would be inaccessible in the event of a network outage or Doppler downtime.")
-	msg = append(msg, "This could mean your development is blocked, or it could mean that your production services can't start up.")
-	msg = append(msg, "")
-	msg = append(msg, color.Green.Render("What should I do now?"))
-	msg = append(msg, "1. You can change the location of the fallback file using the '--fallback' flag.")
-	msg = append(msg, "2. You can attempt to debug and fix the local error causing the write failure.")
-	msg = append(msg, "3. You can choose to ignore this error using the '--no-exit-on-write-failure' flag, but be forewarned that this is probably a really bad idea.")
-	msg = append(msg, "")
-	msg = append(msg, "Run 'doppler run --help' for more info.")
-	msg = append(msg, "")
-
-	return msg
-}
-
-func readFallbackFile(path string, legacyPath string, passphrase string, silent bool) map[string]string {
-	// avoid re-logging if re-running for legacy file
-	// TODO remove this when removing legacy path support
-	if !silent {
-		utils.Log("Reading secrets from fallback file")
-	}
-	utils.LogDebug(fmt.Sprintf("Using fallback file %s", path))
-
-	if _, err := os.Stat(path); err != nil {
-		if os.IsNotExist(err) {
-			// attempt to read from the legacy path, in case the fallback file was created with an older version of the CLI
-			// TODO remove this when releasing CLI v4 (DPLR-435)
-			if legacyPath != "" {
-				return readFallbackFile(legacyPath, "", passphrase, true)
-			}
-
-			utils.HandleError(errors.New("The fallback file does not exist"))
-		}
-
-		utils.HandleError(err, "Unable to read fallback file")
-	}
-
-	response, err := ioutil.ReadFile(path) // #nosec G304
-	if err != nil {
-		utils.HandleError(err, "Unable to read fallback file")
-	}
-
-	utils.LogDebug("Decrypting fallback file")
-	decryptedSecrets, err := crypto.Decrypt(passphrase, response)
-	if err != nil {
-		var msg []string
-		msg = append(msg, "")
-		msg = append(msg, "=== More Info ===")
-		msg = append(msg, "")
-		msg = append(msg, color.Green.Render("Why did decryption fail?"))
-		msg = append(msg, "The most common cause of decryption failure is using an incorrect passphrase.")
-		msg = append(msg, "The default passphrase is computed using your token, project, and config.")
-		msg = append(msg, "You must use the same token, project, and config that you used when saving the backup file.")
-		msg = append(msg, "")
-		msg = append(msg, color.Green.Render("What should I do now?"))
-		msg = append(msg, "Ensure you are using the same scope that you used when creating the fallback file.")
-		msg = append(msg, "Alternatively, manually specify your configuration using the appropriate flags (e.g. --project).")
-		msg = append(msg, "")
-		msg = append(msg, "Run 'doppler run --help' for more info.")
-		msg = append(msg, "")
-
-		utils.HandleError(err, "Unable to decrypt fallback file", strings.Join(msg, "\n"))
-	}
-
-	secrets, err := parseSecrets([]byte(decryptedSecrets))
-	if err != nil {
-		utils.HandleError(err, "Unable to parse fallback file")
-	}
-
-	return secrets
-}
-
-func parseSecrets(response []byte) (map[string]string, error) {
-	secrets := map[string]string{}
-	err := json.Unmarshal(response, &secrets)
-	return secrets, err
-}
-
 // legacyFallbackFile deprecated file path used by early versions of CLI v3
 func legacyFallbackFile(project string, config string) string {
 	name := fmt.Sprintf("%s:%s", project, config)
@@ -639,7 +547,7 @@ func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, format mod
 			if err != nil {
 				utils.LogDebug("Unable to create directory for fallback file")
 				if exitOnWriteFailure {
-					utils.HandleError(err, "Unable to create directory for fallback file", strings.Join(writeFailureMessage(), "\n"))
+					utils.HandleError(err, "Unable to create directory for fallback file", strings.Join(controllers.WriteFailureMessage(), "\n"))
 				}
 			}
 		}
@@ -656,34 +564,6 @@ func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, format mod
 	}
 
 	return fallbackPath, legacyFallbackPath
-}
-
-func getCacheFileETag(metadataPath string, cachePath string) string {
-	metadata, Err := controllers.MetadataFile(metadataPath)
-	if !Err.IsNil() {
-		utils.LogDebugError(Err.Unwrap())
-		utils.LogDebug(Err.Message)
-		return ""
-	}
-
-	if metadata.Hash == "" {
-		return metadata.ETag
-	}
-
-	// verify hash
-	cacheFileBytes, err := ioutil.ReadFile(cachePath) // #nosec G304
-	if err == nil {
-		cacheFileContents := string(cacheFileBytes)
-		hash := crypto.Hash(cacheFileContents)
-
-		if hash == metadata.Hash {
-			return metadata.ETag
-		}
-
-		utils.LogDebug("Fallback file failed hash check, ignoring cached secrets")
-	}
-
-	return ""
 }
 
 func init() {
@@ -727,6 +607,8 @@ func init() {
 	runCmd.Flags().Int("mount-max-reads", 0, "maximum number of times the mounted secrets file can be read (0 for unlimited)")
 	runCmd.Flags().StringSliceVar(&secretsToInclude, "only-secrets", []string{}, "only include the specified secrets")
 	runCmd.Flags().Bool("no-exit-on-missing-only-secrets", false, "do not exit on missing secrets via --only-secrets")
+	// we only restart the process if it hasn't already exited
+	runCmd.Flags().Bool("watch", false, "(BETA) automatically restart the process when secrets change")
 
 	// deprecated
 	runCmd.Flags().Bool("silent-exit", false, "disable error output if the supplied command exits non-zero")

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -456,16 +456,16 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 			metadataPath = controllers.MetadataFilePath(localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, format, nameTransformer, nil)
 		}
 
-		fallbackOpts := fallbackOptions{
-			enable:             enableFallback,
-			path:               fallbackPath,
-			legacyPath:         legacyFallbackPath,
-			readonly:           fallbackReadonly,
-			exclusive:          fallbackOnly,
-			exitOnWriteFailure: exitOnWriteFailure,
-			passphrase:         fallbackPassphrase,
+		fallbackOpts := controllers.FallbackOptions{
+			Enable:             enableFallback,
+			Path:               fallbackPath,
+			LegacyPath:         legacyFallbackPath,
+			Readonly:           fallbackReadonly,
+			Exclusive:          fallbackOnly,
+			ExitOnWriteFailure: exitOnWriteFailure,
+			Passphrase:         fallbackPassphrase,
 		}
-		secrets := fetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format, nil)
+		secrets := controllers.FetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format, nil)
 
 		var err error
 		body, err = json.Marshal(secrets)

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -636,7 +636,7 @@ func init() {
 	secretsDownloadCmd.Flags().StringP("config", "c", "", "config (e.g. dev)")
 	secretsDownloadCmd.RegisterFlagCompletionFunc("config", configNamesValidArgs)
 	secretsDownloadCmd.Flags().String("format", models.JSON.String(), fmt.Sprintf("output format. one of %s", validFormatList))
-	secretsDownloadCmd.Flags().String("name-transformer", "", fmt.Sprintf("(BETA) output name transformer. one of %v", validNameTransformersList))
+	secretsDownloadCmd.Flags().String("name-transformer", "", fmt.Sprintf("output name transformer. one of %v", validNameTransformersList))
 	secretsDownloadCmd.RegisterFlagCompletionFunc("name-transformer", func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
 		return models.SecretsNameTransformerTypes, cobra.ShellCompDirectiveDefault
 	})

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -349,7 +349,7 @@ func ValidateSecrets(secrets map[string]string, secretsToInclude []string, exitO
 	}
 }
 
-func PrepareSecrets(dopplerSecrets map[string]string, originalEnv []string, preserveEnv string, existingEnvKeys map[string]string, mountOptions MountOptions) ([]string, func()) {
+func PrepareSecrets(dopplerSecrets map[string]string, originalEnv []string, preserveEnv string, mountOptions MountOptions) ([]string, func()) {
 	env := []string{}
 	secrets := map[string]string{}
 	var onExit func()
@@ -378,6 +378,15 @@ func PrepareSecrets(dopplerSecrets map[string]string, originalEnv []string, pres
 				utils.LogDebug(fmt.Sprintf("Ignoring reserved secret %s", reservedKey))
 				delete(dopplerSecrets, reservedKey)
 			}
+		}
+
+		existingEnvKeys := map[string]string{}
+		for _, envVar := range originalEnv {
+			// key=value format
+			parts := strings.SplitN(envVar, "=", 2)
+			key := parts[0]
+			value := parts[1]
+			existingEnvKeys[key] = value
 		}
 
 		if preserveEnv != "false" {

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -19,6 +19,7 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io/fs"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -154,12 +155,15 @@ func MountSecrets(secrets []byte, mountPath string, maxReads int) (string, func(
 
 	// cleanup named pipe on exit
 	cleanupFIFO := func() {
-		if utils.Exists(mountPath) {
-			utils.LogDebug(fmt.Sprintf("Deleting secrets mount %s", mountPath))
-			if err := os.Remove(mountPath); err != nil {
-				utils.LogDebug("Unable to delete secrets mount")
-				utils.LogError(err)
+		utils.LogDebug(fmt.Sprintf("Deleting secrets mount %s", mountPath))
+		if err := os.Remove(mountPath); err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				// ignore
+				return
 			}
+
+			utils.LogDebug("Unable to delete secrets mount")
+			utils.LogError(err)
 		}
 	}
 

--- a/pkg/controllers/watch.go
+++ b/pkg/controllers/watch.go
@@ -1,0 +1,62 @@
+/*
+Copyright © 2023 Doppler <support@doppler.com>
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+package controllers
+
+import (
+	"encoding/json"
+	"strings"
+
+	"github.com/DopplerHQ/cli/pkg/models"
+	"github.com/DopplerHQ/cli/pkg/utils"
+)
+
+func ParseWatchEvent(data []byte) models.WatchSecrets {
+	// Expected format: "event: message\ndata: {JSON}\n\n"
+	var parts []string
+	for _, s := range strings.Split(string(data), "\n") {
+		if s != "" {
+			parts = append(parts, s)
+		}
+	}
+	if len(parts) != 2 {
+		utils.LogDebug("Unable to parse API response; invalid length")
+		CaptureEvent("WatchDataParseError", map[string]interface{}{"error": "invalid length"})
+		return models.WatchSecrets{}
+	}
+	if parts[0] != "event: message" {
+		utils.LogDebug("Unable to parse API response; invalid event")
+		CaptureEvent("WatchDataParseError", map[string]interface{}{"error": "invalid event"})
+		return models.WatchSecrets{}
+	}
+	const dataPrefix = "data: "
+	if !strings.HasPrefix(parts[1], dataPrefix) {
+		utils.LogDebug("Unable to parse API response; invalid data")
+		CaptureEvent("WatchDataParseError", map[string]interface{}{"error": "invalid data"})
+		return models.WatchSecrets{}
+	}
+
+	dataJson := strings.TrimPrefix(parts[1], dataPrefix)
+	var watchSecrets models.WatchSecrets
+	err := json.Unmarshal([]byte(dataJson), &watchSecrets)
+	if err != nil {
+		CaptureEvent("WatchDataParseError", map[string]interface{}{"error": "invalid data json"})
+		utils.LogDebug("Unable to parse API response")
+		utils.LogDebugError(err)
+		return models.WatchSecrets{}
+	}
+
+	return watchSecrets
+}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -222,7 +222,7 @@ func request(req *http.Request, verifyTLS bool, allowTimeout bool) (*http.Respon
 	var response *http.Response
 	response = nil
 
-	err = utils.Retry(RequestAttempts, 100*time.Millisecond, func() error {
+	err = utils.Retry(RequestAttempts, 500*time.Millisecond, func() error {
 		// disable semgrep rule b/c we properly check that resp isn't nil before using it within the err block
 		resp, err := client.Do(req) // nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
 		if err != nil {

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -28,6 +28,7 @@ import (
 	"net/url"
 	"runtime"
 	"strings"
+	"syscall"
 	"time"
 
 	"github.com/DopplerHQ/cli/pkg/utils"
@@ -235,7 +236,7 @@ func request(req *http.Request, verifyTLS bool, allowTimeout bool) (*http.Respon
 
 			utils.LogDebug(err.Error())
 
-			if isTimeout(err) {
+			if isTimeout(err) || errors.Is(err, syscall.ECONNREFUSED) {
 				// retry request
 				return err
 			}

--- a/pkg/http/http.go
+++ b/pkg/http/http.go
@@ -221,7 +221,7 @@ func request(req *http.Request, verifyTLS bool, allowTimeout bool) (*http.Respon
 	var response *http.Response
 	response = nil
 
-	err = retry(RequestAttempts, 100*time.Millisecond, func() error {
+	err = utils.Retry(RequestAttempts, 100*time.Millisecond, func() error {
 		// disable semgrep rule b/c we properly check that resp isn't nil before using it within the err block
 		resp, err := client.Do(req) // nosemgrep: trailofbits.go.invalid-usage-of-modified-variable.invalid-usage-of-modified-variable
 		if err != nil {
@@ -240,7 +240,7 @@ func request(req *http.Request, verifyTLS bool, allowTimeout bool) (*http.Respon
 				return err
 			}
 
-			return StopRetry{err}
+			return utils.StopRetryError(err)
 		}
 
 		response = resp
@@ -264,7 +264,7 @@ func request(req *http.Request, verifyTLS bool, allowTimeout bool) (*http.Respon
 		}
 
 		// we cannot recover from this error code; accept defeat
-		return StopRetry{errors.New("Request failed")}
+		return utils.StopRetryError(errors.New("Request failed"))
 	})
 
 	return response, err

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -157,3 +157,7 @@ type ActorWorkplaceInfo struct {
 	Name string `json:"name"`
 	Slug string `json:"slug"`
 }
+
+type WatchSecrets struct {
+	Type string `json:"type"`
+}

--- a/pkg/utils/retry.go
+++ b/pkg/utils/retry.go
@@ -1,5 +1,5 @@
 /*
-Copyright © 2019 Doppler <support@doppler.com>
+Copyright © 2023 Doppler <support@doppler.com>
 
 Licensed under the Apache License, Version 2.0 (the "License");
 you may not use this file except in compliance with the License.
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 */
-package http
+package utils
 
 import (
 	"math/rand"
@@ -24,7 +24,7 @@ func init() {
 	rand.Seed(time.Now().UnixNano())
 }
 
-func retry(attempts int, sleep time.Duration, f func() error) error {
+func Retry(attempts int, sleep time.Duration, f func() error) error {
 	if err := f(); err != nil {
 		if s, ok := err.(StopRetry); ok {
 			// Return the original error for later checking
@@ -37,12 +37,16 @@ func retry(attempts int, sleep time.Duration, f func() error) error {
 			sleep = sleep + jitter/2
 
 			time.Sleep(sleep)
-			return retry(attempts, 2*sleep, f)
+			return Retry(attempts, 2*sleep, f)
 		}
 		return err
 	}
 
 	return nil
+}
+
+func StopRetryError(err error) StopRetry {
+	return StopRetry{err}
 }
 
 // StopRetry indicates to stop attempting retries. wraps an error


### PR DESCRIPTION
This PR adds a `--watch` flag to the `run` command that will automatically restart the user's process when secrets change. It monitors for changed secrets using a long-lived request. When secrets change, the CLI fetches the latest secrets, sends a SIGTERM to the process, waits up to 10 seconds, sends a SIGKILL if necessary, and then starts the process again.

This feature is currently in beta and is not yet broadly available in customer workplaces. Given this, the feature will not be mentioned in the CLI's release notes.

Closes ENG-6390