### PR TITLE
Add config liveness ping during doppler run

### DIFF
--- a/pkg/controllers/configs.go
+++ b/pkg/controllers/configs.go
@@ -89,3 +89,14 @@ func GetEnvironmentIDs(config models.ScopedOptions) ([]string, Error) {
 	}
 	return ids, Error{}
 }
+
+func LivenessPing(config models.ScopedOptions) (bool, Error) {
+	utils.RequireValue("token", config.Token.Value)
+
+	_, err := http.LivenessPing(config.APIHost.Value, utils.GetBool(config.VerifyTLS.Value, true), config.Token.Value, config.EnclaveProject.Value, config.EnclaveConfig.Value)
+	if !err.IsNil() {
+		return false, Error{Err: err.Unwrap(), Message: err.Message}
+	}
+
+	return true, Error{}
+}

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -154,12 +154,11 @@ func RevokeAuthToken(host string, verifyTLS bool, token string) (map[string]inte
 	return result, Error{}
 }
 
-
 // GetOIDCAuthToken get a short lived service account identity auth token from an OIDC token
 func GetOIDCAuthToken(host string, verifyTLS bool, identityId string, oidcJWT string) (map[string]interface{}, Error) {
 	reqBody := map[string]interface{}{}
-	reqBody["identity"] = identityId 
-	reqBody["token"] = oidcJWT 
+	reqBody["identity"] = identityId
+	reqBody["token"] = oidcJWT
 	body, err := json.Marshal(reqBody)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Invalid OIDC auth token"}
@@ -184,9 +183,8 @@ func GetOIDCAuthToken(host string, verifyTLS bool, identityId string, oidcJWT st
 	return result, Error{}
 }
 
-
 // RevokeIdentityAuthToken revoke a short lived service account identity auth token
-func RevokeIdentityAuthToken(host string, verifyTLS bool, token string) (Error) {
+func RevokeIdentityAuthToken(host string, verifyTLS bool, token string) Error {
 	reqBody := map[string]interface{}{}
 	reqBody["token"] = token
 	body, err := json.Marshal(reqBody)

--- a/pkg/http/api.go
+++ b/pkg/http/api.go
@@ -911,6 +911,24 @@ func GetConfig(host string, verifyTLS bool, apiKey string, project string, confi
 	return info, Error{}
 }
 
+func LivenessPing(host string, verifyTLS bool, apiKey string, project string, config string) (bool, Error) {
+	var params []queryParam
+	params = append(params, queryParam{Key: "project", Value: project})
+	params = append(params, queryParam{Key: "config", Value: config})
+
+	url, err := generateURL(host, "/v3/configs/config/ping", params)
+	if err != nil {
+		return false, Error{Err: err, Message: "Unable to generate url"}
+	}
+
+	statusCode, _, _, err := GetRequest(url, verifyTLS, apiKeyHeader(apiKey))
+	if err != nil {
+		return false, Error{Err: err, Message: "Unable to liveness ping", Code: statusCode}
+	}
+
+	return true, Error{}
+}
+
 // CreateConfig create a config
 func CreateConfig(host string, verifyTLS bool, apiKey string, project string, name string, environment string) (models.ConfigInfo, Error) {
 	postBody := map[string]interface{}{"name": name, "environment": environment}


### PR DESCRIPTION
We want to periodically ping Doppler's servers during `doppler run` to accurately track the usage of a given config during long-running processes.

Requires https://github.com/DopplerHQ/server/pull/7246

Closes ENG-8646