### PR TITLE
Fix slow command exit by reducing analytics timeout

### DIFF
--- a/pkg/http/analytics.go
+++ b/pkg/http/analytics.go
@@ -36,6 +36,11 @@ func CaptureCommand(command string) ([]byte, Error) {
 		return nil, Error{Err: err, Message: "Unable to generate url"}
 	}
 
+	// Use shorter timeout for analytics to avoid blocking command execution
+	originalTimeout := TimeoutDuration
+	TimeoutDuration = AnalyticsTimeoutDuration
+	defer func() { TimeoutDuration = originalTimeout }()
+
 	_, _, resp, err := PostRequest(url, true, map[string]string{"Content-Type": "application/json"}, body)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to send anonymous analytics"}
@@ -59,6 +64,11 @@ func CaptureEvent(event string, metadata map[string]interface{}) ([]byte, Error)
 	if err != nil {
 		return nil, Error{Err: err, Message: "Unable to generate url"}
 	}
+
+	// Use shorter timeout for analytics to avoid blocking command execution
+	originalTimeout := TimeoutDuration
+	TimeoutDuration = AnalyticsTimeoutDuration
+	defer func() { TimeoutDuration = originalTimeout }()
 
 	_, _, resp, err := PostRequest(url, true, map[string]string{"Content-Type": "application/json"}, body)
 	if err != nil {

--- a/pkg/http/config.go
+++ b/pkg/http/config.go
@@ -23,5 +23,8 @@ var UseTimeout = true
 // TimeoutDuration how long to wait for a request to complete before timing out
 var TimeoutDuration = 10 * time.Second
 
+// AnalyticsTimeoutDuration timeout for analytics requests (shorter to avoid blocking command execution)
+var AnalyticsTimeoutDuration = 2 * time.Second
+
 // RequestAttempts how many request attempts are made before giving up
 var RequestAttempts = 5


### PR DESCRIPTION
## Summary

Fixes #511 - Commands taking 10+ seconds to exit after completion

## Root Cause

The analytics module uses `global.WaitGroup` which blocks program exit until all analytics requests complete. These requests had a 10-second timeout, causing the CLI to hang for up to 10 seconds on every command.

## Changes

Added a separate shorter timeout (2 seconds) specifically for analytics requests to avoid blocking command execution:

- Added `AnalyticsTimeoutDuration = 2 * time.Second` in `pkg/http/config.go`
- Modified `CaptureCommand()` and `CaptureEvent()` in `pkg/http/analytics.go` to use the shorter timeout

## Testing

Before:
```bash
time doppler run -- echo "test"
# Takes 10+ seconds to exit
```

After:
```bash
time doppler run -- echo "test"  
# Exits in ~2 seconds
```

## Impact

- 80% reduction in command exit time (10s → 2s)
- Analytics requests still complete in most cases (2s is sufficient for most networks)
- Improves user experience significantly
- No breaking changes

## Related Issues

- Closes #511