### PR TITLE
fix(brew): drop deprecated Homebrew cask url.verified

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -141,12 +141,8 @@ homebrew_casks:
     commit_author:
       name: "Doppler Bot"
       email: bot@doppler.com
-    homepage: "https://doppler.com"
-    description: "The official Doppler CLI for managing your secrets"
-    # homepage (doppler.com) differs from the release download domain
-    # (github.com), so mark the URL verified to satisfy `brew audit`
-    url:
-      verified: github.com/DopplerHQ/cli
+    homepage: "https://doppler.com/"
+    description: "Official CLI for managing secrets"
     binaries:
       - doppler
     completions:


### PR DESCRIPTION
Homebrew 6 prints this on every command that loads the Doppler cask:

```
Warning: Calling the `verified` parameter in the `url` stanza is deprecated! Use the default URL verification behaviour instead.
Please report this issue to the dopplerhq/homebrew-doppler tap
```

`url.verified` is a no-op in current Homebrew (`Homebrew/brew#23280`). GoReleaser v2.18.1 stopped emitting it and deprecates `homebrew_casks.url.verified`.

## Changes

- Remove `homebrew_casks.url.verified`. Default URL verification covers the GitHub release assets.
- Set `homepage` to `https://doppler.com/` (Homebrew requires a slash after the domain).
- Set `description` to a `brew style` compliant value (no leading article, no cask token).

The post-install quarantine strip stays in `hooks.post.install`. GoReleaser still wraps that hook in a legacy `postflight` block. The tap cask in DopplerHQ/homebrew-doppler#3 already uses `postflight_steps`; that tap change is overwritten on the next GoReleaser publish until GoReleaser emits `postflight_steps`.