### PR TITLE
Obfuscate Doppler token for doppler configure --all

### DIFF
--- a/pkg/cmd/configure.go
+++ b/pkg/cmd/configure.go
@@ -37,7 +37,7 @@ var configureCmd = &cobra.Command{
 		jsonFlag := utils.OutputJSON
 
 		if all {
-			printer.Configs(configuration.AllConfigs(), jsonFlag)
+			printer.Configs(configuration.AllConfigs(), jsonFlag, true)
 			return
 		}
 

--- a/pkg/printer/config.go
+++ b/pkg/printer/config.go
@@ -133,7 +133,7 @@ func ScopedConfigValues(conf models.ScopedOptions, args []string, values map[str
 }
 
 // Configs print configs
-func Configs(configs map[string]models.FileScopedOptions, jsonFlag bool) {
+func Configs(configs map[string]models.FileScopedOptions, jsonFlag bool, obfuscateToken bool) {
 	if jsonFlag {
 		JSON(configs)
 		return
@@ -145,6 +145,10 @@ func Configs(configs map[string]models.FileScopedOptions, jsonFlag bool) {
 
 		for name, value := range pairs {
 			if value != "" {
+				if obfuscateToken && name == models.ConfigToken.String() {
+					value = utils.RedactAuthToken(value)
+				}
+
 				translatedName := configuration.TranslateConfigOption(name)
 				rows = append(rows, []string{translatedName, value, scope})
 			}


### PR DESCRIPTION
Note that `--json` (with and without `--all`) will continue to print the full token.

Closes ENG-8558