### PR TITLE
fix: handle broken pipe error while rapidly reading from secrets mount

### DIFF
--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -225,6 +225,9 @@ func MountSecrets(secrets []byte, mountPath string, maxReads int) (string, func(
 				utils.HandleError(err, message)
 			}
 
+			if enableReadsLimit {
+				numReads++
+			}
 			utils.LogDebug("Secrets mount opened by reader")
 
 			if _, err := f.Write(secrets); err != nil {
@@ -259,9 +262,6 @@ func MountSecrets(secrets []byte, mountPath string, maxReads int) (string, func(
 				cleanupFIFO()
 				utils.HandleError(err, message)
 			}
-
-			// only increment read count after successfully writing and closing
-			numReads++
 
 			// delay before re-opening file so reader can detect an EOF.
 			// if we immediately re-open the file, the original reader will keep reading

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -236,8 +236,7 @@ func MountSecrets(secrets []byte, mountPath string, maxReads int) (string, func(
 					break
 				}
 				// broken pipe occurs when reader closes pipe before writing completes (eg. with vite dev server)
-				var errno syscall.Errno
-				if errors.As(err, &errno) && errno == syscall.EPIPE {
+				if errors.Is(err, syscall.EPIPE) {
 					utils.LogDebug("Reader closed pipe before write completed")
 					_ = f.Close()
 					continue
@@ -253,8 +252,7 @@ func MountSecrets(secrets []byte, mountPath string, maxReads int) (string, func(
 					break
 				}
 				// broken pipe on close is safe to ignore - the reader has already disconnected
-				var errno syscall.Errno
-				if errors.As(err, &errno) && errno == syscall.EPIPE {
+				if errors.Is(err, syscall.EPIPE) {
 					utils.LogDebug("Pipe closed by reader")
 					continue
 				}

--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -26,6 +26,7 @@ import (
 	"path/filepath"
 	"sort"
 	"strings"
+	"syscall"
 	"text/template"
 	"time"
 
@@ -176,7 +177,7 @@ func MountSecrets(secrets []byte, mountPath string, maxReads int) (string, func(
 		return "", nil, Error{Err: errors.New("The mount path already exists. This may be due to another running instance of the Doppler CLI, or due to an improper shutdown. If this is unexpected, delete the file and try again.")}
 	}
 
-	if err := utils.CreateNamedPipe(mountPath, 0600); err != nil {
+	if err := utils.CreateNamedPipe(mountPath, 0o600); err != nil {
 		return "", nil, Error{Err: err, Message: "Unable to mount secrets file"}
 	}
 
@@ -224,7 +225,6 @@ func MountSecrets(secrets []byte, mountPath string, maxReads int) (string, func(
 				utils.HandleError(err, message)
 			}
 
-			numReads++
 			utils.LogDebug("Secrets mount opened by reader")
 
 			if _, err := f.Write(secrets); err != nil {
@@ -232,6 +232,14 @@ func MountSecrets(secrets []byte, mountPath string, maxReads int) (string, func(
 				if errors.Is(err, fs.ErrNotExist) && fifoCleanupStarted {
 					break
 				}
+				// broken pipe occurs when reader closes pipe before writing completes (eg. with vite dev server)
+				var errno syscall.Errno
+				if errors.As(err, &errno) && errno == syscall.EPIPE {
+					utils.LogDebug("Reader closed pipe before write completed")
+					_ = f.Close()
+					continue
+				}
+
 				cleanupFIFO()
 				utils.HandleError(err, message)
 			}
@@ -241,9 +249,19 @@ func MountSecrets(secrets []byte, mountPath string, maxReads int) (string, func(
 				if errors.Is(err, fs.ErrNotExist) && fifoCleanupStarted {
 					break
 				}
+				// broken pipe on close is safe to ignore - the reader has already disconnected
+				var errno syscall.Errno
+				if errors.As(err, &errno) && errno == syscall.EPIPE {
+					utils.LogDebug("Pipe closed by reader")
+					continue
+				}
+
 				cleanupFIFO()
 				utils.HandleError(err, message)
 			}
+
+			// only increment read count after successfully writing and closing
+			numReads++
 
 			// delay before re-opening file so reader can detect an EOF.
 			// if we immediately re-open the file, the original reader will keep reading


### PR DESCRIPTION
potentially fixes #502

I've been running this without the crash for about half an hour, so I *think* it solves it. Hard to tell, because I'm still getting spammed by the *Secrets mount opened by reader* message, but I don't think this would introduce any further breaking behavior either.