### PR TITLE
Remove --retry-all-errors from curl download

### DIFF
--- a/.github/workflows/cli-action.yml
+++ b/.github/workflows/cli-action.yml
@@ -1,26 +1,21 @@
 name: Test CLI action
 
-on: [push]
+on: 
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
 
 jobs:
-  ubuntu:
-    runs-on: ubuntu-latest
+  cli-action:
+    strategy:
+      matrix:
+        os: [windows-latest, ubuntu-latest, macos-latest]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Install CLI
-      uses: dopplerhq/cli-action@v2
-    - name: Test CLI
-      run: doppler --version
-  windows:
-    runs-on: windows-latest
-    steps:
-    - name: Install CLI
-      uses: dopplerhq/cli-action@v2
-    - name: Test CLI
-      run: doppler --version
-  macOS:
-    runs-on: macos-latest
-    steps:
-    - name: Install CLI
-      uses: dopplerhq/cli-action@v2
+      uses: dopplerhq/cli-action@v4
     - name: Test CLI
       run: doppler --version

--- a/.github/workflows/install.yml
+++ b/.github/workflows/install.yml
@@ -1,20 +1,15 @@
 name: Test install.sh
 
-on: [push]
+on: 
+  pull_request:
+  push:
+    branches:
+      - master
+
+permissions:
+  contents: read
 
 jobs:
-  ubuntu-bash:
-    runs-on: ubuntu-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-      with:
-        path: ./src/github.com/${{ github.repository }}
-    - name: Install CLI
-      shell: bash
-      run: sudo ./scripts/install.sh --debug
-    - name: Test CLI
-      run: doppler --version
   ubuntu-sh:
     runs-on: ubuntu-latest
     steps:
@@ -127,17 +122,6 @@ jobs:
       run: sudo ./scripts/install.sh --debug --no-package-manager --install-path ./tmp
     - name: Test CLI
       run: ./tmp/doppler --version
-  macOS:
-    runs-on: macos-latest
-    steps:
-    - name: Checkout
-      uses: actions/checkout@v1
-      with:
-        path: ./src/github.com/${{ github.repository }}
-    - name: Install CLI
-      run: ./scripts/install.sh --debug
-    - name: Test CLI
-      run: doppler --version
   macOS-no-install:
     runs-on: macos-latest
     steps:
@@ -149,8 +133,40 @@ jobs:
       run: ./scripts/install.sh --debug --no-install
     - name: Verify file existence
       run: ls -l ./doppler
+  ubuntu:
+    strategy:
+      matrix:
+        os: [ubuntu-latest, ubuntu-24.04, ubuntu-22.04, ubuntu-24.04-arm, ubuntu-22.04-arm]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/${{ github.repository }}
+    - name: Install CLI
+      shell: bash
+      run: sudo ./scripts/install.sh --debug
+    - name: Test CLI
+      run: doppler --version
+  macOS:
+    strategy:
+      matrix:
+        os: [macos-latest, macos-26, macos-26-intel, macos-15-intel, macos-15, macos-14-large, macos-14]
+    runs-on: ${{ matrix.os }}
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v1
+      with:
+        path: ./src/github.com/${{ github.repository }}
+    - name: Install CLI
+      run: ./scripts/install.sh --debug
+    - name: Test CLI
+      run: doppler --version
   windows:
-    runs-on: windows-latest
+    strategy:
+      matrix:
+        os: [windows-latest, windows-2025, windows-2022, windows-11-arm]
+    runs-on: ${{ matrix.os }}
     steps:
     - name: Checkout
       uses: actions/checkout@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: Run tests
 
-on: [push, pull_request]
+on: 
+  pull_request:
+  push:
+    branches:
+      - master
 
 jobs:
   e2e:

--- a/.github/workflows/vulncheck.yml
+++ b/.github/workflows/vulncheck.yml
@@ -3,6 +3,8 @@ name: Vulncheck
 on:
   pull_request:
   push:
+    branches:
+      - master
 
 permissions:
   contents: read # to fetch code (actions/checkout)

--- a/scripts/install.sh
+++ b/scripts/install.sh
@@ -146,7 +146,7 @@ curl_download() {
 
   # allow curl to fail w/o exiting
   set +e
-  headers=$(curl --tlsv1.2 --proto "=https" -w "%{http_code}" --silent --connect-timeout 10 --max-time 60 --retry 5 --retry-all-errors -o "$output_file" -LN -D - "$url" 2>&1)
+  headers=$(curl --tlsv1.2 --proto "=https" -w "%{http_code}" --silent --connect-timeout 10 --max-time 60 --retry 5 -o "$output_file" -LN -D - "$url" 2>&1)
   exit_code=$?
   set -e
 


### PR DESCRIPTION
This command does not work with output redirection, per the curl manpage. Also tests additional runner images.