### PR TITLE
Publish winget package

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -69,7 +69,7 @@ jobs:
         GPG_SECRET_KEY: ${{ secrets.GPG_SECRET_KEY }}
     - name: Build and publish binaries
       run:
-        GOOGLE_APPLICATION_CREDENTIALS=<(echo "$GOOGLE_CREDS") goreleaser release --rm-dist
+        GOOGLE_APPLICATION_CREDENTIALS=<(echo "$GOOGLE_CREDS") goreleaser release --clean
       env:
         GOPATH: ${{ runner.workspace }}
         GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -157,6 +157,28 @@ scoop:
   description: "The official Doppler CLI for managing your secrets"
   license: Apache-2.0
 
+winget:
+  - name: doppler
+    publisher: Doppler
+    short_description: "The official Doppler CLI for managing your secrets"
+    license: Apache-2.0
+    publisher_url: https://doppler.com
+    commit_author:
+      name: "Doppler Bot"
+      email: bot@doppler.com
+    homepage: "https://doppler.com"
+    skip_upload: auto
+    repository:
+      owner: DopplerHQ
+      name: winget-pkgs
+      branch: "cli-{{.Version}}"
+      pull_request:
+        enabled: true
+        base:
+          owner: microsoft
+          name: winget-pkgs
+          branch: master
+
 nfpms:
   - id: doppler
     file_name_template: >-

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -38,7 +38,6 @@ builds:
 
 archives:
 -
-  rlcp: true
   name_template: >-
     {{ .ProjectName }}_
     {{- .Version }}_
@@ -74,7 +73,6 @@ checksum:
   algorithm: sha256
 
 source:
-  rlcp: true
   enabled: true
   name_template: '{{ .ProjectName }}_{{ .Version }}_src'
   format: 'tar.gz'
@@ -129,7 +127,7 @@ dockers:
 
 brews:
   - name: doppler
-    tap:
+    repository:
       owner: DopplerHQ
       name: homebrew-doppler
     commit_author:
@@ -146,16 +144,16 @@ brews:
     test: |
       system "#{bin}/doppler --version"
 
-scoop:
-  bucket:
-    owner: DopplerHQ
-    name: scoop-doppler
-  commit_author:
-    name: "Doppler Bot"
-    email: bot@doppler.com
-  homepage: "https://doppler.com"
-  description: "The official Doppler CLI for managing your secrets"
-  license: Apache-2.0
+scoops:
+  - repository:
+      owner: DopplerHQ
+      name: scoop-doppler
+    commit_author:
+      name: "Doppler Bot"
+      email: bot@doppler.com
+    homepage: "https://doppler.com"
+    description: "The official Doppler CLI for managing your secrets"
+    license: Apache-2.0
 
 winget:
   - name: doppler

--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ test-packages:
 	./tests/packages.sh
 
 test-release:
-	doppler run -- goreleaser release --snapshot --skip-publish --rm-dist --parallelism=4
+	doppler run -- goreleaser release --snapshot --skip-publish --clean --parallelism=4
 
 scan:
 	if [ ! -f "$$GOPATH/bin/gosec" ]; then echo "Error: gosec is not installed\n\nYou can install gosec with 'go get github.com/securego/gosec/cmd/gosec'\n" && exit 1; fi


### PR DESCRIPTION
This will publish a winget package to a branch in DopplerHQ/winget-pkgs and then open a PR in the microsoft/winget-pkgs repo. I verified this functionality locally and created a [test PR](https://github.com/microsoft/winget-pkgs/pull/111029). Once this is shipped, I will revisit update support for Windows users that are using winget (ENG-6426).

Closes ENG-6425