### PR TITLE
Fix installing updates via winget

### DIFF
--- a/pkg/controllers/update.go
+++ b/pkg/controllers/update.go
@@ -86,13 +86,13 @@ func CheckUpdate(command string) (bool, models.VersionCheck) {
 	}
 
 	if utils.IsWindows() && !utils.IsMINGW64() {
-		if !InstalledViaWinget() {
+		if !installedViaWinget() {
 			utils.Log(fmt.Sprintf("Update: Doppler CLI %s is available\n\nYou can update via 'scoop update doppler'\nWe recommend installing the Doppler CLI via winget for easier updates", versionCheck.LatestVersion))
 			configuration.SetVersionCheck(versionCheck)
 			return false, models.VersionCheck{}
 		}
 
-		if !IsUpdateAvailableViaWinget(versionCheck.LatestVersion) {
+		if !isUpdateAvailableViaWinget(versionCheck.LatestVersion) {
 			CaptureEvent("UpgradeNotAvailableViaWinget", map[string]interface{}{"version": versionCheck.LatestVersion})
 			utils.LogDebug(fmt.Sprintf("Doppler CLI version %s is not yet available via winget", versionCheck.LatestVersion))
 			// reuse old version so we prompt the user again
@@ -251,8 +251,8 @@ func InstallUpdate(version string) {
 	var installedVersion string
 	var controllerErr Error
 	if utils.IsWindows() && !utils.IsMINGW64() {
-		if InstalledViaWinget() {
-			wasUpdated, installedVersion, controllerErr = UpdateViaWinget(version)
+		if installedViaWinget() {
+			wasUpdated, installedVersion, controllerErr = updateViaWinget(version)
 		} else {
 			utils.HandleError(fmt.Errorf("updates are not supported when installed via scoop. Please install the Doppler CLI via winget or update manually via `scoop update doppler`"))
 		}
@@ -281,7 +281,7 @@ func InstallUpdate(version string) {
 	configuration.SetVersionCheck(versionCheck)
 }
 
-func InstalledViaWinget() bool {
+func installedViaWinget() bool {
 	utils.LogDebug("Checking if CLI is installed via winget")
 	command := fmt.Sprintf("winget list --id %s -n 1 --exact --disable-interactivity", wingetPackageId)
 	utils.LogDebug(fmt.Sprintf("Executing \"%s\"", command))
@@ -302,7 +302,7 @@ func InstalledViaWinget() bool {
 	return err == nil
 }
 
-func IsUpdateAvailableViaWinget(updateVersion string) bool {
+func isUpdateAvailableViaWinget(updateVersion string) bool {
 	utils.LogDebug("Checking if CLI update is available via winget")
 	command := fmt.Sprintf("winget list --id %s -n 1 --exact --disable-interactivity", wingetPackageId)
 	utils.LogDebug(fmt.Sprintf("Executing \"%s\"", command))
@@ -330,7 +330,7 @@ func IsUpdateAvailableViaWinget(updateVersion string) bool {
 	return len(matches) > 0
 }
 
-func UpdateViaWinget(version string) (bool, string, Error) {
+func updateViaWinget(version string) (bool, string, Error) {
 	command := fmt.Sprintf("winget upgrade --id %s --exact --disable-interactivity --version %s", wingetPackageId, strings.TrimPrefix(version, "v"))
 	utils.LogDebug(fmt.Sprintf("Executing \"%s\"", command))
 

--- a/pkg/controllers/update.go
+++ b/pkg/controllers/update.go
@@ -329,7 +329,7 @@ func isUpdateAvailableViaWinget(updateVersion string) bool {
 	utils.LogDebug(strOut)
 
 	// Ex: `Doppler.doppler 3.63.1 3.64.0 winget`
-	re := regexp.MustCompile(fmt.Sprintf(`%s\s+%s\s+%s\s+winget`, wingetPackageId, strings.TrimPrefix(version.ProgramVersion, "v"), strings.TrimPrefix(updateVersion, "v")))
+	re := regexp.MustCompile(fmt.Sprintf(`%s\s+\d+\.\d+\.\d+\s+%s\s+winget`, wingetPackageId, strings.TrimPrefix(updateVersion, "v")))
 
 	matches := re.FindStringSubmatch(strOut)
 	return len(matches) > 0


### PR DESCRIPTION
 `winget upgrade` errors if the CLI is running when we try to update it. We need to exec `winget upgrade` in the background and then immediately exit. This has the downside that our error handling/messaging isn't as robust, we can't capture timing/success anlytics, and upgrading via the auto-upgrade prompt does not result in running the original command. For ex, if a user runs `doppler configs` and then chooses to update when prompted, the CLI will update and exit before executing the `configs` command. We want users to always be on the latest CLI version, so these limitations are preferable to requiring users to manually run `doppler update`.

Closes ENG-6662