### PR TITLE
Fix docker releases

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -31,6 +31,13 @@ jobs:
           ref: "master"
           # include tags so we can determine new version
           fetch-depth: 0
+      - name: Resolve Docker config directory
+        run: |
+          # Sets DOCKER_CONFIG for all future steps to an absolute path
+          mkdir -p "$DOCKER_CONFIG";
+          echo "DOCKER_CONFIG=$(cd "$DOCKER_CONFIG" && pwd)" >> "$GITHUB_ENV";
+        env:
+          DOCKER_CONFIG: ${{ secrets.DOCKER_CONFIG }}
       - name: Set up Docker Buildx
         # dockers_v2 builds via `docker buildx build`; goreleaser expects the
         # docker-container driver, which this action configures by default
@@ -50,7 +57,6 @@ jobs:
           echo "$DOCKER_HUB_TOKEN" | docker login -u "$DOCKER_HUB_USER" --password-stdin "$DOCKER_REGISTRY";
           echo "$GCP_KEY" | docker login -u "$GCR_USER" --password-stdin "$GCR_REGISTRY";
         env:
-          DOCKER_CONFIG: ${{ secrets.DOCKER_CONFIG }}
           DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
           DOCKER_HUB_TOKEN: ${{ secrets.DOCKER_HUB_TOKEN }}
           DOCKER_HUB_USER: ${{ secrets.DOCKER_HUB_USER }}
@@ -75,7 +81,6 @@ jobs:
         env:
           GOPATH: ${{ runner.workspace }}
           GITHUB_TOKEN: ${{ secrets.RELEASE_GITHUB_TOKEN }}
-          DOCKER_CONFIG: ${{ secrets.DOCKER_CONFIG }}
           GCP_KEY: ${{ secrets.GCP_KEY }}
           GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
       - name: Publish to Cloudsmith
@@ -110,8 +115,9 @@ jobs:
           docker logout "$DOCKER_REGISTRY";
           docker logout "$GCR_REGISTRY";
           set -e;
-          rm -rf "$DOCKER_CONFIG";
+          # leave the rest of the dir alone; it holds the buildx builder state
+          # that setup-buildx-action tears down in its post-job step
+          rm -f "$DOCKER_CONFIG/config.json";
         env:
-          DOCKER_CONFIG: ${{ secrets.DOCKER_CONFIG }}
           DOCKER_REGISTRY: ${{ secrets.DOCKER_REGISTRY }}
           GCR_REGISTRY: ${{ secrets.GCR_REGISTRY }}


### PR DESCRIPTION
dockers_v2 runs docker from a different directory that dockers did. Because DOCKER_CONFIG is a relative path, goreleaser is failing to use that config. The fix here is just to re-export an absolute path for the entire job to use.