### PR TITLE
Add missing entries to dangerousSecretNames (BASH_ENV, LD_AUDIT, and other loader/interpreter variables)

### DIFF
--- a/pkg/controllers/secrets.go
+++ b/pkg/controllers/secrets.go
@@ -24,6 +24,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"sort"
 	"strings"
 	"syscall"
@@ -63,6 +64,49 @@ var dangerousSecretNames = [...]string{
 	// NodeJS
 	"NODE_VERSION",
 	"NODE_OPTIONS",
+	"NODE_REPL_EXTERNAL_MODULE",
+
+	// Shell startup files sourced by non-interactive shells.
+	// bash reads BASH_ENV before running any non-interactive shell, so this
+	// reaches every `#!/bin/bash` script started via `doppler run`.
+	"BASH_ENV",
+	"ENV",
+	"SHELLOPTS",
+	"PS4",
+	// Python / Ruby
+	"PYTHONPATH",
+	"PYTHONSTARTUP",
+	"RUBYOPT",
+	// JVM: -javaagent: / -javaagent-style options are honoured from these
+	"JAVA_TOOL_OPTIONS",
+	"_JAVA_OPTIONS",
+	"CLASSPATH",
+	// git executes the value of these as a command
+	"GIT_SSH_COMMAND",
+	"GIT_EXTERNAL_DIFF",
+}
+
+// Whole namespaces where every member influences the dynamic linker, so an
+// exhaustive list is not maintainable. Deliberately limited to the loader
+// prefixes: broader prefixes (NODE_, JAVA_, GIT_, PYTHON_ ...) would match
+// ubiquitous benign names such as NODE_ENV, JAVA_HOME and GIT_DIR.
+var dangerousSecretNamePatterns = []*regexp.Regexp{
+	regexp.MustCompile(`^LD_`),
+	regexp.MustCompile(`^DYLD_`),
+}
+
+func isDangerousSecretName(name string) bool {
+	for _, dangerousName := range dangerousSecretNames {
+		if name == dangerousName {
+			return true
+		}
+	}
+	for _, pattern := range dangerousSecretNamePatterns {
+		if pattern.MatchString(name) {
+			return true
+		}
+	}
+	return false
 }
 
 type FallbackOptions struct {
@@ -301,11 +345,14 @@ func MissingSecrets(secrets map[string]string, secretsToInclude []string) []stri
 func CheckForDangerousSecretNames(secrets map[string]string) error {
 	dangerousSecretNamesFound := []string{}
 
-	for _, dangerousName := range dangerousSecretNames {
-		if _, ok := secrets[dangerousName]; ok {
-			dangerousSecretNamesFound = append(dangerousSecretNamesFound, dangerousName)
+	// iterate the config's secrets rather than the list, so that the prefix
+	// patterns are applied too
+	for name := range secrets {
+		if isDangerousSecretName(name) {
+			dangerousSecretNamesFound = append(dangerousSecretNamesFound, name)
 		}
 	}
+	sort.Strings(dangerousSecretNamesFound)
 
 	if len(dangerousSecretNamesFound) > 0 {
 		return fmt.Errorf("your config contains the following potentially dangerous secret names (https://docs.doppler.com/docs/accessing-secrets#injection):\n- %s", strings.Join(dangerousSecretNamesFound, "\n- "))


### PR DESCRIPTION
### What

`dangerousSecretNames` in `pkg/controllers/secrets.go` has been unchanged since it was added in #341. It omits a number of environment variables that influence loader or interpreter behaviour in the same way as the names it already covers. This adds them, and generalises detection slightly.

Most notable omissions:

| Name | Why it belongs |
|---|---|
| `BASH_ENV` | bash sources it before running **any** non-interactive shell, so it applies to every `#!/bin/bash` script started through `doppler run` |
| `LD_AUDIT` | direct sibling of `LD_PRELOAD` and `LD_LIBRARY_PATH`, both already on the list |
| `JAVA_TOOL_OPTIONS`, `_JAVA_OPTIONS` | the JVM honours `-javaagent:` from these |
| `PYTHONPATH`, `PYTHONSTARTUP`, `RUBYOPT` | equivalents of the already-listed `PERL5OPT` / `PYTHONWARNINGS` |
| `GIT_SSH_COMMAND`, `GIT_EXTERNAL_DIFF` | git executes their value as a command |
| `ENV`, `SHELLOPTS`, `PS4` | shell startup / trace-time execution |

### How

`CheckForDangerousSecretNames` now iterates the config's secrets rather than the fixed list, which allows two prefix patterns to be applied as well:

```go
regexp.MustCompile(`^LD_`)
regexp.MustCompile(`^DYLD_`)
```

These are deliberately limited to the loader namespaces, where every member is relevant. I tried broader prefixes (`NODE_`, `JAVA_`, `GIT_`, `PYTHON_`) and rejected them: they match ubiquitous benign names such as `NODE_ENV`, `JAVA_HOME`, `GIT_DIR` and `PYTHON_VERSION`, which would make the warning useless in practice.

### Behaviour

**No behaviour change.** `ValidateSecrets` still only warns and never blocks, and the `--mount` path still skips the check entirely. The only difference is that the existing warning now covers more names.

Verified locally against a stub API, one secret name per run:

- `NODE_ENV`, `JAVA_HOME`, `GIT_DIR`, `DATABASE_URL`, `BASH_VERSION` -> child runs, **no warning**
- `BASH_ENV`, `LD_AUDIT`, `LD_PRELOAD`, `JAVA_TOOL_OPTIONS`, `GIT_SSH_COMMAND`, `PYTHONPATH`, `NODE_OPTIONS` -> child runs, **warning emitted**

### Origin

I came across this while looking at the CLI for your HackerOne program. The report was closed as a duplicate of an earlier one that had been assessed as Informative, on the basis that environment-variable injection is intended behaviour and access control on who may write to a config is the operator's responsibility. That is fair, and this PR does not argue otherwise. It only makes the existing advisory list less incomplete, since `LD_PRELOAD` being listed while `LD_AUDIT` is not looks more like an oversight than a decision.

Happy to drop the pattern matching and keep only the added names if you would prefer a smaller change, or to close this if the current list is deliberate.
