### PR TITLE
Switch to using gpgv for signature verification

### DIFF
--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -64,10 +64,10 @@ jobs:
     - name: Uninstall gnupg
       run: |
         sudo apt-get remove -y gnupg;
-        sudo mv /usr/bin/gpg /usr/bin/gpg.old
+        sudo mv /usr/bin/gpgv /usr/bin/gpgv.old
     - name: Verify gnupg has been removed
       run: |
-        result=$(which gpg) || true;
+        result=$(which gpgv) || true;
         if [ -n "$result" ]; then
           exit 1;
         fi;

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -391,9 +391,9 @@ fi
 
 log_debug "Detected format '$format'"
 
-gpg_binary="$(command -v gpg || true)";
-if [ -x "$gpg_binary" ]; then
-  log_debug "Using $gpg_binary for signature verification"
+gpgv_binary="$(command -v gpgv || true)";
+if [ -x "$gpgv_binary" ]; then
+  log_debug "Using $gpgv_binary for signature verification"
 else
   log "ERROR: Unable to find gpg binary for signature verification"
   log "You can resolve this error by installing your system's gnupg package"
@@ -474,7 +474,7 @@ if [ -d ~/.gnupg ]; then
   # Run sudo chown -r $(whoami) ~/.gnupg to fix this
   ls -l ~/.gnupg > /dev/null 2>&1 || (log "Failed to read ~/.gnupg. Please verify the directory's ownership, or run 'sudo chown -R $(whoami) ~/.gnupg' to fix this." && clean_exit 4)
 fi
-gpg --no-default-keyring --keyring "$key_filename" --verify "$sig_filename" "$filename" > /dev/null 2>&1 || (log "Failed to verify binary signature" && clean_exit 1)
+gpgv --keyring "$key_filename" "$sig_filename" "$filename" > /dev/null 2>&1 || (log "Failed to verify binary signature" && clean_exit 1)
 log_debug "Signature successfully verified!"
 
 if [ "$format" = "deb" ]; then


### PR DESCRIPTION
Our install script uses `--no-default-keyring` and `--keyring` to force `gpg` to use our public key to verify the file signature after download. As per the docs for those two options:

> Note that if the option `use-keyboxd` is enabled in `common.conf`, **no keyrings are used at all** and keys are all maintained by the keyboxd process in its own database.

If this option is enabled, installs will fail like this:

```
Downloading Doppler CLI
Verifying signature
Failed to verify binary signature
ERROR: script failed during execution
```

This change switches us over to using `gpgv` which is a binary installed with `gnupg` that's used strictly for verifying signatures in the fashion we want and doesn't use keyboxd.