### PR TITLE
Atomically create and check existence of configuration and fallback directories

### DIFF
--- a/pkg/cmd/run.go
+++ b/pkg/cmd/run.go
@@ -564,13 +564,11 @@ func initFallbackDir(cmd *cobra.Command, config models.ScopedOptions, format mod
 			legacyFallbackPath = legacyFallbackFile(config.EnclaveProject.Value, config.EnclaveConfig.Value)
 		}
 
-		if !utils.Exists(configuration.UserFallbackDir) {
-			err := os.Mkdir(configuration.UserFallbackDir, 0700)
-			if err != nil {
-				utils.LogDebug("Unable to create directory for fallback file")
-				if exitOnWriteFailure {
-					utils.HandleError(err, "Unable to create directory for fallback file", strings.Join(controllers.WriteFailureMessage(), "\n"))
-				}
+		err := os.Mkdir(configuration.UserFallbackDir, 0700)
+		if err != nil && !os.IsExist(err) {
+			utils.LogDebug("Unable to create directory for fallback file")
+			if exitOnWriteFailure {
+				utils.HandleError(err, "Unable to create directory for fallback file", strings.Join(controllers.WriteFailureMessage(), "\n"))
 			}
 		}
 	}

--- a/pkg/configuration/config.go
+++ b/pkg/configuration/config.go
@@ -70,12 +70,9 @@ func Setup() {
 	utils.LogDebug(fmt.Sprintf("Using config dir %s", UserConfigDir))
 	utils.LogDebug(fmt.Sprintf("Using config file %s", UserConfigFile))
 
-	if !utils.Exists(UserConfigDir) {
-		utils.LogDebug(fmt.Sprintf("Creating the config directory %s", UserConfigDir))
-		err := os.Mkdir(UserConfigDir, 0700)
-		if err != nil {
-			utils.HandleError(err, fmt.Sprintf("Unable to create config directory %s", UserConfigDir))
-		}
+	err := os.Mkdir(UserConfigDir, 0700)
+	if err != nil && !os.IsExist(err) {
+		utils.HandleError(err, fmt.Sprintf("Unable to create config directory %s", UserConfigDir))
 	}
 
 	// This may be different from `UserConfigDir` if `--configuration` was provided


### PR DESCRIPTION
There is a race condition when doppler CLI is run concurrently.

This PR creates/checks existence of files in one syscall (mkdir) to avoid this race condition for the configuration (`~/.doppler`) and fallback (`~/.doppler/fallback`) directories.

Closes #493 

Repeated test in #493 with this change and could no longer reproduce the race condition.