### PR TITLE
chore: all commands help text is now sentence case

### DIFF
--- a/pkg/cmd/changelog.go
+++ b/pkg/cmd/changelog.go
@@ -24,7 +24,7 @@ import (
 
 var changelogCmd = &cobra.Command{
 	Use:   "changelog",
-	Short: "view the CLI's changelog",
+	Short: "View the CLI's changelog",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		number := utils.GetIntFlag(cmd, "number", 16)

--- a/pkg/cmd/open.go
+++ b/pkg/cmd/open.go
@@ -25,7 +25,7 @@ import (
 
 var openCmd = &cobra.Command{
 	Use:   "open",
-	Short: "open the Doppler dashboard",
+	Short: "Open the Doppler dashboard",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		localConfig := configuration.LocalConfig(cmd)
@@ -38,7 +38,7 @@ var openCmd = &cobra.Command{
 
 var openDashboardCmd = &cobra.Command{
 	Use:   "dashboard",
-	Short: "open the Doppler dashboard",
+	Short: "Open the Doppler dashboard",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		localConfig := configuration.LocalConfig(cmd)

--- a/pkg/cmd/update.go
+++ b/pkg/cmd/update.go
@@ -27,7 +27,7 @@ import (
 
 var updateCmd = &cobra.Command{
 	Use:   "update",
-	Short: "update the Doppler CLI",
+	Short: "Update the Doppler CLI",
 	Args:  cobra.NoArgs,
 	Run: func(cmd *cobra.Command, args []string) {
 		if !utils.CanUpdate() {


### PR DESCRIPTION
Fixed command help strings that started with a lowercase character.