### PR TITLE
Increase cap on projects that can be fetched at once

### DIFF
--- a/pkg/cmd/projects.go
+++ b/pkg/cmd/projects.go
@@ -147,7 +147,7 @@ func deleteProjects(cmd *cobra.Command, args []string) {
 		}
 
 		if !utils.Silent {
-			info, err := http.GetProjects(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, 1, 100)
+			info, err := http.GetProjects(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, 1, 1000)
 			if !err.IsNil() {
 				utils.HandleError(err.Unwrap(), err.Message)
 			}

--- a/pkg/cmd/setup.go
+++ b/pkg/cmd/setup.go
@@ -103,7 +103,7 @@ func setup(cmd *cobra.Command, args []string) {
 				break
 			}
 
-			projects, httpErr := http.GetProjects(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, 1, 100)
+			projects, httpErr := http.GetProjects(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, 1, 1000)
 			if !httpErr.IsNil() {
 				utils.HandleError(httpErr.Unwrap(), httpErr.Message)
 			}

--- a/pkg/controllers/projects.go
+++ b/pkg/controllers/projects.go
@@ -24,7 +24,7 @@ import (
 func GetProjectIDs(config models.ScopedOptions) ([]string, Error) {
 	utils.RequireValue("token", config.Token.Value)
 
-	info, err := http.GetProjects(config.APIHost.Value, utils.GetBool(config.VerifyTLS.Value, true), config.Token.Value, 1, 100)
+	info, err := http.GetProjects(config.APIHost.Value, utils.GetBool(config.VerifyTLS.Value, true), config.Token.Value, 1, 1000)
 	if !err.IsNil() {
 		return nil, Error{Err: err.Unwrap(), Message: err.Message}
 	}


### PR DESCRIPTION
For some usages (`doppler setup`, completions) 100 was not enough. It has been raised to 1000.