### PR TITLE
Fix forwarding of env vars when using --preserve-env

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -568,7 +568,7 @@ func init() {
 	runCmd.RegisterFlagCompletionFunc("config", configNamesValidArgs)
 	runCmd.Flags().String("command", "", "command to execute (e.g. \"echo hi\")")
 	// note: requires using "--preserve-env=VALUE", doesn't work with "--preserve-env VALUE"
-	runCmd.Flags().String("preserve-env", "false", "a comma separated list of secrets for which the existing value from the environment, if any, should take precedence of the Doppler secret value. value must be specified with an equals sign (e.g. --preserve-env=\"FOO,BAR\"). specify \"true\" to give precedence to all existing environment values, however this has potential security implications and should be used at your own risk.")
+	runCmd.Flags().String("preserve-env", "false", "a comma separated list of secrets for which the existing value from the environment, if any, should take precedence over the Doppler secret value. value must be specified with an equals sign (e.g. --preserve-env=\"FOO,BAR\"). specify \"true\" to give precedence to all existing environment values, however this has potential security implications and should be used at your own risk.")
 	// we must specify a default when no value is passed as this flag used to be a boolean
 	// https://github.com/spf13/pflag#setting-no-option-default-values-for-flags
 	runCmd.Flags().Lookup("preserve-env").NoOptDefVal = "true"

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -398,11 +398,13 @@ func PrepareSecrets(dopplerSecrets map[string]string, originalEnv []string, pres
 			}
 			// then use existing env vars
 			for name, value := range existingEnvKeys {
-				if preserveEnv != "true" && !utils.Contains(secretsToPreserve, name) {
+				_, isDopplerSecret := secrets[name]
+				preserveEnvVar := preserveEnv == "true" || utils.Contains(secretsToPreserve, name)
+				if isDopplerSecret && !preserveEnvVar {
 					continue
 				}
 
-				if _, found := secrets[name]; found {
+				if isDopplerSecret {
 					utils.LogDebug(fmt.Sprintf("Ignoring Doppler secret %s", name))
 				}
 				secrets[name] = value

--- a/tests/e2e/run.sh
+++ b/tests/e2e/run.sh
@@ -140,4 +140,16 @@ beforeEach
 value="$(TEST="foo" "$DOPPLER_BINARY" run --preserve-env="INVALID" -- printenv TEST)"
 [[ "$value" == "abc" ]] || error "ERROR: existing env var not ignored when preserve-env flag passed list of nonexistent secret names"
 
+beforeEach
+
+# verify preserve-env flag preserves env vars that aren't Doppler secrets
+value="$(NOT_DOPPLER_SECRET="foo" "$DOPPLER_BINARY" run --preserve-env="TEST" -- printenv NOT_DOPPLER_SECRET || true)"
+[[ "$value" == "foo" ]] || error "ERROR: existing env var not preserved when preserve-env flag passed unrelated secret name"
+
+beforeEach
+
+# verify preserve-env flag preserves env vars that aren't Doppler secrets when passing false
+value="$(NOT_DOPPLER_SECRET="foo" "$DOPPLER_BINARY" run --preserve-env=false -- printenv NOT_DOPPLER_SECRET || true)"
+[[ "$value" == "foo" ]] || error "ERROR: existing env var not preserved when preserve-env flag passed false"
+
 afterAll


### PR DESCRIPTION
Previously, we incorrectly ignored all non-preserved environment variables. We should only ignore non-preserved environment variables that are also Doppler secrets. Tests have been added for this scenario.

Closes ENG-6948