### PR TITLE
feat: publish linux/arm64 Docker images

### DIFF
--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -23,6 +23,10 @@ jobs:
       uses: actions/checkout@v1
       with:
         path: ./src/github.com/${{ github.repository }}
+    - name: Set up QEMU
+      uses: docker/setup-qemu-action@v4
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v4
     - name: GoReleaser Action
       uses: goreleaser/goreleaser-action@v6
       with:

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -23,6 +23,9 @@ jobs:
       uses: actions/checkout@v1
       with:
         path: ./src/github.com/${{ github.repository }}
+    - name: Set up QEMU
+      # emulates arm64 so the snapshot linux/arm64 image can be built on this runner
+      uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
     - name: GoReleaser Action
       uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
       with:

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -33,6 +33,10 @@ jobs:
           fetch-depth: 0
       - name: Update alpine image
         run: docker pull alpine
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v4
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
       - name: Install Doppler CLI
         uses: dopplerhq/cli-action@v2
       - name: Install Cloudsmith CLI

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,9 @@ jobs:
           ref: "master"
           # include tags so we can determine new version
           fetch-depth: 0
+      - name: Set up QEMU
+        # emulates arm64 so the linux/arm64 image can be built on this runner
+        uses: docker/setup-qemu-action@96fe6ef7f33517b61c61be40b68a1882f3264fb8 # v4.2.0
       - name: Set up Docker Buildx
         # dockers_v2 builds via `docker buildx build`; goreleaser expects the
         # docker-container driver, which this action configures by default

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,26 +105,26 @@ changelog:
     - Merge pull request
     - Merge branch
 
-dockers:
+dockers_v2:
   - dockerfile: docker/alpine
-    goos: linux
-    goarch: amd64
     ids:
       - doppler
-    image_templates:
-      - "dopplerhq/cli:{{ .Version }}"             # Ex: 1.4.2
-      - "dopplerhq/cli:{{ .Major }}.{{ .Minor }}"  # Ex: 1.4
-      - "dopplerhq/cli:{{ .Major }}"               # Ex: 1
-      - "dopplerhq/cli:latest"
-      - "gcr.io/dopplerhq/cli:{{ .Version }}"             # Ex: 1.4.2
-      - "gcr.io/dopplerhq/cli:{{ .Major }}.{{ .Minor }}"  # Ex: 1.4
-      - "gcr.io/dopplerhq/cli:{{ .Major }}"               # Ex: 1
-      - "gcr.io/dopplerhq/cli:latest"
-    build_flag_templates:
-      - "--label=org.label-schema.schema-version=1.0"
-      - "--label=org.label-schema.version={{.Version}}"
-      - "--label=org.label-schema.name={{.ProjectName}}"
-      - "--platform=linux/amd64"
+    images:
+      - "dopplerhq/cli"
+      - "gcr.io/dopplerhq/cli"
+    tags:
+      - "{{ .Version }}"             # Ex: 1.4.2
+      - "{{ .Major }}.{{ .Minor }}"  # Ex: 1.4
+      - "{{ .Major }}"               # Ex: 1
+      - "latest"
+    platforms:
+      - "linux/amd64"
+      - "linux/arm64"
+    sbom: false
+    labels:
+      org.label-schema.schema-version: "1.0"
+      org.label-schema.version: "{{ .Version }}"
+      org.label-schema.name: "{{ .ProjectName }}"
 
 brews:
   - name: doppler

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -111,6 +111,7 @@ dockers_v2:
       - doppler
     platforms:
       - linux/amd64
+      - linux/arm64
     images:
       - dopplerhq/cli
       - gcr.io/dopplerhq/cli

--- a/docker/alpine
+++ b/docker/alpine
@@ -4,5 +4,6 @@ RUN apk add --no-cache tini
 # Update OpenSSL to address CVE because `alpine` isn't updated yet
 RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 
-COPY doppler /bin/doppler
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/doppler /bin/doppler
 ENTRYPOINT ["/sbin/tini", "--", "/bin/doppler"]


### PR DESCRIPTION
Now that #540 has migrated the release pipeline to `dockers_v2`, publishing linux/arm64 images reduces to a 7-line change:

- `.goreleaser.yml`: add `linux/arm64` to the `dockers_v2` platforms, so each release pushes a single multi-platform manifest to Docker Hub and GCR.
- `release.yaml` / `release-tests.yaml`: set up QEMU so the arm64 layers can be built on the amd64 runners. The PR snapshot build produces per-platform images (`-amd64`/`-arm64` tag suffixes) without pushing, so CI exercises the new platform on every PR.

Verified locally with GoReleaser 2.17.1: `goreleaser release --snapshot --skip=publish,sign` builds both platform images, and both run `doppler --version` successfully (the non-native one under QEMU emulation).

Closes #531

For full transparency, this change was made with the help of Claude Code.