### PR TITLE
Migrate goreleaser off deprecated brews and dockers

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,7 @@ jobs:
       with:
         path: ./src/github.com/${{ github.repository }}
     - name: GoReleaser Check
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
       with:
         version: latest
         args: check

--- a/.github/workflows/release-tests.yaml
+++ b/.github/workflows/release-tests.yaml
@@ -24,7 +24,7 @@ jobs:
       with:
         path: ./src/github.com/${{ github.repository }}
     - name: GoReleaser Action
-      uses: goreleaser/goreleaser-action@v6
+      uses: goreleaser/goreleaser-action@f06c13b6b1a9625abc9e6e439d9c05a8f2190e94 # v7.2.3
       with:
         version: latest
         args: release --snapshot --skip=publish,sign

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,10 @@ jobs:
           ref: "master"
           # include tags so we can determine new version
           fetch-depth: 0
+      - name: Set up Docker Buildx
+        # dockers_v2 builds via `docker buildx build`; goreleaser expects the
+        # docker-container driver, which this action configures by default
+        uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
       - name: Update alpine image
         run: docker pull alpine
       - name: Install Doppler CLI

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -105,28 +105,29 @@ changelog:
     - Merge pull request
     - Merge branch
 
-dockers:
+dockers_v2:
   - dockerfile: docker/alpine
-    goos: linux
-    goarch: amd64
     ids:
       - doppler
-    image_templates:
-      - "dopplerhq/cli:{{ .Version }}"             # Ex: 1.4.2
-      - "dopplerhq/cli:{{ .Major }}.{{ .Minor }}"  # Ex: 1.4
-      - "dopplerhq/cli:{{ .Major }}"               # Ex: 1
-      - "dopplerhq/cli:latest"
-      - "gcr.io/dopplerhq/cli:{{ .Version }}"             # Ex: 1.4.2
-      - "gcr.io/dopplerhq/cli:{{ .Major }}.{{ .Minor }}"  # Ex: 1.4
-      - "gcr.io/dopplerhq/cli:{{ .Major }}"               # Ex: 1
-      - "gcr.io/dopplerhq/cli:latest"
-    build_flag_templates:
-      - "--label=org.label-schema.schema-version=1.0"
-      - "--label=org.label-schema.version={{.Version}}"
-      - "--label=org.label-schema.name={{.ProjectName}}"
-      - "--platform=linux/amd64"
+    platforms:
+      - linux/amd64
+    images:
+      - dopplerhq/cli
+      - gcr.io/dopplerhq/cli
+    tags:
+      - "{{ .Version }}"        # Ex: 1.4.2
+      - "{{ .Major }}.{{ .Minor }}"  # Ex: 1.4
+      - "{{ .Major }}"          # Ex: 1
+      - "latest"
+    labels:
+      org.label-schema.schema-version: "1.0"
+      org.label-schema.version: "{{ .Version }}"
+      org.label-schema.name: "{{ .ProjectName }}"
+    sbom: false
+    flags:
+      - "--provenance=false"
 
-brews:
+homebrew_casks:
   - name: doppler
     repository:
       owner: DopplerHQ
@@ -134,16 +135,26 @@ brews:
     commit_author:
       name: "Doppler Bot"
       email: bot@doppler.com
-    directory: Formula
     homepage: "https://doppler.com"
     description: "The official Doppler CLI for managing your secrets"
-    install: |-
-      bin.install "doppler"
-      bash_completion.install "completions/doppler.bash" => "doppler"
-      zsh_completion.install "completions/doppler.zsh" => "_doppler"
-      fish_completion.install "completions/doppler.fish"
-    test: |
-      system "#{bin}/doppler --version"
+    # homepage (doppler.com) differs from the release download domain
+    # (github.com), so mark the URL verified to satisfy `brew audit`
+    url:
+      verified: github.com/DopplerHQ/cli
+    binaries:
+      - doppler
+    completions:
+      bash: completions/doppler.bash
+      zsh: completions/doppler.zsh
+      fish: completions/doppler.fish
+    # binaries are GPG-signed but not Apple-notarized, so strip the Gatekeeper
+    # quarantine attribute on macOS to keep `brew install` working
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", "#{staged_path}/doppler"]
+          end
 
 scoops:
   - repository:

--- a/docker/alpine
+++ b/docker/alpine
@@ -4,5 +4,7 @@ RUN apk add --no-cache tini
 # Update OpenSSL to address CVE because `alpine` isn't updated yet
 RUN apk update && apk upgrade --no-cache libcrypto3 libssl3
 
-COPY doppler /bin/doppler
+# dockers_v2 stages artifacts under $TARGETPLATFORM/ in the build context
+ARG TARGETPLATFORM
+COPY $TARGETPLATFORM/doppler /bin/doppler
 ENTRYPOINT ["/sbin/tini", "--", "/bin/doppler"]


### PR DESCRIPTION
`goreleaser check` fails on the v2.16 `brews` deprecation, and `dockers`/ `docker_manifests` are being phased out in favor of `dockers_v2`.

- Replace `brews` with `homebrew_casks` (binaries + completions, plus a post-install hook to clear the macOS quarantine attribute since the binaries are GPG-signed but not Apple-notarized).
- Replace `dockers` with `dockers_v2`, preserving the plain single-arch linux/amd64 image and its labels (sbom/provenance left off to match the previous output).
- Update docker/alpine to COPY from $TARGETPLATFORM, as dockers_v2 stages artifacts per-platform.
- Set up Docker Buildx in the release workflow, which dockers_v2 requires.
- Bump goreleaser-action from v6 to v7 in the build and release-test workflows.