### PR TITLE
Resolve the error - Doppler Error: exec: "x": cannot run executable found relative to current directory'

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -108,6 +108,11 @@ func Cwd() string {
 // RunCommand runs the specified command
 func RunCommand(command []string, env []string, inFile io.Reader, outFile io.Writer, errFile io.Writer, forwardSignals bool) (*exec.Cmd, error) {
 	cmd := exec.Command(command[0], command[1:]...) // #nosec G204 nosemgrep: semgrep_configs.prohibit-exec-command
+	// Resolves https://github.com/DopplerHQ/cli/issues/415
+	if errors.Is(cmd.Err, exec.ErrDot) {
+		cmd.Err = nil
+	}
+
 	cmd.Env = env
 	cmd.Stdin = inFile
 	cmd.Stdout = outFile


### PR DESCRIPTION
Hi there,

Starting with Go 1.19 the Go team put in some guardrails surrounding `exec.Command` and `exec.LookPath` where including the current path was considered undesirable behaviour (https://pkg.go.dev/os/exec@master#hdr-Executables_in_the_current_directory) . This PR aims to restore pre 1.19 behaviour.

The reasoning behind this is there are scripts and systems that do exist (and are created even today) that rely on this behaviour. For something such as Doppler which is essentially injecting the secrets and calling a shell (that doesn't restrict this behaviour), these guardrails seem somewhat irrelevant. 

This would resolve https://github.com/DopplerHQ/cli/issues/415 .