### PR TITLE
[FEATURE] Support doppler secrets set --visibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,6 @@ The Doppler CLI is the official tool for interacting with your Doppler secrets a
 - Execute applications with your secrets injected into the environment
 - View activity and audit logs
 
-
 ## Install
 
 The Doppler CLI is available in several popular package managers. It can also be installed via [shell script](https://github.com/DopplerHQ/cli/blob/master/INSTALL.md#shell-script), [GitHub Action](https://github.com/DopplerHQ/cli-action), or downloaded as a [standalone binary](https://github.com/DopplerHQ/cli/releases/latest).
@@ -25,6 +24,7 @@ $ doppler --version
 ```
 
 To update:
+
 ```sh
 $ brew upgrade doppler
 ```

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -236,10 +236,13 @@ func setSecrets(cmd *cobra.Command, args []string) {
 	raw := utils.GetBoolFlag(cmd, "raw")
 	canPromptUser := !utils.GetBoolFlag(cmd, "no-interactive")
 	localConfig := configuration.LocalConfig(cmd)
+	visibility := cmd.Flag("visibility").Value.String()
 
 	utils.RequireValue("token", localConfig.Token.Value)
 
-	secrets := map[string]interface{}{}
+	var changeRequests []models.ChangeRequest
+	changeRequests = make([]models.ChangeRequest, 0)
+
 	var keys []string
 
 	// if only one arg, read from stdin
@@ -307,27 +310,51 @@ func setSecrets(cmd *cobra.Command, args []string) {
 		value := strings.Join(input, "\n")
 
 		keys = append(keys, key)
-		secrets[key] = value
+		changeRequest := models.ChangeRequest{
+			Name:  key,
+			Value: &value,
+		}
+		if visibility != "" {
+			changeRequest.Visibility = &visibility
+		}
+		changeRequests = append(changeRequests, changeRequest)
 	} else if len(args) == 2 && !strings.Contains(args[0], "=") {
 		// format: 'doppler secrets set KEY value'
 		key := args[0]
 		value := args[1]
 		keys = append(keys, key)
-		secrets[key] = value
+		changeRequest := models.ChangeRequest{
+			Name:  key,
+			Value: &value,
+		}
+		if visibility != "" {
+			changeRequest.Visibility = &visibility
+		}
+		changeRequests = append(changeRequests, changeRequest)
 	} else {
 		// format: 'doppler secrets set KEY=value'
 		for _, arg := range args {
 			secretArr := strings.SplitN(arg, "=", 2)
-			keys = append(keys, secretArr[0])
-			if len(secretArr) < 2 {
-				secrets[secretArr[0]] = ""
-			} else {
-				secrets[secretArr[0]] = secretArr[1]
+			key := secretArr[0]
+			keys = append(keys, key)
+
+			changeRequest := models.ChangeRequest{
+				Name: key,
 			}
+
+			if len(secretArr) < 2 {
+				changeRequest.Value = nil
+			} else {
+				changeRequest.Value = &secretArr[1]
+			}
+			if visibility != "" {
+				changeRequest.Visibility = &visibility
+			}
+			changeRequests = append(changeRequests, changeRequest)
 		}
 	}
 
-	response, err := http.SetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, secrets, nil)
+	response, err := http.SetSecrets(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, localConfig.EnclaveConfig.Value, nil, changeRequests)
 	if !err.IsNil() {
 		utils.HandleError(err.Unwrap(), err.Message)
 	}
@@ -626,6 +653,7 @@ func init() {
 	}
 	secretsSetCmd.Flags().Bool("raw", false, "print the raw secret value without processing variables")
 	secretsSetCmd.Flags().Bool("no-interactive", false, "do not allow entering secret value via interactive mode")
+	secretsSetCmd.Flags().StringP("visibility", "", "", "visibility (e.g. masked, unmasked, or restricted)")
 	secretsCmd.AddCommand(secretsSetCmd)
 
 	secretsUploadCmd.Flags().StringP("project", "p", "", "project (e.g. backend)")

--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -237,6 +237,7 @@ func setSecrets(cmd *cobra.Command, args []string) {
 	canPromptUser := !utils.GetBoolFlag(cmd, "no-interactive")
 	localConfig := configuration.LocalConfig(cmd)
 	visibility := cmd.Flag("visibility").Value.String()
+	visibilityModified := visibility != ""
 
 	utils.RequireValue("token", localConfig.Token.Value)
 
@@ -314,7 +315,7 @@ func setSecrets(cmd *cobra.Command, args []string) {
 			Name:  key,
 			Value: &value,
 		}
-		if visibility != "" {
+		if visibilityModified {
 			changeRequest.Visibility = &visibility
 		}
 		changeRequests = append(changeRequests, changeRequest)
@@ -327,7 +328,7 @@ func setSecrets(cmd *cobra.Command, args []string) {
 			Name:  key,
 			Value: &value,
 		}
-		if visibility != "" {
+		if visibilityModified {
 			changeRequest.Visibility = &visibility
 		}
 		changeRequests = append(changeRequests, changeRequest)
@@ -343,11 +344,11 @@ func setSecrets(cmd *cobra.Command, args []string) {
 			}
 
 			if len(secretArr) < 2 {
-				changeRequest.Value = nil
+				changeRequest.Value = nil // don't change existing value
 			} else {
 				changeRequest.Value = &secretArr[1]
 			}
-			if visibility != "" {
+			if visibilityModified {
 				changeRequest.Visibility = &visibility
 			}
 			changeRequests = append(changeRequests, changeRequest)
@@ -360,7 +361,7 @@ func setSecrets(cmd *cobra.Command, args []string) {
 	}
 
 	if !utils.Silent {
-		printer.Secrets(response, keys, jsonFlag, false, raw, false, false)
+		printer.Secrets(response, keys, jsonFlag, false, raw, false, visibilityModified)
 	}
 }
 

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -27,11 +27,15 @@ type ComputedSecret struct {
 
 // ChangeRequest can be used to smartly update secrets
 type ChangeRequest struct {
-	OriginalName  interface{} `json:"originalName"`
-	OriginalValue interface{} `json:"originalValue,omitempty"`
-	Name          string      `json:"name"`
-	Value         string      `json:"value"`
-	ShouldDelete  bool        `json:"shouldDelete"`
+	Name               string      `json:"name"`
+	OriginalName       interface{} `json:"originalName"`
+	Value              interface{} `json:"value"`
+	OriginalValue      interface{} `json:"originalValue,omitempty"`
+	Visibility         *string     `json:"visibility,omitempty"`
+	OriginalVisibility *string     `json:"originalVisibility,omitempty"`
+	ShouldPromote      *bool       `json:"shouldPromote,omitempty"`
+	ShouldDelete       *bool       `json:"shouldDelete,omitempty"`
+	ShouldConverge     *bool       `json:"shouldConverge,omitempty"`
 }
 
 // SecretNote contains a secret and its note

--- a/pkg/tui/gui/cmp_secret_view.go
+++ b/pkg/tui/gui/cmp_secret_view.go
@@ -50,7 +50,7 @@ func (svm *SecretViewModel) ToChangeRequest() models.ChangeRequest {
 		OriginalName: svm.originalName,
 		Name:         svm.nameView.TextArea.GetContent(),
 		Value:        svm.valueView.TextArea.GetContent(),
-		ShouldDelete: svm.shouldDelete,
+		ShouldDelete: &svm.shouldDelete,
 	}
 
 	if svm.originalVisibility != "restricted" {

--- a/tests/e2e/update.sh
+++ b/tests/e2e/update.sh
@@ -45,16 +45,6 @@ output="$("$DOPPLER_BINARY" update --force 2>&1 || true)";
 
 beforeEach
 
-### gnupg perms issue
-# make gnupg directory inaccessible
-sudo chown root ~/.gnupg;
-output="$("$DOPPLER_BINARY" update --force 2>&1 || true)";
-[ "$(echo "$output" | tail -1)" == "Doppler Error: exit status 4" ] || error "ERROR: expected update to fail without access to gnupg"
-# restore gnupg directory perms
-sudo chown "$(id -un)" ~/.gnupg;
-
-beforeEach
-
 ### successful update
 sudo "$DOPPLER_BINARY" update --force >/dev/null 2>&1 || error "ERROR: unable to update CLI"
 


### PR DESCRIPTION
## Why was this pull request opened?

Submitting this as a proof-of-concept and potential implementation for [[FEATURE] Set secret visibility #453
](https://github.com/DopplerHQ/cli/issues/453)

## What was changed?

- Mainly, the secrets.setSecrets() function was modified to compose an array of `model.ChangeRequest` instead of using a `map[string]interface{}`
- This also required modifying the `model.ChangeRequest` to add all fields in the [secrets-update API](https://docs.doppler.com/reference/secrets-update)

## How to test?

```
$ go run . secrets set -p test -c test TEST=value --visibility masked
┌──────┬───────┬──────┐
│ NAME │ VALUE │ NOTE │
├──────┼───────┼──────┤
│ TEST │ value │      │
└──────┴───────┴──────┘

$ go run . secrets set -p test -c test TEST=value --visibility restricted
┌──────┬──────────────┬──────┐
│ NAME │ VALUE        │ NOTE │
├──────┼──────────────┼──────┤
│ TEST │ [RESTRICTED] │      │
└──────┴──────────────┴──────┘
```