### PR TITLE
Add curl timeout and retry flags to prevent install script hangs

### DIFF
--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,7 +146,7 @@ curl_download() {
 
   # allow curl to fail w/o exiting
   set +e
-  headers=$(curl --tlsv1.2 --proto "=https" -w "%{http_code}" --silent --retry 5 -o "$output_file" -LN -D - "$url" 2>&1)
+  headers=$(curl --tlsv1.2 --proto "=https" -w "%{http_code}" --silent --connect-timeout 10 --max-time 60 --retry 5 --retry-all-errors -o "$output_file" -LN -D - "$url" 2>&1)
   exit_code=$?
   set -e
 


### PR DESCRIPTION
The curl command in curl_download() had no connect-timeout or max-time set, causing it to hang indefinitely on slow/stalled connections. The --retry 5 flag was ineffective because curl never timed out on its own to trigger a retry.

The `dopplerhq/cli-action` action has 30 seconds timeout, so it occasionally fails without retry.

Added:
- --connect-timeout 10: fail fast if server is unreachable
- --max-time 60: cap total transfer time per attempt
- --retry-all-errors: retry on all errors, not just transient ones