### PR TITLE
Alias --fallback-only with --offline

### DIFF
--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -461,6 +461,12 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 	enableCache := enableFallback && !utils.GetBoolFlag(cmd, "no-cache")
 	fallbackReadonly := utils.GetBoolFlag(cmd, "fallback-readonly")
 	fallbackOnly := utils.GetBoolFlag(cmd, "fallback-only")
+	var fallbackFlag string
+	if cmd.Flags().Changed("offline") {
+		fallbackFlag = "--offline"
+	} else {
+		fallbackFlag = "--fallback-only"
+	}
 	exitOnWriteFailure := !utils.GetBoolFlag(cmd, "no-exit-on-write-failure")
 	dynamicSecretsTTL := utils.GetDurationFlag(cmd, "dynamic-ttl")
 
@@ -520,6 +526,7 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 			LegacyPath:         legacyFallbackPath,
 			Readonly:           fallbackReadonly,
 			Exclusive:          fallbackOnly,
+			ExclusiveFlag:      fallbackFlag,
 			ExitOnWriteFailure: exitOnWriteFailure,
 			Passphrase:         fallbackPassphrase,
 		}
@@ -534,7 +541,7 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 		// fallback file is not supported when fetching env/yaml format
 		enableFallback = false
 		enableCache = false
-		flags := []string{"fallback", "fallback-only", "fallback-readonly", "no-exit-on-write-failure"}
+		flags := []string{"fallback", "fallback-only", "offline", "fallback-readonly", "no-exit-on-write-failure"}
 		for _, flag := range flags {
 			if cmd.Flags().Changed(flag) {
 				utils.LogWarning(fmt.Sprintf("--%s has no effect when format is %s", flag, format))
@@ -761,7 +768,8 @@ func init() {
 	secretsDownloadCmd.Flags().Bool("no-fallback", false, "disable reading and writing the fallback file")
 	secretsDownloadCmd.Flags().String("fallback-passphrase", "", "passphrase to use for encrypting the fallback file. by default the passphrase is computed using your current configuration.")
 	secretsDownloadCmd.Flags().Bool("fallback-readonly", false, "disable modifying the fallback file. secrets can still be read from the file.")
-	secretsDownloadCmd.Flags().Bool("fallback-only", false, "read all secrets directly from the fallback file, without contacting Doppler. secrets will not be updated. (implies --fallback-readonly)")
+	secretsDownloadCmdFallbackOnly := secretsDownloadCmd.Flags().Bool("fallback-only", false, "read all secrets directly from the fallback file, without contacting Doppler. secrets will not be updated. (implies --fallback-readonly)")
+	secretsDownloadCmd.Flags().BoolVar(secretsDownloadCmdFallbackOnly, "offline", false, "alias for --fallback-only")
 	secretsDownloadCmd.Flags().Bool("no-exit-on-write-failure", false, "do not exit if unable to write the fallback file")
 	secretsCmd.AddCommand(secretsDownloadCmd)
 

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -70,6 +70,7 @@ type FallbackOptions struct {
 	LegacyPath         string
 	Readonly           bool
 	Exclusive          bool
+	ExclusiveFlag      string
 	ExitOnWriteFailure bool
 	Passphrase         string
 }
@@ -429,7 +430,7 @@ func PrepareSecrets(dopplerSecrets map[string]string, originalEnv []string, pres
 func FetchSecrets(localConfig models.ScopedOptions, enableCache bool, fallbackOpts FallbackOptions, metadataPath string, nameTransformer *models.SecretsNameTransformer, dynamicSecretsTTL time.Duration, format models.SecretsFormat, secretNames []string) map[string]string {
 	if fallbackOpts.Exclusive {
 		if !fallbackOpts.Enable {
-			utils.HandleError(errors.New("Conflict: unable to specify --no-fallback with --fallback-only"))
+			utils.HandleError(errors.New("Conflict: unable to specify --no-fallback with " + fallbackOpts.ExclusiveFlag))
 		}
 		return readFallbackFile(fallbackOpts.Path, fallbackOpts.LegacyPath, fallbackOpts.Passphrase, false)
 	}


### PR DESCRIPTION
This flag can be useful when using the CLI offline as network requests are not made when only using the fallback file. These changes apply to `doppler run` and `doppler secrets download`.

The approach taken here seems cleaner to me than the one originally taken in #478. Plus, the error messages here are clearer as they mention the specific flag (`--fallback-only` or `--offline`) that you utilized:

```
> doppler run --project=aaa --config=stg --scope=dev --offline --no-fallback --watch echo
Warning: --offline has no effect when the fallback file is disabled
Warning: --watch has no effect when used with --offline
Doppler Error: Conflict: unable to specify --no-fallback with --offline

> doppler run --project=aaa --config=stg --scope=dev --fallback-only --no-fallback --watch echo
Warning: --fallback-only has no effect when the fallback file is disabled
Warning: --watch has no effect when used with --fallback-only
Doppler Error: Conflict: unable to specify --no-fallback with --fallback-only
```

Closes #465
Closes ENG-8748