### PR TITLE
Fix a few TUI edge cases

### DIFF
--- a/pkg/tui/gui/cmp_secrets.go
+++ b/pkg/tui/gui/cmp_secrets.go
@@ -219,6 +219,10 @@ func (self *SecretsComponent) createSVMs() error {
 }
 
 func (self *SecretsComponent) ToggleNameValue() error {
+	if len(self.visibleSVMs()) == 0 {
+		return nil
+	}
+
 	isNameFocused := strings.Index(self.gui.g.CurrentView().Name(), "SVM:Name:") == 0
 	isEditing := self.gui.g.CurrentView().Editable
 

--- a/pkg/tui/gui/cmp_secrets.go
+++ b/pkg/tui/gui/cmp_secrets.go
@@ -204,8 +204,9 @@ func (self *SecretsComponent) createSVMs() error {
 		}
 	}
 
-	if len(self.secretVMs) > 0 {
-		self.activeSVM = self.secretVMs[0]
+	visibleSVMs := self.visibleSVMs()
+	if len(visibleSVMs) > 0 {
+		self.activeSVM = visibleSVMs[0]
 	}
 
 	curViewName := self.gui.g.CurrentView().Name()

--- a/pkg/tui/tui_app.go
+++ b/pkg/tui/tui_app.go
@@ -17,10 +17,12 @@ package tui
 
 import (
 	"log"
+	"os"
 
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/tui/common"
 	"github.com/DopplerHQ/cli/pkg/tui/gui"
+	"github.com/DopplerHQ/cli/pkg/utils"
 )
 
 type App struct {
@@ -32,6 +34,11 @@ func Start(opts models.ScopedOptions) {
 	cmn, err := common.NewCommon(opts)
 	if err != nil {
 		log.Fatal(err)
+	}
+
+	if cmn.Opts.EnclaveProject.Value == "" {
+		utils.Log("You must run `doppler setup` prior to launching the TUI")
+		os.Exit(1)
 	}
 
 	gui, err := gui.NewGui(cmn)


### PR DESCRIPTION
- Pressing `tab` when no secrets existed was causing a panic
- Launching the TUI prior to `doppler setup` was opening the TUI with a difficult to spot error message
- Filtering secrets, editing, and saving was causing focus to be lost

Closes ENG-6765