### PR TITLE
Reconnect to Doppler after network failure when using --watch

### DIFF
--- a/pkg/cmd/secrets.go
+++ b/pkg/cmd/secrets.go
@@ -530,7 +530,7 @@ func downloadSecrets(cmd *cobra.Command, args []string) {
 			ExitOnWriteFailure: exitOnWriteFailure,
 			Passphrase:         fallbackPassphrase,
 		}
-		secrets := controllers.FetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format, nil)
+		secrets, _ := controllers.FetchSecrets(localConfig, enableCache, fallbackOpts, metadataPath, nameTransformer, dynamicSecretsTTL, format, nil)
 
 		var err error
 		body, err = json.Marshal(secrets)

--- a/pkg/utils/number.go
+++ b/pkg/utils/number.go
@@ -15,7 +15,16 @@ limitations under the License.
 */
 package utils
 
+import "time"
+
 func Min(x, y int) int {
+	if x < y {
+		return x
+	}
+	return y
+}
+
+func MinDuration(x, y time.Duration) time.Duration {
 	if x < y {
 		return x
 	}


### PR DESCRIPTION
Prior to this PR, if a client is using the `--watch` flag and loses connectivity to the Doppler API (either because they lost internet or the service they were connected to went down), the process started by `doppler run` would continue running but never be restarted.

This PR will now detect connectivity failures and handle reconnection. When reconnecting, the process will only be restarted if secrets have indeed changed; if no secrets were changed, the pre-existing process will continue running.

Closes ENG-8855