### PR TITLE
Add devcontainer.json for Doppler engineers

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,4 @@
+{
+  "image": "us-central1-docker.pkg.dev/gar-prod-73b1cdf/devtools/devcontainer:latest",
+  "name": "cli"
+}


### PR DESCRIPTION
This is intended for Doppler engineer use only, this image is not publically accessible.