### PR TITLE
Add security group as code owner for github actions

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 *       @DopplerHQ/cli-reviewers
+/.github/workflows/ @DopplerHQ/security


### PR DESCRIPTION
@emily-curry @DopplerHQ/security needs to be given write access in this repo

Closes ENG-9548