### PR TITLE
Add support for config inheritance

### DIFF
--- a/pkg/cmd/configs.go
+++ b/pkg/cmd/configs.go
@@ -61,9 +61,22 @@ var configsDeleteCmd = &cobra.Command{
 var configsUpdateCmd = &cobra.Command{
 	Use:               "update [config]",
 	Short:             "Update a config",
+	Long:              "Update properties about a config, such as its name, inheritability flag, and inheritances",
 	Args:              cobra.MaximumNArgs(1),
 	ValidArgsFunction: configNamesValidArgs,
 	Run:               updateConfigs,
+	Example: `Updating a config's name
+$ doppler configs update --project proj --config dev_branch --name dev_branch2
+
+Enabling a config to be inherited
+$ doppler configs update --project proj --config dev --inheritable=true
+
+Configuring which configs the given config inherits
+Note: The inherits flag accepts a comma separated list of PROJ_NAME.CONF_NAME
+$ doppler configs update --project proj --config dev --inherits="shared-db.dev,shared-api.dev"
+
+To clear the inheritance list, pass in an empty value:
+$ doppler configs update --project proj --config dev --inherits=`,
 }
 
 var configsLockCmd = &cobra.Command{
@@ -196,34 +209,77 @@ func deleteConfigs(cmd *cobra.Command, args []string) {
 
 func updateConfigs(cmd *cobra.Command, args []string) {
 	jsonFlag := utils.OutputJSON
+
+	nameSet := cmd.Flags().Changed("name")
+	inheritableSet := cmd.Flags().Changed("inheritable")
+	inheritsSet := cmd.Flags().Changed("inherits")
+
+	varsChanged := 0
+	for _, v := range []bool{nameSet, inheritableSet, inheritsSet} {
+		if v {
+			varsChanged++
+		}
+	}
+
+	if varsChanged != 1 {
+		utils.HandleError(fmt.Errorf("Exactly one of name, inheritable, and inherits must be specified"))
+	}
+
 	name := cmd.Flag("name").Value.String()
+	inheritable := utils.GetBoolFlag(cmd, "inheritable")
+	inherits := cmd.Flag("inherits").Value.String()
 	yes := utils.GetBoolFlag(cmd, "yes")
 	localConfig := configuration.LocalConfig(cmd)
 
 	utils.RequireValue("token", localConfig.Token.Value)
-	utils.RequireValue("name", name)
 
 	config := localConfig.EnclaveConfig.Value
 	if len(args) > 0 {
 		config = args[0]
 	}
 
-	if !yes {
-		utils.PrintWarning("Renaming this config may break your current deploys.")
-		if !utils.ConfirmationPrompt("Continue?", false) {
-			utils.Log("Aborting")
-			return
+	if nameSet {
+		if !yes {
+			utils.PrintWarning("Renaming this config may break your current deploys.")
+			if !utils.ConfirmationPrompt("Continue?", false) {
+				utils.Log("Aborting")
+				return
+			}
+		}
+
+		info, err := http.UpdateConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config, name)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		if !utils.Silent {
+			printer.ConfigInfo(info, jsonFlag)
+		}
+
+	}
+
+	if inheritableSet {
+		info, err := http.UpdateConfigInheritable(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config, inheritable)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		if !utils.Silent {
+			printer.ConfigInfo(info, jsonFlag)
 		}
 	}
 
-	info, err := http.UpdateConfig(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config, name)
-	if !err.IsNil() {
-		utils.HandleError(err.Unwrap(), err.Message)
+	if inheritsSet {
+		info, err := http.UpdateConfigInherits(localConfig.APIHost.Value, utils.GetBool(localConfig.VerifyTLS.Value, true), localConfig.Token.Value, localConfig.EnclaveProject.Value, config, inherits)
+		if !err.IsNil() {
+			utils.HandleError(err.Unwrap(), err.Message)
+		}
+
+		if !utils.Silent {
+			printer.ConfigInfo(info, jsonFlag)
+		}
 	}
 
-	if !utils.Silent {
-		printer.ConfigInfo(info, jsonFlag)
-	}
 }
 
 func lockConfigs(cmd *cobra.Command, args []string) {
@@ -395,9 +451,8 @@ func init() {
 		utils.HandleError(err)
 	}
 	configsUpdateCmd.Flags().String("name", "", "config name")
-	if err := configsUpdateCmd.MarkFlagRequired("name"); err != nil {
-		utils.HandleError(err)
-	}
+	configsUpdateCmd.Flags().Bool("inheritable", false, "toggle config inheritability")
+	configsUpdateCmd.Flags().String("inherits", "", "configs to inherit (e.g. \"proj2.prd,shared.prd\")")
 	configsUpdateCmd.Flags().BoolP("yes", "y", false, "proceed without confirmation")
 	configsCmd.AddCommand(configsUpdateCmd)
 

--- a/pkg/models/api.go
+++ b/pkg/models/api.go
@@ -78,14 +78,17 @@ type EnvironmentInfo struct {
 
 // ConfigInfo project info
 type ConfigInfo struct {
-	Name           string `json:"name"`
-	Root           bool   `json:"root"`
-	Locked         bool   `json:"locked"`
-	Environment    string `json:"environment"`
-	Project        string `json:"project"`
-	CreatedAt      string `json:"created_at"`
-	InitialFetchAt string `json:"initial_fetch_at"`
-	LastFetchAt    string `json:"last_fetch_at"`
+	Name           string             `json:"name"`
+	Root           bool               `json:"root"`
+	Locked         bool               `json:"locked"`
+	Environment    string             `json:"environment"`
+	Project        string             `json:"project"`
+	CreatedAt      string             `json:"created_at"`
+	InitialFetchAt string             `json:"initial_fetch_at"`
+	LastFetchAt    string             `json:"last_fetch_at"`
+	Inheritable    bool               `json:"inheritable"`
+	Inherits       []ConfigDescriptor `json:"inherits"`
+	InheritedBy    []ConfigDescriptor `json:"inheritedBy"`
 }
 
 // ConfigLog a log
@@ -174,4 +177,9 @@ type ActorWorkplaceInfo struct {
 
 type WatchSecrets struct {
 	Type string `json:"type"`
+}
+
+type ConfigDescriptor struct {
+	ProjectSlug string `json:"projectSlug"`
+	ConfigName  string `json:"configName"`
 }

--- a/pkg/models/parse.go
+++ b/pkg/models/parse.go
@@ -111,6 +111,25 @@ func ParseConfigInfo(info map[string]interface{}) ConfigInfo {
 	if info["last_fetch_at"] != nil {
 		configInfo.LastFetchAt = info["last_fetch_at"].(string)
 	}
+	if info["inheritable"] != nil {
+		configInfo.Inheritable = info["inheritable"].(bool)
+	}
+	if info["inherits"] != nil {
+		configInfo.Inherits = []ConfigDescriptor{}
+		inherits := info["inherits"].([]interface{})
+		for _, i := range inherits {
+			descriptorMap := i.(map[string]interface{})
+			configInfo.Inherits = append(configInfo.Inherits, ConfigDescriptor{ProjectSlug: descriptorMap["projectSlug"].(string), ConfigName: descriptorMap["configName"].(string)})
+		}
+	}
+	if info["inheritedBy"] != nil {
+		configInfo.InheritedBy = []ConfigDescriptor{}
+		inheritedBy := info["inheritedBy"].([]interface{})
+		for _, i := range inheritedBy {
+			descriptorMap := i.(map[string]interface{})
+			configInfo.InheritedBy = append(configInfo.InheritedBy, ConfigDescriptor{ProjectSlug: descriptorMap["projectSlug"].(string), ConfigName: descriptorMap["configName"].(string)})
+		}
+	}
 
 	return configInfo
 }


### PR DESCRIPTION
- Adds `inheritable` and `inherits` properties to Configs. 
- Additionally, adds `inheritedBy` for Configs when fetched individually.
- Allows toggling inheritability with `doppler configs update --inheritable [true/false]`
- Allows setting parent inheritances with `doppler configs update --inherits 'billing.dev,database.dev'`

Depends on https://github.com/DopplerHQ/server/pull/7068

Closes ENG-8534

