### PR TITLE
Fixed issue preventing fallback and metadata files from being saved in DOPPLER_CONFIG_DIR

### DIFF
--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -37,6 +37,12 @@ var UserConfigDir string
 // UserConfigFile (e.g. /home/user/doppler/.doppler.yaml)
 var UserConfigFile string
 
+// UserFallbackDir (e.g. /home/user/doppler/.doppler.yaml)
+var UserFallbackDir string
+
+// UserMetadataDir the directory containing metadata files
+var UserMetadataDir string
+
 // Scope to use for config file
 var Scope = "."
 
@@ -54,6 +60,8 @@ func init() {
 
 func SetConfigDir(dir string) {
 	UserConfigDir = dir
+	UserFallbackDir = filepath.Join(dir, "fallback")
+	UserMetadataDir = UserFallbackDir
 	UserConfigFile = filepath.Join(UserConfigDir, configFileName)
 }
 

--- a/pkg/controllers/fallback.go
+++ b/pkg/controllers/fallback.go
@@ -24,14 +24,12 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/DopplerHQ/cli/pkg/configuration"
 	"github.com/DopplerHQ/cli/pkg/crypto"
 	"github.com/DopplerHQ/cli/pkg/models"
 	"github.com/DopplerHQ/cli/pkg/utils"
 	"gopkg.in/yaml.v3"
 )
-
-// DefaultMetadataDir the directory containing metadata files
-var DefaultMetadataDir string
 
 func GenerateFallbackFileHash(token string, project string, config string, format models.SecretsFormat, nameTransformer *models.SecretsNameTransformer, secretNames []string) string {
 	parts := []string{token}
@@ -63,7 +61,7 @@ func GenerateFallbackFileHash(token string, project string, config string, forma
 // MetadataFilePath calculates the name of the metadata file
 func MetadataFilePath(token string, project string, config string, format models.SecretsFormat, nameTransformer *models.SecretsNameTransformer, secretNames []string) string {
 	fileName := fmt.Sprintf(".metadata-%s.json", GenerateFallbackFileHash(token, project, config, format, nameTransformer, secretNames))
-	path := filepath.Join(DefaultMetadataDir, fileName)
+	path := filepath.Join(configuration.UserMetadataDir, fileName)
 	if absPath, err := filepath.Abs(path); err == nil {
 		return absPath
 	}

--- a/tests/e2e/secrets-download-fallback.sh
+++ b/tests/e2e/secrets-download-fallback.sh
@@ -43,6 +43,20 @@ beforeEach
 
 beforeEach
 
+# test fallback file and metadata file respect DOPPLER_CONFIG_DIR
+test_config_dir='/tmp/doppler-fallback-config-test'
+test_fallback_dir="$test_config_dir/fallback"
+mkdir -p "$test_fallback_dir"
+DOPPLER_CONFIG_DIR="$test_config_dir" "$DOPPLER_BINARY" secrets download --no-file > /dev/null
+
+fallback_file_count="$(find "$test_fallback_dir" -name '.secrets-*' | wc -l)"
+[[ "$fallback_file_count" == "1" ]] || (echo "ERROR: 'run' did not create fallback file in DOPPLER_CONFIG_DIR/fallback" && exit 1)
+
+metadata_file_count="$(find "$test_fallback_dir" -name '.metadata-*' | wc -l)"
+[[ "$metadata_file_count" == "1" ]] || (echo "ERROR: 'run' did not create metadata file in DOPPLER_CONFIG_DIR/fallback" && exit 1)
+
+beforeEach
+
 # test fallback-readonly doesn't write a fallback file
 "$DOPPLER_BINARY" secrets download --no-file --fallback-readonly > /dev/null
 "$DOPPLER_BINARY" secrets download --no-file --fallback-only > /dev/null 2>&1 && (echo "ERROR: --fallback-readonly flag is not respected" && exit 1)


### PR DESCRIPTION
The `DOPPLER_CONFIG_DIR` was being appropriately used for reading/writing the configuration files but was not being used as the default for fallback and metadata files. This change hoists the default metadata and fallback directories to the `configuration` controller so it can be defined in the same spot as `configuration.UserConfigFile`.