### PR TITLE
Fix navigating within secret values

### DIFF
--- a/pkg/tui/gui/cmp_secrets.go
+++ b/pkg/tui/gui/cmp_secrets.go
@@ -58,20 +58,6 @@ func CreateSecretsComponent(gui *Gui) (*SecretsComponent, error) {
 	gui.bindKey("Secrets", 'l', gocui.ModNone, func(v *gocui.View) error {
 		return cmp.ToggleNameValue()
 	})
-
-	gui.bindKey("Secrets", gocui.KeyArrowDown, gocui.ModNone, func(v *gocui.View) error {
-		return cmp.SelectDelta(1)
-	})
-	gui.bindKey("Secrets", gocui.KeyArrowUp, gocui.ModNone, func(v *gocui.View) error {
-		return cmp.SelectDelta(-1)
-	})
-	gui.bindKey("Secrets", gocui.KeyArrowLeft, gocui.ModNone, func(v *gocui.View) error {
-		return cmp.ToggleNameValue()
-	})
-	gui.bindKey("Secrets", gocui.KeyArrowRight, gocui.ModNone, func(v *gocui.View) error {
-		return cmp.ToggleNameValue()
-	})
-
 	gui.bindKey("Secrets", gocui.KeyTab, gocui.ModNone, func(v *gocui.View) error {
 		return cmp.ToggleNameValue()
 	})


### PR DESCRIPTION
I noticed this while using the TUI today. We last-minute added the ability to navigate secrets with arrow keys, but that causes a collision with navigating *within* secret values when editing multi-line secrets. Let's remove arrow key navigation for now as a quick-fix.

I didn't use the `chore:` prefix in the commit message because I wasn't sure if we could release without anything in the changelog, but let me know if I should add it in.