### PR TITLE
fix: prevent table misalignment for redacted tokens

### DIFF
--- a/pkg/utils/util.go
+++ b/pkg/utils/util.go
@@ -425,7 +425,7 @@ func UUID() (string, error) {
 func RedactAuthToken(token string) string {
 	// ensure there are enough characters or we'll end up giving away the whole token
 	if len(token) > 30 {
-		return fmt.Sprintf("%s…%s", token[0:10], token[len(token)-5:])
+		return fmt.Sprintf("%s...%s", token[0:10], token[len(token)-5:])
 	}
 
 	return "[REDACTED]"


### PR DESCRIPTION
## Summary

This PR replaces the Unicode ellipsis (`…`) used in redacted auth tokens with ASCII `...`.

## Why

Redacted auth tokens are displayed in table output, for example in `doppler configure --all`.

The Unicode ellipsis character can have ambiguous display width depending on the terminal and font environment. In terminals where it is rendered with a width different from what the table formatter expects, table borders can become misaligned.

I observed the misalignment in:

- iTerm2
- macOS Terminal

I did not observe the issue in:

- Ghostty
- WezTerm
- Warp

Using ASCII `...` avoids ambiguous character width behavior and keeps table alignment stable across terminal environments.

## Before

```text
dp.ct.gy2c…Uyzdq
```

In affected terminals, this can cause the table border to shift by one column.

## After

```text
dp.ct.gy2c...Uyzdq
```

## Screenshots

Before, in iTerm2:

<img width="960" height="281" alt="before" src="https://github.com/user-attachments/assets/afdc6673-3f42-4da2-a2ff-a5883be07d78" />


After, in iTerm2:

<img width="1079" height="275" alt="after_fix" src="https://github.com/user-attachments/assets/98b35759-64ed-4a35-b9ce-37503484384e" />


## Testing


- `make build`
- `make test`
